### PR TITLE
revert(contracts): revert openzeppelin 5 migration

### DIFF
--- a/contracts/hardhat.shared.js
+++ b/contracts/hardhat.shared.js
@@ -87,7 +87,7 @@ const buildNetworks = () => {
 
 const createHardhatConfig = (baseDir) => ({
   solidity: {
-    version: '0.8.20',
+    version: '0.8.4',
     settings: {
       optimizer: {
         enabled: true,

--- a/contracts/metadata-registry/contracts/MetadataRegistry.sol
+++ b/contracts/metadata-registry/contracts/MetadataRegistry.sol
@@ -1,6 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
-
-pragma solidity ^0.8.20;
+pragma solidity 0.8.4;
 pragma abicoder v2;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/metadata-registry/contracts/Migrations.sol
+++ b/contracts/metadata-registry/contracts/Migrations.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.20;
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
 
 contract Migrations {
   address public owner = msg.sender;

--- a/contracts/metadata-registry/package.json
+++ b/contracts/metadata-registry/package.json
@@ -18,8 +18,8 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "@openzeppelin/contracts": "5.4.0",
-    "@openzeppelin/contracts-upgradeable": "5.4.0",
+    "@openzeppelin/contracts": "4.9.6",
+    "@openzeppelin/contracts-upgradeable": "4.9.6",
     "@verii/blockchain-functions": "^0.5.0-build",
     "@verii/verification-coupon-contract": "^0.5.0-build",
     "@verii/permissions-contract": "^0.5.0-build",

--- a/contracts/permissions/contracts/Migrations.sol
+++ b/contracts/permissions/contracts/Migrations.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.20;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 <0.9.0;
 
 contract Migrations {
   address public owner = msg.sender;

--- a/contracts/permissions/contracts/Permissions.sol
+++ b/contracts/permissions/contracts/Permissions.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.20;
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/contracts/permissions/package.json
+++ b/contracts/permissions/package.json
@@ -18,8 +18,8 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "@openzeppelin/contracts": "5.4.0",
-    "@openzeppelin/contracts-upgradeable": "5.4.0",
+    "@openzeppelin/contracts": "4.9.6",
+    "@openzeppelin/contracts-upgradeable": "4.9.6",
     "ethers": "6.16.0"
   }
 }

--- a/contracts/revocation-list/contracts/Migrations.sol
+++ b/contracts/revocation-list/contracts/Migrations.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.20;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 <0.9.0;
 
 contract Migrations {
   address public owner = msg.sender;

--- a/contracts/revocation-list/contracts/RevocationRegistry.sol
+++ b/contracts/revocation-list/contracts/RevocationRegistry.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@verii/permissions-contract/contracts/Permissions.sol";

--- a/contracts/revocation-list/package.json
+++ b/contracts/revocation-list/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@openzeppelin/contracts": "5.4.0",
-    "@openzeppelin/contracts-upgradeable": "5.4.0",
+    "@openzeppelin/contracts": "4.9.6",
+    "@openzeppelin/contracts-upgradeable": "4.9.6",
     "@verii/blockchain-functions": "^0.5.0-build",
     "@verii/permissions-contract": "^0.5.0-build",
     "@verii/signature-verification-library": "^0.5.0-build",

--- a/contracts/verification-coupon/contracts/Migrations.sol
+++ b/contracts/verification-coupon/contracts/Migrations.sol
@@ -1,6 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
-
-pragma solidity ^0.8.20;
+pragma solidity 0.8.4;
 
 contract Migrations {
   address public owner = msg.sender;

--- a/contracts/verification-coupon/contracts/VerificationCoupon.sol
+++ b/contracts/verification-coupon/contracts/VerificationCoupon.sol
@@ -1,25 +1,12 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import "@verii/permissions-contract/contracts/Permissions.sol";
-
-library CounterStorageCompat {
-    struct Counter {
-        uint256 _value;
-    }
-
-    function current(Counter storage counter) internal view returns (uint256) {
-        return counter._value;
-    }
-
-    function increment(Counter storage counter) internal {
-        counter._value += 1;
-    }
-}
 
 /**
  * @dev {ERC721} token, including:
@@ -38,14 +25,14 @@ library CounterStorageCompat {
  */
 contract VerificationCoupon is Initializable, AccessControlEnumerableUpgradeable, ERC1155Upgradeable {
     address VNF;
-    using CounterStorageCompat for CounterStorageCompat.Counter;
+    using CountersUpgradeable for CountersUpgradeable.Counter;
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
     mapping(uint256 => uint256) private expirationTime;
 
     mapping(address => uint256[]) private ownerTokens;
 
-    CounterStorageCompat.Counter private _tokenIdTracker;
+    CountersUpgradeable.Counter private _tokenIdTracker;
 
     string private _tokenName;
 
@@ -57,12 +44,11 @@ contract VerificationCoupon is Initializable, AccessControlEnumerableUpgradeable
 
     function initialize(string memory tokenName, string memory baseTokenURI) public initializer {
         ERC1155Upgradeable.__ERC1155_init(baseTokenURI);
-        AccessControlEnumerableUpgradeable.__AccessControlEnumerable_init();
         VNF = msg.sender;
         _tokenName = tokenName;
 
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _grantRole(MINTER_ROLE, msg.sender);
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _setupRole(MINTER_ROLE, msg.sender);
     }
 
     function setPermissionsAddress(address _permissions) public {

--- a/contracts/verification-coupon/package.json
+++ b/contracts/verification-coupon/package.json
@@ -18,8 +18,8 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "@openzeppelin/contracts": "5.4.0",
-    "@openzeppelin/contracts-upgradeable": "5.4.0",
+    "@openzeppelin/contracts": "4.9.6",
+    "@openzeppelin/contracts-upgradeable": "4.9.6",
     "@verii/permissions-contract": "^0.5.0-build",
     "ethers": "6.16.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3040,15 +3040,15 @@
   dependencies:
     "@opentelemetry/core" "^1.1.0"
 
-"@openzeppelin/contracts-upgradeable@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.4.0.tgz#a325066da702d0a8be091eb17136d3e9c92cc76a"
-  integrity sha512-STJKyDzUcYuB35Zub1JpWW58JxvrFFVgQ+Ykdr8A9PGXgtq/obF5uoh07k2XmFyPxfnZdPdBdhkJ/n2YxJ87HQ==
+"@openzeppelin/contracts-upgradeable@4.9.6":
+  version "4.9.6"
+  resolved "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.6.tgz#38b21708a719da647de4bb0e4802ee235a0d24df"
+  integrity sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==
 
-"@openzeppelin/contracts@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.4.0.tgz#177594bdb2d86c71f5d1052fe40cb4edb95fb20f"
-  integrity sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==
+"@openzeppelin/contracts@4.9.6":
+  version "4.9.6"
+  resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.6.tgz#2a880a24eb19b4f8b25adc2a5095f2aa27f39677"
+  integrity sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==
 
 "@openzeppelin/defender-sdk-base-client@^1.14.4", "@openzeppelin/defender-sdk-base-client@^1.15.2":
   version "1.15.2"


### PR DESCRIPTION
## Summary
- revert contracts commit `4876954` that migrated upgradeable contracts from OpenZeppelin 4.9.6 to 5.4.0
- restore contract pragmas and hardhat compiler settings used before the OZ5 migration
- revert verification-coupon compatibility shim and restore prior CountersUpgradeable usage
- restore contract package dependencies and lockfile entries to OZ 4.9.6

## Why
The OZ5 storage model migration breaks in-place proxy upgrades on existing deployed proxies (`Initializable` storage layout incompatibility), and we need to preserve current proxy addresses.

## Validation
- `yarn eslint --config contracts/eslint.config.mjs contracts/hardhat.shared.js --fix`
- `yarn install --ignore-scripts`
- `yarn contracts:build:hardhat`
