### PR TITLE
ci(dependabot): allow lockfile security updates for indirect deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0
+    versioning-strategy: lockfile-only
+    allow:
+      - dependency-type: all
+    groups:
+      npm_and_yarn:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml` for the npm/yarn ecosystem at the repo root
- configure `versioning-strategy: lockfile-only` to update only lockfile entries for security fixes
- allow `dependency-type: all` so Dependabot can update indirect/transitive vulnerable dependencies
- keep `open-pull-requests-limit: 0` to avoid regular version-update PR noise while still allowing security updates

## Why
Dependabot run `22375932597` (job `64766006346`, 2026-02-25) completed with no PR and logged:
- `VulnerabilityAuditor: missing lockfile`
- `No update possible` for vulnerable dependencies (`ajv`, `cookie`, `minimatch`, `tmp`)

The job definition also showed direct-only updates (`allowed-updates: dependency-type=direct`, `update-subdependencies=false`), which blocks transitive security fixes. This config makes security updates lockfile-driven and transitive-aware.

## Validation
- parsed `.github/dependabot.yml` successfully with Ruby YAML loader
- committed and pushed branch `codex/dependabot-security-update`
