### PR TITLE
ci(node): share dependency install cache across lint/test jobs

### DIFF
--- a/.github/workflows/node-ci.workflow.yml
+++ b/.github/workflows/node-ci.workflow.yml
@@ -63,9 +63,7 @@ jobs:
           ${{ steps.yarn-cache-dir-path.outputs.dir }}
           node_modules
           packages/*/node_modules
-          contracts/*/node_modules
           servers/*/node_modules
-          samples/*/node_modules
           tools/*/node_modules
         key: ${{ steps.cache-keys.outputs.shared-key }}
     - name: Setup Token
@@ -80,9 +78,7 @@ jobs:
           ${{ steps.yarn-cache-dir-path.outputs.dir }}
           node_modules
           packages/*/node_modules
-          contracts/*/node_modules
           servers/*/node_modules
-          samples/*/node_modules
           tools/*/node_modules
         key: ${{ steps.cache-keys.outputs.shared-key }}
       if: ${{ steps.cache-yarn-restore.outputs.cache-hit != 'true' }}
@@ -94,9 +90,7 @@ jobs:
           ${{ steps.yarn-cache-dir-path.outputs.dir }}
           node_modules
           packages/*/node_modules
-          contracts/*/node_modules
           servers/*/node_modules
-          samples/*/node_modules
           tools/*/node_modules
         key: ${{ steps.cache-keys.outputs.run-key }}
     - name: Split Branch Name
@@ -163,9 +157,7 @@ jobs:
           ${{ steps.yarn-cache-dir-path.outputs.dir }}
           node_modules
           packages/*/node_modules
-          contracts/*/node_modules
           servers/*/node_modules
-          samples/*/node_modules
           tools/*/node_modules
         key: ${{ needs.prepare.outputs.deps-cache-key }}
     - name: Install Dependencies (fallback)
@@ -263,9 +255,7 @@ jobs:
           ${{ steps.yarn-cache-dir-path.outputs.dir }}
           node_modules
           packages/*/node_modules
-          contracts/*/node_modules
           servers/*/node_modules
-          samples/*/node_modules
           tools/*/node_modules
         key: ${{ needs.prepare.outputs.deps-cache-key }}
     - name: Install Dependencies (fallback)


### PR DESCRIPTION
## Summary
- install dependencies once in `prepare` and persist the cache
- remove unconditional installs from `lint` and `test`
- add cache-miss fallback install in `lint` and `test` so jobs remain resilient

## Why
- reduces redundant dependency installation work across child matrix jobs while preserving reliability on cache misses

## Notes
- cache key remains `${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('yarn.lock') }}` across prepare/lint/test for consistent reuse