### PR TITLE
chore(contracts): restore SPDX and solidity 0.8.20

### DIFF
--- a/contracts/hardhat.shared.js
+++ b/contracts/hardhat.shared.js
@@ -87,7 +87,7 @@ const buildNetworks = () => {
 
 const createHardhatConfig = (baseDir) => ({
   solidity: {
-    version: '0.8.4',
+    version: '0.8.20',
     settings: {
       optimizer: {
         enabled: true,

--- a/contracts/metadata-registry/contracts/MetadataRegistry.sol
+++ b/contracts/metadata-registry/contracts/MetadataRegistry.sol
@@ -1,4 +1,6 @@
-pragma solidity 0.8.4;
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
 pragma abicoder v2;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/metadata-registry/contracts/Migrations.sol
+++ b/contracts/metadata-registry/contracts/Migrations.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.4;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
 
 contract Migrations {
   address public owner = msg.sender;

--- a/contracts/permissions/contracts/Migrations.sol
+++ b/contracts/permissions/contracts/Migrations.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT
-pragma solidity >=0.4.22 <0.9.0;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
 
 contract Migrations {
   address public owner = msg.sender;

--- a/contracts/permissions/contracts/Permissions.sol
+++ b/contracts/permissions/contracts/Permissions.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.4;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/contracts/revocation-list/contracts/Migrations.sol
+++ b/contracts/revocation-list/contracts/Migrations.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT
-pragma solidity >=0.4.22 <0.9.0;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
 
 contract Migrations {
   address public owner = msg.sender;

--- a/contracts/revocation-list/contracts/RevocationRegistry.sol
+++ b/contracts/revocation-list/contracts/RevocationRegistry.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@verii/permissions-contract/contracts/Permissions.sol";

--- a/contracts/verification-coupon/contracts/Migrations.sol
+++ b/contracts/verification-coupon/contracts/Migrations.sol
@@ -1,4 +1,6 @@
-pragma solidity 0.8.4;
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
 
 contract Migrations {
   address public owner = msg.sender;

--- a/contracts/verification-coupon/contracts/VerificationCoupon.sol
+++ b/contracts/verification-coupon/contracts/VerificationCoupon.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";


### PR DESCRIPTION
## Summary
- reapply SPDX header updates in core contract sources and migrations files
- reapply contract pragma updates to `^0.8.20`
- reapply Hardhat shared compiler version to `0.8.20`
- keep OZ dependency versions unchanged (still 4.9.6 after #404)

## Validation
- `yarn eslint --config contracts/eslint.config.mjs contracts/hardhat.shared.js --fix`
- `yarn contracts:build:hardhat`
