### PR TITLE
[codex] Group Renovate updates for @spencejs packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,6 +84,12 @@
       "automerge": false
     },
     {
+      "groupName": "group: spence packages",
+      "matchPackageNames": [
+        "@spencejs/{/,}**"
+      ]
+    },
+    {
       "matchPackageNames": [
         "twilio{/,}**",
         "ethers{/,}**",


### PR DESCRIPTION
## Summary
- add a Renovate package rule that groups all `@spencejs/*` dependencies into a single PR
- keep the rule aligned with the actual package scope used in this repository

## Why
Renovate currently groups several dependency families, but `@spencejs` packages are still updated independently. Grouping them keeps related internal package updates together and reduces PR noise.

## Validation
- parsed `renovate.json` with `jq`
