### PR TITLE
fix(vnf-wallet-sdk-nodejs): accept mixed DID aliases

### DIFF
--- a/packages/vnf-wallet-sdk-nodejs/src/api/entities/error/VCLError.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/api/entities/error/VCLError.ts
@@ -10,6 +10,12 @@ export type VCLErrorArgs = {
     statusCode?: Nullish<number>;
 };
 
+type VCLKnownErrorFields = Error & {
+    errorCode?: string;
+    requestId?: Nullish<string>;
+    statusCode?: Nullish<number>;
+};
+
 export default class VCLError extends Error {
     payload: Nullish<string> = null;
 
@@ -56,12 +62,15 @@ export default class VCLError extends Error {
         });
     }
 
+    // eslint-disable-next-line complexity
     static fromError(error: any, statusCode: Nullish<number> = null): VCLError {
         if (error instanceof VCLError) {
             return error;
         }
 
-        if (!(error instanceof Error)) {
+        const knownError = VCLError.asKnownError(error);
+
+        if (knownError == null) {
             return new VCLError({
                 error: VCLError.stringifyErrorSafely(error),
                 statusCode,
@@ -69,11 +78,11 @@ export default class VCLError extends Error {
         }
 
         return new VCLError({
-            error: VCLError.stringifyErrorSafely(error),
-            errorCode: VCLError.findErrorCode(error),
-            requestId: error.requestId,
-            message: error.message,
-            statusCode: statusCode ?? error.statusCode,
+            error: VCLError.stringifyErrorSafely(knownError),
+            errorCode: VCLError.findErrorCode(knownError),
+            requestId: knownError.requestId ?? null,
+            message: knownError.message,
+            statusCode: statusCode ?? knownError.statusCode ?? null,
         });
     }
 
@@ -87,6 +96,10 @@ export default class VCLError extends Error {
         } catch {
             return String(error);
         }
+    }
+
+    private static asKnownError(error: any): VCLKnownErrorFields | null {
+        return error instanceof Error ? (error as VCLKnownErrorFields) : null;
     }
 
     private static findErrorCode(error: any): string {

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.ts
@@ -18,8 +18,7 @@ export default class PresentationRequestByDeepLinkVerifierImpl implements Presen
         deepLink: VCLDeepLink,
         didDocument: VCLDidDocument,
     ): Promise<boolean> {
-        const deepLinkDid = deepLink.did;
-        if (deepLinkDid == null) {
+        if (deepLink.did == null) {
             await this.onError(`DID not found in deep link: ${deepLink.value}`);
             return false;
         }
@@ -28,7 +27,7 @@ export default class PresentationRequestByDeepLinkVerifierImpl implements Presen
                 presentationRequest.iss,
                 didDocument,
             ) &&
-            this.isDidBoundToDidDocument(deepLinkDid, didDocument)
+            this.isDidBoundToDidDocument(deepLink.did, didDocument)
         ) {
             return true;
         }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.ts
@@ -23,10 +23,11 @@ export default class PresentationRequestByDeepLinkVerifierImpl implements Presen
             return false;
         }
         if (
-            (didDocument.id === presentationRequest.iss &&
-                didDocument.id === deepLink.did) ||
-            (didDocument.alsoKnownAs.includes(presentationRequest.iss) &&
-                didDocument.alsoKnownAs.includes(deepLink.did!))
+            this.isDidBoundToDidDocument(
+                presentationRequest.iss,
+                didDocument,
+            ) &&
+            this.isDidBoundToDidDocument(deepLink.did, didDocument)
         ) {
             return true;
         }
@@ -35,6 +36,10 @@ export default class PresentationRequestByDeepLinkVerifierImpl implements Presen
             VCLErrorCode.MismatchedPresentationRequestInspectorDid,
         );
         return false;
+    }
+
+    private isDidBoundToDidDocument(did: string, didDocument: VCLDidDocument) {
+        return didDocument.id === did || didDocument.alsoKnownAs.includes(did);
     }
 
     private async onError(

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.ts
@@ -18,7 +18,9 @@ export default class PresentationRequestByDeepLinkVerifierImpl implements Presen
         deepLink: VCLDeepLink,
         didDocument: VCLDidDocument,
     ): Promise<boolean> {
-        if (deepLink.did == null) {
+        const deepLinkDid = deepLink.did;
+
+        if (deepLinkDid == null) {
             await this.onError(`DID not found in deep link: ${deepLink.value}`);
             return false;
         }
@@ -27,7 +29,7 @@ export default class PresentationRequestByDeepLinkVerifierImpl implements Presen
                 presentationRequest.iss,
                 didDocument,
             ) &&
-            this.isDidBoundToDidDocument(deepLink.did, didDocument)
+            this.isDidBoundToDidDocument(deepLinkDid, didDocument)
         ) {
             return true;
         }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.ts
