### PR TITLE
fix(base-contract-io): catch nonce conflicts during gas estimation

### DIFF
--- a/packages/base-contract-io/src/resyncing-nonce-manager.js
+++ b/packages/base-contract-io/src/resyncing-nonce-manager.js
@@ -24,6 +24,11 @@ const nonceConflictErrorCodes = new Set([
 ]);
 const nonceConflictErrorRegex =
   /nonce|already been used|replacement fee too low|transaction underpriced/i;
+const nonceConflictRetries = 3;
+const accountNonceRegexes = [
+  /sender account nonce\s+(\d+)/i,
+  /account nonce(?: is)?\s+(\d+)/i,
+];
 
 const isObjectLike = (value) =>
   value != null && (typeof value === 'object' || typeof value === 'function');
@@ -31,11 +36,42 @@ const isObjectLike = (value) =>
 const getNestedErrorCandidates = (value) =>
   [value.error, value.info, value.cause].filter(isObjectLike);
 
-const hasNonceConflictMessage = (value) => {
+const getErrorText = (value) => {
   const shortMessage =
     typeof value.shortMessage === 'string' ? value.shortMessage : '';
   const message = typeof value.message === 'string' ? value.message : '';
-  return nonceConflictErrorRegex.test(`${shortMessage} ${message}`);
+  return `${shortMessage}\n${message}`;
+};
+
+const parseNonNegativeInteger = (value) => {
+  const parsed = Number.parseInt(value || '', 10);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+};
+
+const getMaxNumber = (values) =>
+  values.reduce((maxValue, value) => {
+    if (value == null) {
+      return maxValue;
+    }
+
+    if (maxValue == null || value > maxValue) {
+      return value;
+    }
+
+    return maxValue;
+  }, null);
+
+const hasNonceConflictMessage = (value) => {
+  return nonceConflictErrorRegex.test(getErrorText(value));
+};
+
+const getAccountNonceFromMessage = (value) => {
+  const text = getErrorText(value);
+  return getMaxNumber(
+    accountNonceRegexes.map((regex) =>
+      parseNonNegativeInteger(regex.exec(text)?.[1]),
+    ),
+  );
 };
 
 const isNonceConflictError = (error, visited = new Set()) => {
@@ -57,6 +93,20 @@ const isNonceConflictError = (error, visited = new Set()) => {
   );
 };
 
+const getMinimumNonceFromError = (error, visited = new Set()) => {
+  if (!isObjectLike(error) || visited.has(error)) {
+    return null;
+  }
+
+  visited.add(error);
+  return getMaxNumber([
+    getAccountNonceFromMessage(error),
+    ...getNestedErrorCandidates(error).map((candidate) =>
+      getMinimumNonceFromError(candidate, visited),
+    ),
+  ]);
+};
+
 class ResyncingNonceManager extends ethers.NonceManager {
   constructor(signer) {
     super(signer);
@@ -64,33 +114,50 @@ class ResyncingNonceManager extends ethers.NonceManager {
   }
 
   sendTransaction(tx) {
-    const sendWithExplicitNonce = async () => {
-      const nonce = await this.getNonce('pending');
-      this.increment();
-      try {
-        const populatedTransaction = await this.signer.populateTransaction({
-          ...(tx || {}),
-          nonce,
-        });
-        return this.signer.sendTransaction({
-          ...populatedTransaction,
-          nonce,
-        });
-      } catch (error) {
-        this.reset();
-        throw error;
-      }
+    const getNonceFloor = async (minimumNonceFromError) => {
+      const [pendingNonce, latestNonce] = await Promise.all([
+        this.signer.getNonce('pending'),
+        this.signer.getNonce('latest'),
+      ]);
+
+      return Math.max(
+        pendingNonce,
+        latestNonce,
+        minimumNonceFromError == null ? 0 : minimumNonceFromError,
+      );
     };
 
-    const sendWithRetry = async () => {
+    const sendWithNonce = async (nonce) => {
+      const populatedTransaction = await this.signer.populateTransaction({
+        ...(tx || {}),
+        nonce,
+      });
+
+      return this.signer.sendTransaction({
+        ...populatedTransaction,
+        nonce,
+      });
+    };
+
+    const nextMinimumNonceFromError = (minimumNonceFromError, error) => {
+      const extractedMinimumNonce = getMinimumNonceFromError(error);
+      return getMaxNumber([minimumNonceFromError, extractedMinimumNonce]);
+    };
+
+    const sendWithRetry = async (attempt = 1, minimumNonceFromError = null) => {
       try {
-        return await super.sendTransaction({ ...(tx || {}) });
+        const nonce = await getNonceFloor(minimumNonceFromError);
+        return await sendWithNonce(nonce);
       } catch (error) {
         this.reset();
-        if (!isNonceConflictError(error)) {
+        if (!isNonceConflictError(error) || attempt >= nonceConflictRetries) {
           throw error;
         }
-        return sendWithExplicitNonce();
+
+        return sendWithRetry(
+          attempt + 1,
+          nextMinimumNonceFromError(minimumNonceFromError, error),
+        );
       }
     };
 

--- a/packages/base-contract-io/test/resyncing-nonce-manager.test.js
+++ b/packages/base-contract-io/test/resyncing-nonce-manager.test.js
@@ -14,37 +14,19 @@
  * limitations under the License.
  */
 
-const { after, beforeEach, describe, it, mock } = require('node:test');
+const { describe, it, mock } = require('node:test');
 const { expect } = require('expect');
-const ethers = require('ethers');
-
-const superSendTransactionMock = mock.fn();
-const getNonceMock = mock.fn();
-const incrementMock = mock.fn();
-const resetMock = mock.fn();
-
-const nonceManagerPrototype = ethers.NonceManager.prototype;
-const originalSendTransaction = nonceManagerPrototype.sendTransaction;
-const originalGetNonce = nonceManagerPrototype.getNonce;
-const originalIncrement = nonceManagerPrototype.increment;
-const originalReset = nonceManagerPrototype.reset;
-
-nonceManagerPrototype.sendTransaction = (tx) => superSendTransactionMock(tx);
-
-nonceManagerPrototype.getNonce = (blockTag) => getNonceMock(blockTag);
-
-nonceManagerPrototype.increment = () => {
-  incrementMock();
-};
-
-nonceManagerPrototype.reset = () => {
-  resetMock();
-};
 
 const { ResyncingNonceManager } = require('../src/resyncing-nonce-manager');
 
 const createSigner = () => ({
   provider: {},
+  getNonce: mock.fn((blockTag) => {
+    if (blockTag === 'pending') {
+      return Promise.resolve(10);
+    }
+    return Promise.resolve(10);
+  }),
   populateTransaction: mock.fn((tx) =>
     Promise.resolve({ ...tx, gasLimit: 1n }),
   ),
@@ -61,87 +43,95 @@ const createDeferred = () => {
   return { promise, resolve, reject };
 };
 
+const waitForQueueTick = () =>
+  new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+
 describe('ResyncingNonceManager', () => {
-  beforeEach(() => {
-    superSendTransactionMock.mock.resetCalls();
-    getNonceMock.mock.resetCalls();
-    incrementMock.mock.resetCalls();
-    resetMock.mock.resetCalls();
-
-    superSendTransactionMock.mock.mockImplementation((tx) =>
-      Promise.resolve({ hash: '0xsuper', tx }),
-    );
-    getNonceMock.mock.mockImplementation(() => Promise.resolve(10));
-  });
-
-  after(() => {
-    nonceManagerPrototype.sendTransaction = originalSendTransaction;
-    nonceManagerPrototype.getNonce = originalGetNonce;
-    nonceManagerPrototype.increment = originalIncrement;
-    nonceManagerPrototype.reset = originalReset;
-    mock.reset();
-  });
-
-  it('uses regular NonceManager flow on the first attempt', async () => {
+  it('uses explicit nonce on the first attempt', async () => {
     const signer = createSigner();
     const manager = new ResyncingNonceManager(signer);
 
     const result = await manager.sendTransaction({ to: '0xaaa' });
 
-    expect(result).toEqual({ hash: '0xsuper', tx: { to: '0xaaa' } });
-    expect(superSendTransactionMock.mock.callCount()).toEqual(1);
-    expect(superSendTransactionMock.mock.calls[0].arguments[0]).toEqual({
-      to: '0xaaa',
+    expect(result).toEqual({
+      hash: '0x1',
+      tx: { to: '0xaaa', nonce: 10, gasLimit: 1n },
     });
-    expect(getNonceMock.mock.callCount()).toEqual(0);
-    expect(incrementMock.mock.callCount()).toEqual(0);
-    expect(resetMock.mock.callCount()).toEqual(0);
-    expect(signer.populateTransaction.mock.callCount()).toEqual(0);
-    expect(signer.sendTransaction.mock.callCount()).toEqual(0);
+    expect(signer.getNonce.mock.callCount()).toEqual(2);
+    expect(signer.getNonce.mock.calls[0].arguments).toEqual(['pending']);
+    expect(signer.getNonce.mock.calls[1].arguments).toEqual(['latest']);
+    expect(signer.populateTransaction.mock.callCount()).toEqual(1);
+    expect(signer.populateTransaction.mock.calls[0].arguments[0]).toEqual({
+      to: '0xaaa',
+      nonce: 10,
+    });
+    expect(signer.sendTransaction.mock.callCount()).toEqual(1);
+    expect(signer.sendTransaction.mock.calls[0].arguments[0]).toEqual({
+      to: '0xaaa',
+      nonce: 10,
+      gasLimit: 1n,
+    });
   });
 
-  it('retries with explicit nonce on nonce-conflict errors', async () => {
+  it('retries nonce-conflict estimate failures and uses nonce from error', async () => {
     const signer = createSigner();
     const manager = new ResyncingNonceManager(signer);
-    const nonceConflictError = Object.assign(new Error('nonce conflict'), {
-      info: { error: { code: 'NONCE_EXPIRED' } },
+    const originalReset = manager.reset.bind(manager);
+    const resetMock = mock.fn(() => originalReset());
+    manager.reset = resetMock;
+
+    signer.getNonce.mock.mockImplementation((blockTag) => {
+      if (blockTag === 'pending') {
+        return Promise.resolve(0);
+      }
+      return Promise.resolve(0);
     });
 
-    superSendTransactionMock.mock.mockImplementationOnce(() =>
-      Promise.reject(nonceConflictError),
+    const nonceConflictError = Object.assign(
+      new Error(
+        'Nonce too low (transaction nonce 0 below sender account nonce 3)',
+      ),
+      { code: 'NONCE_EXPIRED' },
     );
-    getNonceMock.mock.mockImplementationOnce(() => Promise.resolve(42));
+
+    let populateCallCount = 0;
+    signer.populateTransaction.mock.mockImplementation((tx) => {
+      populateCallCount += 1;
+      if (populateCallCount === 1) {
+        return Promise.reject(nonceConflictError);
+      }
+      return Promise.resolve({ ...tx, gasLimit: 1n });
+    });
 
     const result = await manager.sendTransaction({ to: '0xbbb' });
 
     expect(result).toEqual({
       hash: '0x1',
-      tx: { to: '0xbbb', nonce: 42, gasLimit: 1n },
+      tx: { to: '0xbbb', nonce: 3, gasLimit: 1n },
     });
-    expect(superSendTransactionMock.mock.callCount()).toEqual(1);
     expect(resetMock.mock.callCount()).toEqual(1);
-    expect(getNonceMock.mock.callCount()).toEqual(1);
-    expect(getNonceMock.mock.calls[0].arguments).toEqual(['pending']);
-    expect(incrementMock.mock.callCount()).toEqual(1);
-    expect(signer.populateTransaction.mock.callCount()).toEqual(1);
+    expect(signer.populateTransaction.mock.callCount()).toEqual(2);
     expect(signer.populateTransaction.mock.calls[0].arguments[0]).toEqual({
       to: '0xbbb',
-      nonce: 42,
+      nonce: 0,
     });
-    expect(signer.sendTransaction.mock.callCount()).toEqual(1);
-    expect(signer.sendTransaction.mock.calls[0].arguments[0]).toEqual({
+    expect(signer.populateTransaction.mock.calls[1].arguments[0]).toEqual({
       to: '0xbbb',
-      nonce: 42,
-      gasLimit: 1n,
+      nonce: 3,
     });
   });
 
   it('does not retry on non-nonce errors and resets once', async () => {
     const signer = createSigner();
     const manager = new ResyncingNonceManager(signer);
+    const originalReset = manager.reset.bind(manager);
+    const resetMock = mock.fn(() => originalReset());
+    manager.reset = resetMock;
     const boom = new Error('boom');
 
-    superSendTransactionMock.mock.mockImplementationOnce(() =>
+    signer.populateTransaction.mock.mockImplementationOnce(() =>
       Promise.reject(boom),
     );
 
@@ -149,72 +139,45 @@ describe('ResyncingNonceManager', () => {
       'boom',
     );
 
-    expect(superSendTransactionMock.mock.callCount()).toEqual(1);
     expect(resetMock.mock.callCount()).toEqual(1);
-    expect(getNonceMock.mock.callCount()).toEqual(0);
-    expect(incrementMock.mock.callCount()).toEqual(0);
-    expect(signer.populateTransaction.mock.callCount()).toEqual(0);
-    expect(signer.sendTransaction.mock.callCount()).toEqual(0);
-  });
-
-  it('resets twice when retry explicit send setup fails', async () => {
-    const signer = createSigner();
-    const manager = new ResyncingNonceManager(signer);
-    const nonceConflictError = Object.assign(new Error('nonce conflict'), {
-      code: 'NONCE_EXPIRED',
-    });
-
-    superSendTransactionMock.mock.mockImplementationOnce(() =>
-      Promise.reject(nonceConflictError),
-    );
-    getNonceMock.mock.mockImplementationOnce(() => Promise.resolve(7));
-    signer.populateTransaction.mock.mockImplementationOnce(() =>
-      Promise.reject(new Error('retry populate failed')),
-    );
-
-    await expect(manager.sendTransaction({ to: '0xddd' })).rejects.toThrow(
-      'retry populate failed',
-    );
-
-    expect(resetMock.mock.callCount()).toEqual(2);
-    expect(incrementMock.mock.callCount()).toEqual(1);
+    expect(signer.populateTransaction.mock.callCount()).toEqual(1);
     expect(signer.sendTransaction.mock.callCount()).toEqual(0);
   });
 
   it('serializes concurrent sends through the internal queue', async () => {
     const signer = createSigner();
     const manager = new ResyncingNonceManager(signer);
-    const firstSend = createDeferred();
-    let sendCallNumber = 0;
+    const firstPopulate = createDeferred();
 
-    superSendTransactionMock.mock.mockImplementation((tx) => {
-      sendCallNumber += 1;
-      if (sendCallNumber === 1) {
-        return firstSend.promise;
+    let populateCallCount = 0;
+    signer.populateTransaction.mock.mockImplementation((tx) => {
+      populateCallCount += 1;
+      if (populateCallCount === 1) {
+        return firstPopulate.promise;
       }
-      return Promise.resolve({ hash: '0xsecond', tx });
+      return Promise.resolve({ ...tx, gasLimit: 2n });
     });
 
     const firstPromise = manager.sendTransaction({ nonce: 1 });
     const secondPromise = manager.sendTransaction({ nonce: 2 });
 
-    await Promise.resolve();
-    expect(superSendTransactionMock.mock.callCount()).toEqual(1);
+    await waitForQueueTick();
+    expect(signer.populateTransaction.mock.callCount()).toEqual(1);
 
-    firstSend.resolve({ hash: '0xfirst', tx: { nonce: 1 } });
+    firstPopulate.resolve({ nonce: 1, gasLimit: 1n });
     const [firstResult, secondResult] = await Promise.all([
       firstPromise,
       secondPromise,
     ]);
 
-    expect(firstResult).toEqual({ hash: '0xfirst', tx: { nonce: 1 } });
-    expect(secondResult).toEqual({ hash: '0xsecond', tx: { nonce: 2 } });
-    expect(superSendTransactionMock.mock.callCount()).toEqual(2);
-    expect(superSendTransactionMock.mock.calls[0].arguments[0]).toEqual({
-      nonce: 1,
+    expect(firstResult).toEqual({
+      hash: '0x1',
+      tx: { nonce: 10, gasLimit: 1n },
     });
-    expect(superSendTransactionMock.mock.calls[1].arguments[0]).toEqual({
-      nonce: 2,
+    expect(secondResult).toEqual({
+      hash: '0x1',
+      tx: { nonce: 10, gasLimit: 2n },
     });
+    expect(signer.populateTransaction.mock.callCount()).toEqual(2);
   });
 });


### PR DESCRIPTION
## Summary
- make `ResyncingNonceManager` use explicit nonce-first sends so nonce is set before `populateTransaction`/`estimateGas`
- treat nonce-conflict errors during estimation/send as recoverable with bounded retries
- parse nested provider errors (`error/info/cause`) to extract account nonce hints and raise retry nonce floor
- keep send serialization via the internal queue and refresh nonce state (`reset`) between retry attempts
- update `resyncing-nonce-manager` unit tests to cover explicit nonce first-send, estimation-time retry, non-nonce error behavior, and queue serialization

## Validation
- `node --test packages/base-contract-io/test/resyncing-nonce-manager.test.js`
- `node --test packages/base-contract-io/test/nonce-management.test.js`
