### PR TITLE
fix: accept additional presentation contexts

### DIFF
--- a/packages/verii-verification/src/validate-presentation-context.js
+++ b/packages/verii-verification/src/validate-presentation-context.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const { castArray, includes } = require('lodash/fp');
+const { castArray } = require('lodash/fp');
 const newError = require('http-errors');
 
 const validatePresentationContext = (
@@ -22,7 +22,7 @@ const validatePresentationContext = (
   {
     config: {
       enablePresentationContextValidation,
-      presentationContextValue: expectedValue,
+      presentationContextValue: expectedValues,
     },
   },
 ) => {
@@ -30,7 +30,12 @@ const validatePresentationContext = (
     return;
   }
 
-  if (!includes(expectedValue, castArray(presentation?.['@context']))) {
+  const presentationContexts =
+    presentation?.['@context'] == null
+      ? []
+      : castArray(presentation['@context']);
+
+  if (!expectedValues.some((value) => presentationContexts.includes(value))) {
     throw newError(400, 'presentation @context is not set correctly', {
       errorCode: 'presentation_invalid',
     });

--- a/packages/verii-verification/test/validate-presentation-context.test.js
+++ b/packages/verii-verification/test/validate-presentation-context.test.js
@@ -22,7 +22,10 @@ const {
 
 const config = {
   enablePresentationContextValidation: true,
-  presentationContextValue: 'http://example.com/presentation.jsonld',
+  presentationContextValue: [
+    'http://example.com/presentation.jsonld',
+    'http://example.com/presentation-v2.jsonld',
+  ],
 };
 
 describe('validate presentation context', () => {
@@ -35,7 +38,10 @@ describe('validate presentation context', () => {
         {
           config: {
             enablePresentationContextValidation: false,
-            presentationContextValue: 'http://example.com/presentation.jsonld',
+            presentationContextValue: [
+              'http://example.com/presentation.jsonld',
+              'http://example.com/presentation-v2.jsonld',
+            ],
           },
         },
       ),
@@ -62,6 +68,16 @@ describe('validate presentation context', () => {
         validatePresentationContext(
           {
             '@context': 'http://example.com/presentation.jsonld',
+          },
+          { config },
+        ),
+      ).toBeUndefined();
+    });
+    it('should pass string presentation context for another allowed value', () => {
+      expect(
+        validatePresentationContext(
+          {
+            '@context': 'http://example.com/presentation-v2.jsonld',
           },
           { config },
         ),

--- a/servers/credentialagent/src/config/core-config.js
+++ b/servers/credentialagent/src/config/core-config.js
@@ -106,8 +106,13 @@ const coreConfig = {
     .asString(),
   presentationContextValue: env
     .get('PRESENTATION_CONTEXT_VALUE')
-    .default('https://www.w3.org/2018/credentials/v1')
-    .asString(),
+    .default(
+      [
+        'https://www.w3.org/2018/credentials/v1',
+        'https://www.w3.org/ns/credentials/v2',
+      ].join(','),
+    )
+    .asArray(),
   enablePresentationContextValidation: env
     .get('ENABLE_PRESENTATION_CONTEXT_VALIDATION')
     .default('false')


### PR DESCRIPTION
## Summary
- allow presentation context validation to accept an array of configured values
- default credentialagent presentation contexts to `https://www.w3.org/2018/credentials/v1` and `https://www.w3.org/ns/credentials/v2`
- keep the test changes minimal by updating the shared validator test fixture and adding one assertion for the second accepted context

## Testing
- `yarn eslint --fix packages/verii-verification/src/validate-presentation-context.js packages/verii-verification/test/validate-presentation-context.test.js servers/credentialagent/src/config/core-config.js`
- `NODE_ENV=test node --test --test-concurrency=1 --test-reporter=spec packages/verii-verification/test/validate-presentation-context.test.js`
- `NODE_ENV=test node --test --test-concurrency=1 --experimental-test-module-mocks --test-reporter=spec servers/credentialagent/test/holder/presentation-submission.test.js` *(fails in this environment: Mongo connect to localhost:27017 returned EPERM)*
- `NODE_ENV=test node --test --test-concurrency=1 --experimental-test-module-mocks --test-reporter=spec servers/credentialagent/test/holder/submit-identification.test.js` *(fails in this environment: Mongo connect to localhost:27017 returned EPERM)*