@@ -18,7 +18,8 @@ export default class PresentationRequestByDeepLinkVerifierImpl implements Presen
         deepLink: VCLDeepLink,
         didDocument: VCLDidDocument,
     ): Promise<boolean> {
-        if (deepLink.did === null) {
+        const deepLinkDid = deepLink.did;
+        if (deepLinkDid == null) {
             await this.onError(`DID not found in deep link: ${deepLink.value}`);
             return false;
         }
@@ -27,7 +28,7 @@ export default class PresentationRequestByDeepLinkVerifierImpl implements Presen
                 presentationRequest.iss,
                 didDocument,
             ) &&
-            this.isDidBoundToDidDocument(deepLink.did, didDocument)
+            this.isDidBoundToDidDocument(deepLinkDid, didDocument)
         ) {
             return true;
         }

--- a/packages/vnf-wallet-sdk-nodejs/test/verifiers/PresentationRequestByDeepLinkVerifier.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/verifiers/PresentationRequestByDeepLinkVerifier.test.ts
@@ -42,7 +42,7 @@ describe('PresentationRequestByDeepLinkVerifier', () => {
         );
     };
 
-    test('testVerifyPresentationRequestSuccess', async () => {
+    test('verifies a matching presentation request deep link', async () => {
         subject = new PresentationRequestByDeepLinkVerifierImpl();
 
         const isVerified = await subject.verifyPresentationRequest(
@@ -53,7 +53,7 @@ describe('PresentationRequestByDeepLinkVerifier', () => {
         expect(isVerified).toBeTruthy();
     });
 
-    test('testVerifyPresentationRequestSuccessWithDidDocumentIdInPresentationRequest', async () => {
+    test('verifies a presentation request when iss matches didDocument.id', async () => {
         subject = new PresentationRequestByDeepLinkVerifierImpl();
         const presentationRequestWithDidDocumentId = createPresentationRequest(
             DidDocumentMocks.DidDocumentMock.id,
@@ -67,7 +67,7 @@ describe('PresentationRequestByDeepLinkVerifier', () => {
         expect(isVerified).toBeTruthy();
     });
 
-    test('testVerifyPresentationRequestSuccessWithDidDocumentIdInDeepLink', async () => {
+    test('verifies a presentation request when inspectorDid matches didDocument.id', async () => {
         subject = new PresentationRequestByDeepLinkVerifierImpl();
         const deepLinkWithDidDocumentId = new VCLDeepLink(
             `velocity-network://inspect?inspectorDid=${encodeURIComponent(
@@ -83,7 +83,7 @@ describe('PresentationRequestByDeepLinkVerifier', () => {
         expect(isVerified).toBeTruthy();
     });
 
-    test('testVerifyPresentationRequestError', async () => {
+    test('throws for a mismatched presentation request deep link', async () => {
         subject = new PresentationRequestByDeepLinkVerifierImpl();
         try {
             const isVerified = await subject.verifyPresentationRequest(
@@ -99,7 +99,7 @@ describe('PresentationRequestByDeepLinkVerifier', () => {
         }
     });
 
-    test('testVerifyPresentationRequestErrorWhenDeepLinkDidMissing', async () => {
+    test('throws when the deep link does not include a DID', async () => {
         subject = new PresentationRequestByDeepLinkVerifierImpl();
 
         await expect(

--- a/packages/vnf-wallet-sdk-nodejs/test/verifiers/PresentationRequestByDeepLinkVerifier.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/verifiers/PresentationRequestByDeepLinkVerifier.test.ts
@@ -7,12 +7,19 @@
 
 import { describe, test } from 'node:test';
 import { expect } from 'expect';
-import { VCLErrorCode } from '../../src';
+import {
+    VCLDeepLink,
+    VCLErrorCode,
+    VCLJwt,
+    VCLPresentationRequest,
+    VCLVerifiedProfile,
+} from '../../src';
 import { PresentationRequestByDeepLinkVerifierImpl } from '../../src/impl/data/verifiers';
 import { DidDocumentMocks } from '../infrastructure/resources/valid/DidDocumentMocks';
 import PresentationRequestByDeepLinkVerifier from '../../src/impl/domain/verifiers/PresentationRequestByDeepLinkVerifier';
 import { PresentationRequestMocks } from '../infrastructure/resources/valid/PresentationRequestMocks';
 import { DeepLinkMocks } from '../infrastructure/resources/valid/DeepLinkMocks';
+import { DidJwkMocks } from '../infrastructure/resources/valid/DidJwkMocks';
 
 describe('PresentationRequestByDeepLinkVerifier', () => {
     let subject: PresentationRequestByDeepLinkVerifier;
@@ -21,7 +28,21 @@ describe('PresentationRequestByDeepLinkVerifier', () => {
 
     const deepLink = DeepLinkMocks.PresentationRequestDeepLinkDevNet;
 
-    test('verifies a matching presentation request deep link', async () => {
+    const createPresentationRequest = (iss: string): VCLPresentationRequest => {
+        const jwt = VCLJwt.fromEncodedJwt(
+            PresentationRequestMocks.EncodedPresentationRequest,
+        );
+        jwt.payload.iss = iss;
+        return new VCLPresentationRequest(
+            jwt,
+            new VCLVerifiedProfile({}),
+            new VCLDeepLink('velocity-network://inspect'),
+            null,
+            DidJwkMocks.DidJwk,
+        );
+    };
+
+    test('testVerifyPresentationRequestSuccess', async () => {
         subject = new PresentationRequestByDeepLinkVerifierImpl();
 
         const isVerified = await subject.verifyPresentationRequest(
@@ -32,7 +53,37 @@ describe('PresentationRequestByDeepLinkVerifier', () => {
         expect(isVerified).toBeTruthy();
     });
 
-    test('throws for a mismatched presentation request deep link', async () => {
+    test('testVerifyPresentationRequestSuccessWithDidDocumentIdInPresentationRequest', async () => {
+        subject = new PresentationRequestByDeepLinkVerifierImpl();
+        const presentationRequestWithDidDocumentId = createPresentationRequest(
+            DidDocumentMocks.DidDocumentMock.id,
+        );
+
+        const isVerified = await subject.verifyPresentationRequest(
+            presentationRequestWithDidDocumentId,
+            deepLink,
+            DidDocumentMocks.DidDocumentMock,
+        );
+        expect(isVerified).toBeTruthy();
+    });
+
+    test('testVerifyPresentationRequestSuccessWithDidDocumentIdInDeepLink', async () => {
+        subject = new PresentationRequestByDeepLinkVerifierImpl();
+        const deepLinkWithDidDocumentId = new VCLDeepLink(
+            `velocity-network://inspect?inspectorDid=${encodeURIComponent(
+                DidDocumentMocks.DidDocumentMock.id,
+            )}`,
+        );
+
+        const isVerified = await subject.verifyPresentationRequest(
+            presentationRequest,
+            deepLinkWithDidDocumentId,
+            DidDocumentMocks.DidDocumentMock,
+        );
+        expect(isVerified).toBeTruthy();
+    });
+
+    test('testVerifyPresentationRequestError', async () => {
         subject = new PresentationRequestByDeepLinkVerifierImpl();
         try {
             const isVerified = await subject.verifyPresentationRequest(

--- a/packages/vnf-wallet-sdk-nodejs/test/verifiers/PresentationRequestByDeepLinkVerifier.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/verifiers/PresentationRequestByDeepLinkVerifier.test.ts
@@ -98,4 +98,19 @@ describe('PresentationRequestByDeepLinkVerifier', () => {
             );
         }
     });
+
+    test('testVerifyPresentationRequestErrorWhenDeepLinkDidMissing', async () => {
+        subject = new PresentationRequestByDeepLinkVerifierImpl();
+
+        await expect(
+            subject.verifyPresentationRequest(
+                presentationRequest,
+                new VCLDeepLink('velocity-network://inspect'),
+                DidDocumentMocks.DidDocumentMock,
+            ),
+        ).rejects.toMatchObject({
+            errorCode: VCLErrorCode.SdkError,
+            message: expect.stringContaining('DID not found in deep link'),
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- update `PresentationRequestByDeepLinkVerifierImpl` to validate each DID independently against `didDocument.id` OR `didDocument.alsoKnownAs`
- keep mismatch behavior/error code for truly invalid combinations
- add tests for both mixed valid combinations (`iss=id` + `deepLink=alsoKnownAs`, and `iss=alsoKnownAs` + `deepLink=id`)

## Why
Valid presentation requests were being rejected when one DID matched `didDocument.id` and the other matched `didDocument.alsoKnownAs`.

## Validation
- `node --enable-source-maps --import=global-jsdom/register --import=tsx --import=./setup-tests.js --test --test-reporter=spec --test-reporter-destination=stdout test/verifiers/PresentationRequestByDeepLinkVerifier.test.ts`