### PR TITLE
fix(ci): resolve post-test junit action download failure

### DIFF
--- a/.github/workflows/node-ci.workflow.yml
+++ b/.github/workflows/node-ci.workflow.yml
@@ -315,7 +315,7 @@ jobs:
         pattern: test-*
         merge-multiple: true
     - name: Publish Test Results
-      uses: mikepenz/action-junit-report@b05b53431409fb91ca23e9e6b2da4fede2f944e8 # v5
+      uses: mikepenz/action-junit-report@v5
       with:
         report_paths: "**/test-results.junit.xml"
         check_name: Test Results


### PR DESCRIPTION
## Summary
- replace the broken `mikepenz/action-junit-report` commit pin in `node-ci.workflow.yml`
- use `mikepenz/action-junit-report@v5` so the `Post Test` job can resolve the action again

## Root cause
- CI run `22425022251` failed in `Post Test` during setup when GitHub Actions tried to download:
  - `mikepenz/action-junit-report@b05b53431409fb91ca23e9e6b2da4fede2f944e8`
- the tarball for that pinned SHA was not available, so test result publishing never started

## Validation
- re-diagnosed from a clean worktree created from `origin/main`
- confirmed failure occurs before workflow steps in `Post Test` and points to the pinned SHA download error