### PR TITLE
[codex] align nodejs VCLError API with mobile SDKs

### DIFF
--- a/packages/vnf-wallet-sdk-nodejs/package.json
+++ b/packages/vnf-wallet-sdk-nodejs/package.json
@@ -27,7 +27,6 @@
     "axios": "^1.13.5",
     "canonicalize": "^2.1.0",
     "jose": "^5.9.6",
-    "lodash": "^4.17.21",
     "pino": "^10.0.0",
     "pino-pretty": "^13.0.0"
   },

--- a/packages/vnf-wallet-sdk-nodejs/src/api/entities/error/VCLError.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/api/entities/error/VCLError.ts
@@ -61,12 +61,24 @@ export default class VCLError extends Error {
             return error;
         }
         return new VCLError({
-            error: JSON.stringify(error),
+            error: VCLError.stringifyErrorSafely(error),
             errorCode: VCLError.findErrorCode(error),
             requestId: error.requestId,
             message: error.message,
             statusCode: statusCode ?? error.statusCode,
         });
+    }
+
+    private static stringifyErrorSafely(error: any): Nullish<string> {
+        if (error == null) {
+            return null;
+        }
+
+        try {
+            return JSON.stringify(error);
+        } catch {
+            return String(error);
+        }
     }
 
     private static findErrorCode(error: any): string {

--- a/packages/vnf-wallet-sdk-nodejs/src/api/entities/error/VCLError.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/api/entities/error/VCLError.ts
@@ -60,6 +60,14 @@ export default class VCLError extends Error {
         if (error instanceof VCLError) {
             return error;
         }
+
+        if (!(error instanceof Error)) {
+            return new VCLError({
+                error: VCLError.stringifyErrorSafely(error),
+                statusCode,
+            });
+        }
+
         return new VCLError({
             error: VCLError.stringifyErrorSafely(error),
             errorCode: VCLError.findErrorCode(error),

--- a/packages/vnf-wallet-sdk-nodejs/src/api/entities/error/VCLError.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/api/entities/error/VCLError.ts
@@ -1,6 +1,15 @@
 import { Dictionary, Nullish } from '../../VCLTypes';
 import VCLErrorCode from './VCLErrorCode';
 
+export type VCLErrorArgs = {
+    payload?: Nullish<string>;
+    error?: Nullish<string>;
+    errorCode?: string;
+    requestId?: Nullish<string>;
+    message?: Nullish<string>;
+    statusCode?: Nullish<number>;
+};
+
 export default class VCLError extends Error {
     payload: Nullish<string> = null;
 
@@ -13,56 +22,52 @@ export default class VCLError extends Error {
     statusCode: Nullish<number> = null;
 
     // eslint-disable-next-line complexity
-    constructor(
-        error: Nullish<string> = null,
-        errorCode: string = VCLErrorCode.SdkError.toString(),
-        requestId: Nullish<string> = null,
-        message: Nullish<string> = null,
-        statusCode: Nullish<number> = null,
-    ) {
+    constructor({
+        payload = null,
+        error = null,
+        errorCode = VCLErrorCode.SdkError.toString(),
+        requestId = null,
+        message = null,
+        statusCode = null,
+    }: VCLErrorArgs = {}) {
         super(message ?? '');
+        this.payload = payload;
         this.error = error;
         this.errorCode = errorCode;
         this.requestId = requestId;
         this.statusCode = statusCode;
-        this.payload = JSON.stringify(this.jsonObject);
 
         this.name = 'VCLError';
         // eslint-disable-next-line better-mutation/no-mutating-functions
         Object.setPrototypeOf(this, new.target.prototype); // restore prototype chain
     }
 
+    // eslint-disable-next-line complexity
     static fromPayload(payload: string): VCLError {
         const payloadJson = JSON.parse(payload);
-        return VCLError.fromJson(payloadJson);
-    }
-
-    // eslint-disable-next-line complexity
-    static fromJson(payloadJson: Dictionary<any>): VCLError {
-        const result = new VCLError(
-            payloadJson?.[VCLError.KeyError],
-            payloadJson?.[VCLError.KeyErrorCode] ??
+        return new VCLError({
+            payload,
+            error: payloadJson?.[VCLError.KeyError],
+            errorCode:
+                payloadJson?.[VCLError.KeyErrorCode] ??
                 VCLErrorCode.SdkError.toString(),
-            payloadJson?.[VCLError.KeyRequestId],
-            payloadJson?.[VCLError.KeyMessage],
-            payloadJson?.[VCLError.KeyStatusCode],
-        );
-        result.payload = JSON.stringify(payloadJson);
-
-        return result;
+            requestId: payloadJson?.[VCLError.KeyRequestId],
+            message: payloadJson?.[VCLError.KeyMessage],
+            statusCode: payloadJson?.[VCLError.KeyStatusCode],
+        });
     }
 
     static fromError(error: any, statusCode: Nullish<number> = null): VCLError {
         if (error instanceof VCLError) {
             return error;
         }
-        return new VCLError(
-            JSON.stringify(error),
-            VCLError.findErrorCode(error),
-            error.requestId,
-            error.message,
-            statusCode ?? error.statusCode,
-        );
+        return new VCLError({
+            error: JSON.stringify(error),
+            errorCode: VCLError.findErrorCode(error),
+            requestId: error.requestId,
+            message: error.message,
+            statusCode: statusCode ?? error.statusCode,
+        });
     }
 
     private static findErrorCode(error: any): string {

--- a/packages/vnf-wallet-sdk-nodejs/src/api/entities/error/VCLError.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/api/entities/error/VCLError.ts
@@ -43,10 +43,9 @@ export default class VCLError extends Error {
     }
 
     // eslint-disable-next-line complexity
-    static fromPayload(payload: string): VCLError {
-        const payloadJson = JSON.parse(payload);
+    static fromPayloadJson(payloadJson: Dictionary<any>): VCLError {
         return new VCLError({
-            payload,
+            payload: JSON.stringify(payloadJson),
             error: payloadJson?.[VCLError.KeyError],
             errorCode:
                 payloadJson?.[VCLError.KeyErrorCode] ??

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/VCLImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/VCLImpl.ts
@@ -42,7 +42,6 @@ import CredentialTypesModel from './domain/models/CredentialTypesModel';
 import InitializationWatcher from './utils/InitializationWatcher';
 import { ProfileServiceTypeVerifier } from './utils/ProfileServiceTypeVerifier';
 import VCLLog from './utils/VCLLog';
-import VCLErrorCode from '../api/entities/error/VCLErrorCode';
 import VerifiedProfileUseCase from './domain/usecases/VerifiedProfileUseCase';
 import JwtServiceUseCase from './domain/usecases/JwtServiceUseCase';
 import IdentificationSubmissionUseCase from './domain/usecases/IdentificationSubmissionUseCase';
@@ -167,7 +166,9 @@ export class VCLImpl implements VCL {
             }
         } else {
             return completionHandler(
-                new VCLError('Failed to get credential type schemas'),
+                new VCLError({
+                    message: 'Failed to get credential type schemas',
+                }),
             );
         }
     }
@@ -255,11 +256,11 @@ export class VCLImpl implements VCL {
     ) => {
         const { did } = presentationRequestDescriptor;
         if (!did) {
-            const err = new VCLError(
-                `did was not found in ${JSON.stringify(
+            const err = new VCLError({
+                message: `did was not found in ${JSON.stringify(
                     presentationRequestDescriptor,
                 )}`,
-            );
+            });
 
             logError('getPresentationRequest::verifiedProfile', err);
             throw err;
@@ -324,13 +325,11 @@ export class VCLImpl implements VCL {
     ) => {
         const { did } = credentialManifestDescriptor;
         if (!did) {
-            const error = new VCLError(
-                `did was not found in ${JSON.stringify(
+            const error = new VCLError({
+                message: `did was not found in ${JSON.stringify(
                     credentialManifestDescriptor,
                 )}`,
-                VCLErrorCode.SdkError.toString(),
-                null,
-            );
+            });
 
             logError("credentialManifestDescriptor.did doesn't exist", error);
             throw error;
@@ -428,9 +427,9 @@ export class VCLImpl implements VCL {
                 throw error;
             }
         } else {
-            const error = new VCLError(
-                'No countries for getCredentialTypesUIFormSchema',
-            );
+            const error = new VCLError({
+                message: 'No countries for getCredentialTypesUIFormSchema',
+            });
 
             logError('getCredentialTypesUIFormSchema', error);
             throw error;

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
@@ -66,11 +66,11 @@ export default class NetworkServiceImpl implements NetworkService {
     private normalizeError(error: any): VCLError {
         const response = error?.response;
         const payload = response?.data;
+        const contentType = response?.headers?.['content-type'];
 
         if (response) {
-            const jsonPayload = this.toJsonPayload(payload);
-            if (jsonPayload != null) {
-                return VCLError.fromPayload(jsonPayload);
+            if (this.isJsonContentType(contentType) && payload != null) {
+                return VCLError.fromPayloadJson(payload);
             }
 
             if (payload != null) {
@@ -88,20 +88,11 @@ export default class NetworkServiceImpl implements NetworkService {
         return VCLError.fromError(error, response?.status);
     }
 
-    private toJsonPayload(payload: unknown): Nullish<string> {
-        if (typeof payload === 'string') {
-            try {
-                JSON.parse(payload);
-                return payload;
-            } catch {
-                return null;
-            }
-        }
-
-        if (payload && typeof payload === 'object') {
-            return JSON.stringify(payload);
-        }
-
-        return null;
+    private isJsonContentType(contentType?: string): boolean {
+        return (
+            typeof contentType === 'string' &&
+            (contentType.includes('application/json') ||
+                contentType.includes('+json'))
+        );
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
@@ -83,10 +83,15 @@ export default class NetworkServiceImpl implements NetworkService {
     }
 
     private isJsonContentType(contentType?: string): boolean {
+        if (typeof contentType !== 'string') {
+            return false;
+        }
+
+        const normalizedContentType = contentType.toLowerCase();
+
         return (
-            typeof contentType === 'string' &&
-            (contentType.includes('application/json') ||
-                contentType.includes('+json'))
+            normalizedContentType.includes('application/json') ||
+            normalizedContentType.includes('+json')
         );
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
@@ -72,16 +72,12 @@ export default class NetworkServiceImpl implements NetworkService {
 
         if (this.isJsonContentType(response.headers?.['content-type'])) {
             const normalizedError = VCLError.fromPayloadJson(response.data);
-            return normalizedError.statusCode == null
-                ? new VCLError({
-                      payload: normalizedError.payload,
-                      error: normalizedError.error,
-                      errorCode: normalizedError.errorCode,
-                      requestId: normalizedError.requestId,
-                      message: normalizedError.message,
-                      statusCode: response.status,
-                  })
-                : normalizedError;
+
+            if (normalizedError.statusCode == null) {
+                // eslint-disable-next-line better-mutation/no-mutation
+                normalizedError.statusCode = response.status;
+            }
+            return normalizedError;
         }
 
         const textPayload = toNullableString(response.data);

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
@@ -62,30 +62,28 @@ export default class NetworkServiceImpl implements NetworkService {
         VCLLog.info(request, 'Network request');
     }
 
-    // eslint-disable-next-line complexity
     private normalizeError(error: any): VCLError {
         const response = error?.response;
-        const payload = response?.data;
-        const contentType = response?.headers?.['content-type'];
-
-        if (response) {
-            if (this.isJsonContentType(contentType) && payload != null) {
-                return VCLError.fromPayloadJson(payload);
-            }
-
-            if (payload != null) {
-                const textPayload =
-                    typeof payload === 'string' ? payload : String(payload);
-
-                return new VCLError({
-                    payload: textPayload,
-                    message: textPayload,
-                    statusCode: response.status,
-                });
-            }
+        if (!response) {
+            return VCLError.fromError(error);
         }
 
-        return VCLError.fromError(error, response?.status);
+        return this.normalizeResponseError(response, error);
+    }
+
+    private normalizeResponseError(response: any, error: any): VCLError {
+        if (this.isJsonContentType(response.headers?.['content-type'])) {
+            return VCLError.fromPayloadJson(response.data);
+        }
+
+        const textPayload =
+            response.data == null ? null : String(response.data);
+
+        return new VCLError({
+            payload: textPayload,
+            message: error.message ?? textPayload,
+            statusCode: response.status,
+        });
     }
 
     private isJsonContentType(contentType?: string): boolean {

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
@@ -2,6 +2,7 @@ import axios, { AxiosResponse } from 'axios';
 import { Nullish } from '../../../../api/VCLTypes';
 import VCLError from '../../../../api/entities/error/VCLError';
 import NetworkService from '../../../domain/infrastructure/network/NetworkService';
+import { toNullableString } from '../../../utils/HelperFunctions';
 import VCLLog from '../../../utils/VCLLog';
 import Response from './Response';
 import Request from './Request';
@@ -68,16 +69,11 @@ export default class NetworkServiceImpl implements NetworkService {
             return VCLError.fromError(error);
         }
 
-        return this.normalizeResponseError(response, error);
-    }
-
-    private normalizeResponseError(response: any, error: any): VCLError {
         if (this.isJsonContentType(response.headers?.['content-type'])) {
             return VCLError.fromPayloadJson(response.data);
         }
 
-        const textPayload =
-            response.data == null ? null : String(response.data);
+        const textPayload = toNullableString(response.data);
 
         return new VCLError({
             payload: textPayload,

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
@@ -63,6 +63,7 @@ export default class NetworkServiceImpl implements NetworkService {
         VCLLog.info(request, 'Network request');
     }
 
+    // eslint-disable-next-line complexity
     private normalizeError(error: any): VCLError {
         const response = error?.response;
         if (!response) {
@@ -70,7 +71,17 @@ export default class NetworkServiceImpl implements NetworkService {
         }
 
         if (this.isJsonContentType(response.headers?.['content-type'])) {
-            return VCLError.fromPayloadJson(response.data);
+            const normalizedError = VCLError.fromPayloadJson(response.data);
+            return normalizedError.statusCode == null
+                ? new VCLError({
+                      payload: normalizedError.payload,
+                      error: normalizedError.error,
+                      errorCode: normalizedError.errorCode,
+                      requestId: normalizedError.requestId,
+                      message: normalizedError.message,
+                      statusCode: response.status,
+                  })
+                : normalizedError;
         }
 
         const textPayload = toNullableString(response.data);

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/infrastructure/network/NetworkServiceImpl.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
 import { Nullish } from '../../../../api/VCLTypes';
+import VCLError from '../../../../api/entities/error/VCLError';
 import NetworkService from '../../../domain/infrastructure/network/NetworkService';
 import VCLLog from '../../../utils/VCLLog';
 import Response from './Response';
@@ -7,7 +8,6 @@ import Request from './Request';
 import { HttpMethod } from './HttpMethod';
 
 export default class NetworkServiceImpl implements NetworkService {
-    // eslint-disable-next-line complexity
     async sendRequestRaw(request: Request): Promise<Response> {
         const MAX_AGE = 60 * 60 * 24; // 24 hours
 
@@ -49,7 +49,7 @@ export default class NetworkServiceImpl implements NetworkService {
             const r = await handler();
             return new Response(r!.data, r!.status);
         } catch (error: any) {
-            throw error.response?.data ?? error;
+            throw this.normalizeError(error);
         }
     }
 
@@ -60,5 +60,48 @@ export default class NetworkServiceImpl implements NetworkService {
 
     logRequest(request: Request) {
         VCLLog.info(request, 'Network request');
+    }
+
+    // eslint-disable-next-line complexity
+    private normalizeError(error: any): VCLError {
+        const response = error?.response;
+        const payload = response?.data;
+
+        if (response) {
+            const jsonPayload = this.toJsonPayload(payload);
+            if (jsonPayload != null) {
+                return VCLError.fromPayload(jsonPayload);
+            }
+
+            if (payload != null) {
+                const textPayload =
+                    typeof payload === 'string' ? payload : String(payload);
+
+                return new VCLError({
+                    payload: textPayload,
+                    message: textPayload,
+                    statusCode: response.status,
+                });
+            }
+        }
+
+        return VCLError.fromError(error, response?.status);
+    }
+
+    private toJsonPayload(payload: unknown): Nullish<string> {
+        if (typeof payload === 'string') {
+            try {
+                JSON.parse(payload);
+                return payload;
+            } catch {
+                return null;
+            }
+        }
+
+        if (payload && typeof payload === 'object') {
+            return JSON.stringify(payload);
+        }
+
+        return null;
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/AuthTokenRepositoryImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/AuthTokenRepositoryImpl.ts
@@ -23,7 +23,9 @@ export default class AuthTokenRepositoryImpl implements AuthTokenRepository {
     ): Promise<VCLAuthToken> {
         const { authTokenUri } = authTokenDescriptor;
         if (authTokenUri == null) {
-            throw new VCLError('authTokenDescriptor.authTokenUri = null');
+            throw new VCLError({
+                message: 'authTokenDescriptor.authTokenUri = null',
+            });
         }
         try {
             const authTokenResponse = await this.networkService.sendRequest({
@@ -52,10 +54,10 @@ export default class AuthTokenRepositoryImpl implements AuthTokenRepository {
 
     async verifyAuthTokenPayload(payload: Dictionary<any>): Promise<void> {
         if (payload.access_token == null) {
-            throw new VCLError('payload.access_token = null');
+            throw new VCLError({ message: 'payload.access_token = null' });
         }
         if (payload.refresh_token == null) {
-            throw new VCLError('payload.refresh_token = null');
+            throw new VCLError({ message: 'payload.refresh_token = null' });
         }
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/CredentialManifestRepositoryImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/CredentialManifestRepositoryImpl.ts
@@ -14,7 +14,9 @@ export default class CredentialManifestRepositoryImpl implements CredentialManif
     ): Promise<string> {
         const { endpoint } = credentialManifestDescriptor;
         if (!endpoint) {
-            throw new VCLError('credentialManifestDescriptor.endpoint = null');
+            throw new VCLError({
+                message: 'credentialManifestDescriptor.endpoint = null',
+            });
         }
 
         const credentialManifestResponse =

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/FinalizeOffersRepositoryImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/FinalizeOffersRepositoryImpl.ts
@@ -37,8 +37,8 @@ export class FinalizeOffersRepositoryImpl implements FinalizeOffersRepository {
         if (finalizedOffersResponse.payload instanceof Error) {
             throw VCLError.fromError(finalizedOffersResponse.payload);
         }
-        throw new VCLError(
-            `Failed to parse: ${finalizedOffersResponse.payload}`,
-        );
+        throw new VCLError({
+            message: `Failed to parse: ${finalizedOffersResponse.payload}`,
+        });
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/GenerateOffersRepositoryImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/GenerateOffersRepositoryImpl.ts
@@ -31,6 +31,6 @@ export default class GenerateOffersRepositoryImpl implements GenerateOffersRepos
                 sessionToken,
             );
         }
-        throw new VCLError({ message: 'Offers did not returned.' });
+        throw new VCLError({ message: 'Offers were not returned.' });
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/GenerateOffersRepositoryImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/GenerateOffersRepositoryImpl.ts
@@ -31,6 +31,6 @@ export default class GenerateOffersRepositoryImpl implements GenerateOffersRepos
                 sessionToken,
             );
         }
-        throw new VCLError('Offers did not returned.');
+        throw new VCLError({ message: 'Offers did not returned.' });
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/PresentationRequestRepositoryImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/PresentationRequestRepositoryImpl.ts
@@ -14,7 +14,9 @@ export default class PresentationRequestRepositoryImpl implements PresentationRe
     ): Promise<string> {
         const { endpoint } = presentationRequestDescriptor;
         if (!endpoint) {
-            throw new VCLError('presentationRequestDescriptor.endpoint = null');
+            throw new VCLError({
+                message: 'presentationRequestDescriptor.endpoint = null',
+            });
         }
 
         const presentationRequestResponse =

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/usecases/CredentialManifestUseCaseImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/usecases/CredentialManifestUseCaseImpl.ts
@@ -45,13 +45,15 @@ export default class CredentialManifestUseCaseImpl implements CredentialManifest
                 );
             const { kid } = credentialManifest.jwt;
             if (kid === null) {
-                throw new VCLError(
-                    `Empty credentialManifest.jwt.kid in jwt: ${credentialManifest.jwt}`,
-                );
+                throw new VCLError({
+                    message: `Empty credentialManifest.jwt.kid in jwt: ${credentialManifest.jwt}`,
+                });
             }
             const publicJwk = didDocument.getPublicJwk(kid);
             if (publicJwk === null) {
-                throw new VCLError(`public jwk not found for kid: ${kid}`);
+                throw new VCLError({
+                    message: `public jwk not found for kid: ${kid}`,
+                });
             }
             return this.verifyCredentialManifestJwt(
                 publicJwk,
@@ -59,7 +61,7 @@ export default class CredentialManifestUseCaseImpl implements CredentialManifest
                 didDocument,
             );
         }
-        throw new VCLError('Empty jwtStr');
+        throw new VCLError({ message: 'Empty jwtStr' });
     }
 
     async verifyCredentialManifestJwt(
@@ -104,8 +106,8 @@ export default class CredentialManifestUseCaseImpl implements CredentialManifest
         if (isVerified) {
             return credentialManifest;
         }
-        throw new VCLError(
-            `Failed to verify credentialManifest jwt:\n${credentialManifest.jwt}`,
-        );
+        throw new VCLError({
+            message: `Failed to verify credentialManifest jwt:\n${credentialManifest.jwt}`,
+        });
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/usecases/FinalizeOffersUseCaseImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/usecases/FinalizeOffersUseCaseImpl.ts
@@ -83,7 +83,7 @@ export default class FinalizeOffersUseCaseImpl implements FinalizeOffersUseCase 
                 );
             }
         }
-        throw new VCLError('Credentials verification failed');
+        throw new VCLError({ message: 'Credentials verification failed' });
     }
 
     async verifyCredentialsByDeepLink(

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/usecases/PresentationRequestUseCaseImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/usecases/PresentationRequestUseCaseImpl.ts
@@ -43,9 +43,9 @@ export default class PresentationRequestUseCaseImpl implements PresentationReque
         const { kid } = presentationRequest.jwt;
         const publicJwk = didDocument.getPublicJwk(kid);
         if (publicJwk == null) {
-            throw new VCLError(
-                `Public JWK not found for kid: ${kid} in DID Document: ${didDocument}`,
-            );
+            throw new VCLError({
+                message: `Public JWK not found for kid: ${kid} in DID Document: ${didDocument}`,
+            });
         }
         return this.verifyPresentationRequest(
             publicJwk,
@@ -83,8 +83,8 @@ export default class PresentationRequestUseCaseImpl implements PresentationReque
         if (isVerified) {
             return presentationRequest;
         }
-        throw new VCLError(
-            `Failed  to verify: ${presentationRequest.jwt.payload}`,
-        );
+        throw new VCLError({
+            message: `Failed  to verify: ${presentationRequest.jwt.payload}`,
+        });
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/usecases/PresentationRequestUseCaseImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/usecases/PresentationRequestUseCaseImpl.ts
@@ -84,7 +84,7 @@ export default class PresentationRequestUseCaseImpl implements PresentationReque
             return presentationRequest;
         }
         throw new VCLError({
-            message: `Failed  to verify: ${presentationRequest.jwt.payload}`,
+            message: `Failed to verify: ${presentationRequest.jwt.payload}`,
         });
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/CredentialManifestByDeepLinkVerifierImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/CredentialManifestByDeepLinkVerifierImpl.ts
@@ -42,6 +42,9 @@ export default class CredentialManifestByDeepLinkVerifierImpl implements Credent
         errorCode: VCLErrorCode = VCLErrorCode.SdkError,
     ) {
         VCLLog.error(errorMessage);
-        throw new VCLError(null, errorCode, null, errorMessage);
+        throw new VCLError({
+            errorCode: errorCode.toString(),
+            message: errorMessage,
+        });
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/CredentialsByDeepLinkVerifierImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/CredentialsByDeepLinkVerifierImpl.ts
@@ -59,6 +59,9 @@ export default class CredentialsByDeepLinkVerifierImpl implements CredentialsByD
         errorCode: VCLErrorCode = VCLErrorCode.SdkError,
     ) {
         VCLLog.error(errorMessage);
-        throw new VCLError(null, errorCode, null, errorMessage);
+        throw new VCLError({
+            errorCode: errorCode.toString(),
+            message: errorMessage,
+        });
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/OffersByDeepLinkVerifierImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/OffersByDeepLinkVerifierImpl.ts
@@ -59,6 +59,9 @@ export default class OffersByDeepLinkVerifierImpl implements OffersByDeepLinkVer
         errorCode: VCLErrorCode = VCLErrorCode.SdkError,
     ) {
         VCLLog.error(errorMessage);
-        throw new VCLError(null, errorCode, null, errorMessage);
+        throw new VCLError({
+            errorCode: errorCode.toString(),
+            message: errorMessage,
+        });
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.ts
@@ -42,6 +42,9 @@ export default class PresentationRequestByDeepLinkVerifierImpl implements Presen
         errorCode: VCLErrorCode = VCLErrorCode.SdkError,
     ) {
         VCLLog.error(errorMessage);
-        throw new VCLError(null, errorCode, null, errorMessage);
+        throw new VCLError({
+            errorCode: errorCode.toString(),
+            message: errorMessage,
+        });
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/utils/HelperFunctions.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/utils/HelperFunctions.ts
@@ -89,3 +89,7 @@ export const ensureDefined = <T>(
     }
     return value;
 };
+
+export const toNullableString = (value: unknown): Nullish<string> => {
+    return value == null ? null : String(value);
+};

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/utils/HelperFunctions.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/utils/HelperFunctions.ts
@@ -85,7 +85,7 @@ export const ensureDefined = <T>(
     name: string,
 ): T => {
     if (value == null) {
-        throw new VCLError(`${name} is required`);
+        throw new VCLError({ message: `${name} is required` });
     }
     return value;
 };

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/utils/ProfileServiceTypeVerifier.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/utils/ProfileServiceTypeVerifier.ts
@@ -57,15 +57,13 @@ export class ProfileServiceTypeVerifier {
         ) {
             return true;
         }
-        throw new VCLError(
-            null,
-            VCLErrorCode.SdkError.toString(),
-            null,
-            this.toJsonString(
+        throw new VCLError({
+            errorCode: VCLErrorCode.SdkError.toString(),
+            message: this.toJsonString(
                 verifiedProfile.name,
                 `Wrong service type - expected: ${expectedServiceTypes.all}, found: ${verifiedProfile.serviceTypes.all}`,
             ),
-            VCLStatusCode.VerificationError,
-        );
+            statusCode: VCLStatusCode.VerificationError,
+        });
     }
 }

--- a/packages/vnf-wallet-sdk-nodejs/test/entities/VCLError.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/entities/VCLError.test.ts
@@ -89,13 +89,12 @@ describe('VCLError', () => {
     });
 
     test('creates an error from another error', () => {
-        const sourceError = {
-            error: ErrorMocks.SomeErrorJson.error,
-            errorCode: ErrorMocks.SomeErrorJson.errorCode,
-            requestId: ErrorMocks.SomeErrorJson.requestId,
-            message: ErrorMocks.SomeErrorJson.message,
-            statusCode: ErrorMocks.SomeErrorJson.statusCode,
-        };
+        const sourceError = new Error(
+            ErrorMocks.SomeErrorJson.message,
+        ) as Error & Record<string, any>;
+        sourceError.errorCode = ErrorMocks.SomeErrorJson.errorCode;
+        sourceError.requestId = ErrorMocks.SomeErrorJson.requestId;
+        sourceError.statusCode = ErrorMocks.SomeErrorJson.statusCode;
         const error = VCLError.fromError(sourceError);
 
         expect(error.payload).toBeNull();
@@ -104,5 +103,16 @@ describe('VCLError', () => {
         expect(error.requestId).toEqual(ErrorMocks.SomeErrorJson.requestId);
         expect(error.message).toEqual(ErrorMocks.SomeErrorJson.message);
         expect(error.statusCode).toEqual(ErrorMocks.SomeErrorJson.statusCode);
+    });
+
+    test('creates an error from a non-error value', () => {
+        const error = VCLError.fromError('Readable error');
+
+        expect(error.payload).toBeNull();
+        expect(error.error).toEqual('"Readable error"');
+        expect(error.errorCode).toEqual('sdk_error');
+        expect(error.requestId).toBeNull();
+        expect(error.message).toEqual('');
+        expect(error.statusCode).toBeNull();
     });
 });

--- a/packages/vnf-wallet-sdk-nodejs/test/entities/VCLError.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/entities/VCLError.test.ts
@@ -4,8 +4,8 @@ import VCLError from '../../src/api/entities/error/VCLError';
 import { ErrorMocks } from '../infrastructure/resources/valid/ErrorMocks';
 
 describe('VCLError', () => {
-    test('creates an error from a payload', () => {
-        const error = VCLError.fromPayload(ErrorMocks.Payload);
+    test('creates an error from a JSON payload', () => {
+        const error = VCLError.fromPayloadJson(JSON.parse(ErrorMocks.Payload));
 
         expect(error.payload).toEqual(ErrorMocks.Payload);
         expect(error.error).toEqual(ErrorMocks.Error);
@@ -40,8 +40,8 @@ describe('VCLError', () => {
         expect(error.statusCode).toBeNull();
     });
 
-    test('serializes an error created from a payload', () => {
-        const error = VCLError.fromPayload(ErrorMocks.Payload);
+    test('serializes an error created from a JSON payload', () => {
+        const error = VCLError.fromPayloadJson(JSON.parse(ErrorMocks.Payload));
         const errorJsonObject = error.jsonObject;
 
         expect(errorJsonObject[VCLError.KeyPayload]).toEqual(

--- a/packages/vnf-wallet-sdk-nodejs/test/entities/VCLError.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/entities/VCLError.test.ts
@@ -15,19 +15,29 @@ describe('VCLError', () => {
     });
 
     test('creates an error from explicit properties', () => {
-        const error = new VCLError(
-            ErrorMocks.Error,
-            ErrorMocks.ErrorCode,
-            ErrorMocks.RequestId,
-            ErrorMocks.Message,
-            ErrorMocks.StatusCode,
-        );
+        const error = new VCLError({
+            error: ErrorMocks.Error,
+            errorCode: ErrorMocks.ErrorCode,
+            requestId: ErrorMocks.RequestId,
+            message: ErrorMocks.Message,
+            statusCode: ErrorMocks.StatusCode,
+        });
 
         expect(error.error).toEqual(ErrorMocks.Error);
         expect(error.errorCode).toEqual(ErrorMocks.ErrorCode);
         expect(error.requestId).toEqual(ErrorMocks.RequestId);
         expect(error.message).toEqual(ErrorMocks.Message);
         expect(error.statusCode).toEqual(ErrorMocks.StatusCode);
+    });
+
+    test('creates an error from a human-readable message', () => {
+        const error = new VCLError({ message: 'Readable error' });
+
+        expect(error.payload).toBeNull();
+        expect(error.error).toBeNull();
+        expect(error.message).toEqual('Readable error');
+        expect(error.requestId).toBeNull();
+        expect(error.statusCode).toBeNull();
     });
 
     test('serializes an error created from a payload', () => {
@@ -53,15 +63,16 @@ describe('VCLError', () => {
     });
 
     test('serializes an error created from explicit properties', () => {
-        const error = new VCLError(
-            ErrorMocks.Error,
-            ErrorMocks.ErrorCode,
-            ErrorMocks.RequestId,
-            ErrorMocks.Message,
-            ErrorMocks.StatusCode,
-        );
+        const error = new VCLError({
+            error: ErrorMocks.Error,
+            errorCode: ErrorMocks.ErrorCode,
+            requestId: ErrorMocks.RequestId,
+            message: ErrorMocks.Message,
+            statusCode: ErrorMocks.StatusCode,
+        });
         const errorJsonObject = error.jsonObject;
 
+        expect(errorJsonObject[VCLError.KeyPayload]).toBeNull();
         expect(errorJsonObject[VCLError.KeyError]).toEqual(ErrorMocks.Error);
         expect(errorJsonObject[VCLError.KeyErrorCode]).toEqual(
             ErrorMocks.ErrorCode,
@@ -78,12 +89,17 @@ describe('VCLError', () => {
     });
 
     test('creates an error from another error', () => {
-        const error = VCLError.fromJson(ErrorMocks.SomeErrorJson);
+        const sourceError = {
+            error: ErrorMocks.SomeErrorJson.error,
+            errorCode: ErrorMocks.SomeErrorJson.errorCode,
+            requestId: ErrorMocks.SomeErrorJson.requestId,
+            message: ErrorMocks.SomeErrorJson.message,
+            statusCode: ErrorMocks.SomeErrorJson.statusCode,
+        };
+        const error = VCLError.fromError(sourceError);
 
-        expect(JSON.parse(error.payload ?? '{}')).toStrictEqual(
-            ErrorMocks.SomeErrorJson,
-        );
-        expect(error.error).toEqual(ErrorMocks.SomeErrorJson.error);
+        expect(error.payload).toBeNull();
+        expect(error.error).toEqual(JSON.stringify(sourceError));
         expect(error.errorCode).toEqual(ErrorMocks.SomeErrorJson.errorCode);
         expect(error.requestId).toEqual(ErrorMocks.SomeErrorJson.requestId);
         expect(error.message).toEqual(ErrorMocks.SomeErrorJson.message);

--- a/packages/vnf-wallet-sdk-nodejs/test/infrastructure/network/NetworkServiceImpl.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/infrastructure/network/NetworkServiceImpl.test.ts
@@ -8,6 +8,10 @@ import { expect } from 'expect';
 import NetworkServiceImpl from '../../../src/impl/data/infrastructure/network/NetworkServiceImpl';
 import Request from '../../../src/impl/data/infrastructure/network/Request';
 import { HttpMethod } from '../../../src/impl/data/infrastructure/network/HttpMethod';
+import {
+    HeaderKeys,
+    HeaderValues,
+} from '../../../src/impl/data/repositories/Urls';
 import VCLError from '../../../src/api/entities/error/VCLError';
 import { ErrorMocks } from '../../infrastructure/resources/valid/ErrorMocks';
 import {
@@ -19,6 +23,9 @@ import {
 const origin = 'https://network-service.test';
 const textPlain = 'text/plain';
 const jsonContentType = Request.ContentTypeApplicationJson;
+const protocolHeaders = {
+    [HeaderKeys.XVnfProtocolVersion]: HeaderValues.XVnfProtocolVersion,
+};
 
 describe('NetworkServiceImpl integration', () => {
     const subject = new NetworkServiceImpl();
@@ -32,13 +39,19 @@ describe('NetworkServiceImpl integration', () => {
             { hello: 'world' },
             200,
             {
+                ...protocolHeaders,
                 'cache-control': 'public, max-age=86400',
             },
             { 'content-type': jsonContentType },
         );
 
         const response = await subject.sendRequest(
-            new Request(`${origin}/json?mode=get`, HttpMethod.GET),
+            new Request(
+                `${origin}/json?mode=get`,
+                HttpMethod.GET,
+                undefined,
+                protocolHeaders,
+            ),
         );
 
         expect(response.code).toEqual(200);
@@ -51,12 +64,18 @@ describe('NetworkServiceImpl integration', () => {
             `${origin}/text`,
             'plain response body',
             200,
-            {},
+            protocolHeaders,
             { 'content-type': textPlain },
         );
 
         const response = await subject.sendRequest(
-            new Request(`${origin}/text`, HttpMethod.GET, undefined, {}, false),
+            new Request(
+                `${origin}/text`,
+                HttpMethod.GET,
+                undefined,
+                protocolHeaders,
+                false,
+            ),
         );
 
         expect(response.code).toEqual(200);
@@ -71,6 +90,7 @@ describe('NetworkServiceImpl integration', () => {
             { accepted: true },
             200,
             {
+                ...protocolHeaders,
                 'cache-control': 'public, max-age=86400',
                 'content-type': new RegExp(`^${jsonContentType}`),
             },
@@ -78,10 +98,15 @@ describe('NetworkServiceImpl integration', () => {
         );
 
         const response = await subject.sendRequest(
-            new Request(`${origin}/submit`, HttpMethod.POST, {
-                foo: 'bar',
-                count: 2,
-            }),
+            new Request(
+                `${origin}/submit`,
+                HttpMethod.POST,
+                {
+                    foo: 'bar',
+                    count: 2,
+                },
+                protocolHeaders,
+            ),
         );
 
         expect(response.code).toEqual(200);
@@ -96,6 +121,7 @@ describe('NetworkServiceImpl integration', () => {
             'PONG',
             200,
             {
+                ...protocolHeaders,
                 'content-type': textPlain,
             },
             { 'content-type': textPlain },
@@ -106,7 +132,7 @@ describe('NetworkServiceImpl integration', () => {
                 `${origin}/plain-text`,
                 HttpMethod.POST,
                 'PING',
-                {},
+                protocolHeaders,
                 false,
                 textPlain,
             ),
@@ -124,6 +150,7 @@ describe('NetworkServiceImpl integration', () => {
             ErrorMocks.SomeErrorJson,
             400,
             {
+                ...protocolHeaders,
                 'cache-control': 'public, max-age=86400',
                 'content-type': new RegExp(`^${jsonContentType}`),
             },
@@ -132,9 +159,14 @@ describe('NetworkServiceImpl integration', () => {
 
         await expect(
             subject.sendRequest(
-                new Request(`${origin}/errors`, HttpMethod.POST, {
-                    invalid: true,
-                }),
+                new Request(
+                    `${origin}/errors`,
+                    HttpMethod.POST,
+                    {
+                        invalid: true,
+                    },
+                    protocolHeaders,
+                ),
             ),
         ).rejects.toMatchObject({
             payload: JSON.stringify(ErrorMocks.SomeErrorJson),
@@ -152,13 +184,18 @@ describe('NetworkServiceImpl integration', () => {
             `${origin}/missing`,
             ErrorMocks.SomeErrorJson,
             404,
-            {},
+            protocolHeaders,
             { 'content-type': jsonContentType },
         );
 
         await expect(
             subject.sendRequest(
-                new Request(`${origin}/missing`, HttpMethod.GET, undefined),
+                new Request(
+                    `${origin}/missing`,
+                    HttpMethod.GET,
+                    undefined,
+                    protocolHeaders,
+                ),
             ),
         ).rejects.toMatchObject({
             payload: JSON.stringify(ErrorMocks.SomeErrorJson),
@@ -176,7 +213,7 @@ describe('NetworkServiceImpl integration', () => {
             `${origin}/internal-error`,
             'server error',
             500,
-            {},
+            protocolHeaders,
             { 'content-type': textPlain },
         );
 
@@ -186,6 +223,7 @@ describe('NetworkServiceImpl integration', () => {
                     `${origin}/internal-error`,
                     HttpMethod.GET,
                     undefined,
+                    protocolHeaders,
                 ),
             ),
         ).rejects.toMatchObject({

--- a/packages/vnf-wallet-sdk-nodejs/test/infrastructure/network/NetworkServiceImpl.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/infrastructure/network/NetworkServiceImpl.test.ts
@@ -191,7 +191,7 @@ describe('NetworkServiceImpl integration', () => {
         ).rejects.toMatchObject({
             payload: 'server error',
             error: null,
-            message: 'server error',
+            message: 'Request failed with status code 500',
             statusCode: 500,
         });
         expect(scope.isDone()).toBeTruthy();

--- a/packages/vnf-wallet-sdk-nodejs/test/infrastructure/network/NetworkServiceImpl.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/infrastructure/network/NetworkServiceImpl.test.ts
@@ -147,7 +147,31 @@ describe('NetworkServiceImpl integration', () => {
         expect(scope.isDone()).toBeTruthy();
     });
 
-    test('treats plain-text error bodies as human-readable VCLError messages', async () => {
+    test('parses JSON 404 error bodies as VCLError payloads', async () => {
+        const scope = mockAbsoluteGet(
+            `${origin}/missing`,
+            ErrorMocks.SomeErrorJson,
+            404,
+            {},
+            { 'content-type': jsonContentType },
+        );
+
+        await expect(
+            subject.sendRequest(
+                new Request(`${origin}/missing`, HttpMethod.GET, undefined),
+            ),
+        ).rejects.toMatchObject({
+            payload: JSON.stringify(ErrorMocks.SomeErrorJson),
+            error: ErrorMocks.SomeErrorJson.error,
+            errorCode: ErrorMocks.SomeErrorJson.errorCode,
+            requestId: ErrorMocks.SomeErrorJson.requestId,
+            message: ErrorMocks.SomeErrorJson.message,
+            statusCode: ErrorMocks.SomeErrorJson.statusCode,
+        });
+        expect(scope.isDone()).toBeTruthy();
+    });
+
+    test('treats plain-text 500 error bodies as human-readable VCLError messages', async () => {
         const scope = mockAbsoluteGet(
             `${origin}/internal-error`,
             'server error',

--- a/packages/vnf-wallet-sdk-nodejs/test/infrastructure/network/NetworkServiceImpl.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/infrastructure/network/NetworkServiceImpl.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2022 Velocity Career Labs inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, test } from 'node:test';
+import { expect } from 'expect';
+import NetworkServiceImpl from '../../../src/impl/data/infrastructure/network/NetworkServiceImpl';
+import Request from '../../../src/impl/data/infrastructure/network/Request';
+import { HttpMethod } from '../../../src/impl/data/infrastructure/network/HttpMethod';
+import VCLError from '../../../src/api/entities/error/VCLError';
+import { ErrorMocks } from '../../infrastructure/resources/valid/ErrorMocks';
+import {
+    mockAbsoluteGet,
+    mockAbsolutePost,
+    useNockLifecycle,
+} from '../../utils/nock';
+
+const origin = 'https://network-service.test';
+const textPlain = 'text/plain';
+const jsonContentType = Request.ContentTypeApplicationJson;
+
+describe('NetworkServiceImpl integration', () => {
+    const subject = new NetworkServiceImpl();
+
+    useNockLifecycle();
+    beforeEach(() => undefined);
+
+    test('sends GET requests with cache-control and parses json responses', async () => {
+        const scope = mockAbsoluteGet(
+            `${origin}/json?mode=get`,
+            { hello: 'world' },
+            200,
+            {
+                'cache-control': 'public, max-age=86400',
+            },
+            { 'content-type': jsonContentType },
+        );
+
+        const response = await subject.sendRequest(
+            new Request(`${origin}/json?mode=get`, HttpMethod.GET),
+        );
+
+        expect(response.code).toEqual(200);
+        expect(response.payload).toEqual({ hello: 'world' });
+        expect(scope.isDone()).toBeTruthy();
+    });
+
+    test('parses text responses for GET requests', async () => {
+        const scope = mockAbsoluteGet(
+            `${origin}/text`,
+            'plain response body',
+            200,
+            {},
+            { 'content-type': textPlain },
+        );
+
+        const response = await subject.sendRequest(
+            new Request(`${origin}/text`, HttpMethod.GET, undefined, {}, false),
+        );
+
+        expect(response.code).toEqual(200);
+        expect(response.payload).toEqual('plain response body');
+        expect(scope.isDone()).toBeTruthy();
+    });
+
+    test('sends JSON POST bodies with application/json content type', async () => {
+        const scope = mockAbsolutePost(
+            `${origin}/submit`,
+            { foo: 'bar', count: 2 },
+            { accepted: true },
+            200,
+            {
+                'cache-control': 'public, max-age=86400',
+                'content-type': new RegExp(`^${jsonContentType}`),
+            },
+            { 'content-type': jsonContentType },
+        );
+
+        const response = await subject.sendRequest(
+            new Request(`${origin}/submit`, HttpMethod.POST, {
+                foo: 'bar',
+                count: 2,
+            }),
+        );
+
+        expect(response.code).toEqual(200);
+        expect(response.payload).toEqual({ accepted: true });
+        expect(scope.isDone()).toBeTruthy();
+    });
+
+    test('sends text POST bodies with text/plain content type and parses text responses', async () => {
+        const scope = mockAbsolutePost(
+            `${origin}/plain-text`,
+            'PING',
+            'PONG',
+            200,
+            {
+                'content-type': textPlain,
+            },
+            { 'content-type': textPlain },
+        );
+
+        const response = await subject.sendRequest(
+            new Request(
+                `${origin}/plain-text`,
+                HttpMethod.POST,
+                'PING',
+                {},
+                false,
+                textPlain,
+            ),
+        );
+
+        expect(response.code).toEqual(200);
+        expect(response.payload).toEqual('PONG');
+        expect(scope.isDone()).toBeTruthy();
+    });
+
+    test('parses JSON error bodies as VCLError payloads', async () => {
+        const scope = mockAbsolutePost(
+            `${origin}/errors`,
+            { invalid: true },
+            ErrorMocks.SomeErrorJson,
+            400,
+            {
+                'cache-control': 'public, max-age=86400',
+                'content-type': new RegExp(`^${jsonContentType}`),
+            },
+            { 'content-type': jsonContentType },
+        );
+
+        await expect(
+            subject.sendRequest(
+                new Request(`${origin}/errors`, HttpMethod.POST, {
+                    invalid: true,
+                }),
+            ),
+        ).rejects.toMatchObject({
+            payload: JSON.stringify(ErrorMocks.SomeErrorJson),
+            error: ErrorMocks.SomeErrorJson.error,
+            errorCode: ErrorMocks.SomeErrorJson.errorCode,
+            requestId: ErrorMocks.SomeErrorJson.requestId,
+            message: ErrorMocks.SomeErrorJson.message,
+            statusCode: ErrorMocks.SomeErrorJson.statusCode,
+        });
+        expect(scope.isDone()).toBeTruthy();
+    });
+
+    test('treats plain-text error bodies as human-readable VCLError messages', async () => {
+        const scope = mockAbsoluteGet(
+            `${origin}/internal-error`,
+            'server error',
+            500,
+            {},
+            { 'content-type': textPlain },
+        );
+
+        await expect(
+            subject.sendRequest(
+                new Request(
+                    `${origin}/internal-error`,
+                    HttpMethod.GET,
+                    undefined,
+                ),
+            ),
+        ).rejects.toMatchObject({
+            payload: 'server error',
+            error: null,
+            message: 'server error',
+            statusCode: 500,
+        });
+        expect(scope.isDone()).toBeTruthy();
+    });
+
+    test('propagates errors when no HTTP response is available', async () => {
+        await expect(
+            subject.sendRequest(
+                new Request(`${origin}/unmatched`, HttpMethod.GET, undefined),
+            ),
+        ).rejects.toBeInstanceOf(VCLError);
+    });
+});

--- a/packages/vnf-wallet-sdk-nodejs/test/utils/nock.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/utils/nock.ts
@@ -6,6 +6,7 @@ const PROTOCOL_VERSION_HEADER = 'x-vnf-protocol-version';
 const PROTOCOL_VERSION_VALUE = '1.0';
 
 type HeaderValue = string | RegExp;
+type ReplyHeaders = Record<string, string>;
 
 const withProtocolHeaders = (
     origin: string,
@@ -15,6 +16,19 @@ const withProtocolHeaders = (
         PROTOCOL_VERSION_HEADER,
         PROTOCOL_VERSION_VALUE,
     );
+
+    for (const [key, value] of Object.entries(headers)) {
+        scope = scope.matchHeader(key, value);
+    }
+
+    return scope;
+};
+
+const withHeaders = (
+    origin: string,
+    headers: Record<string, HeaderValue> = {},
+) => {
+    let scope = nock(origin);
 
     for (const [key, value] of Object.entries(headers)) {
         scope = scope.matchHeader(key, value);
@@ -42,10 +56,11 @@ export const mockRegistrarGet = (
     replyBody: unknown,
     statusCode = 200,
     headers: Record<string, HeaderValue> = {},
+    replyHeaders: ReplyHeaders = {},
 ) => {
     return withProtocolHeaders(REGISTRAR_ORIGIN, headers)
         .get(path)
-        .reply(statusCode, replyBody);
+        .reply(statusCode, replyBody, replyHeaders);
 };
 
 export const mockRegistrarPost = (
@@ -54,10 +69,11 @@ export const mockRegistrarPost = (
     replyBody: unknown,
     statusCode = 200,
     headers: Record<string, HeaderValue> = {},
+    replyHeaders: ReplyHeaders = {},
 ) => {
     return withProtocolHeaders(REGISTRAR_ORIGIN, headers)
         .post(path, requestBody)
-        .reply(statusCode, replyBody);
+        .reply(statusCode, replyBody, replyHeaders);
 };
 
 export const mockAbsoluteGet = (
@@ -65,12 +81,13 @@ export const mockAbsoluteGet = (
     replyBody: unknown,
     statusCode = 200,
     headers: Record<string, HeaderValue> = {},
+    replyHeaders: ReplyHeaders = {},
 ) => {
     const { origin, pathname, search } = new URL(requestUrl);
 
-    return withProtocolHeaders(origin, headers)
+    return withHeaders(origin, headers)
         .get(`${pathname}${search}`)
-        .reply(statusCode, replyBody);
+        .reply(statusCode, replyBody, replyHeaders);
 };
 
 export const mockAbsolutePost = (
@@ -79,12 +96,13 @@ export const mockAbsolutePost = (
     replyBody: unknown,
     statusCode = 200,
     headers: Record<string, HeaderValue> = {},
+    replyHeaders: ReplyHeaders = {},
 ) => {
     const { origin, pathname, search } = new URL(requestUrl);
 
-    return withProtocolHeaders(origin, headers)
+    return withHeaders(origin, headers)
         .post(`${pathname}${search}`, requestBody)
-        .reply(statusCode, replyBody);
+        .reply(statusCode, replyBody, replyHeaders);
 };
 
 export const mockResolveDid = (

--- a/packages/vnf-wallet-sdk-nodejs/test/utils/nock.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/utils/nock.ts
@@ -6,7 +6,7 @@ const PROTOCOL_VERSION_HEADER = 'x-vnf-protocol-version';
 const PROTOCOL_VERSION_VALUE = '1.0';
 
 type HeaderValue = string | RegExp;
-type ReplyHeaders = Record<string, string>;
+type ReplyHeaders = Record<string, string | string[] | number>;
 
 const withProtocolHeaders = (
     origin: string,

--- a/packages/vnf-wallet-sdk-nodejs/test/utils/nock.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/utils/nock.ts
@@ -24,19 +24,6 @@ const withProtocolHeaders = (
     return scope;
 };
 
-const withHeaders = (
-    origin: string,
-    headers: Record<string, HeaderValue> = {},
-) => {
-    let scope = nock(origin);
-
-    for (const [key, value] of Object.entries(headers)) {
-        scope = scope.matchHeader(key, value);
-    }
-
-    return scope;
-};
-
 export const useNockLifecycle = () => {
     before(() => {
         nock.disableNetConnect();
@@ -85,7 +72,7 @@ export const mockAbsoluteGet = (
 ) => {
     const { origin, pathname, search } = new URL(requestUrl);
 
-    return withHeaders(origin, headers)
+    return withProtocolHeaders(origin, headers)
         .get(`${pathname}${search}`)
         .reply(statusCode, replyBody, replyHeaders);
 };
@@ -100,7 +87,7 @@ export const mockAbsolutePost = (
 ) => {
     const { origin, pathname, search } = new URL(requestUrl);
 
-    return withHeaders(origin, headers)
+    return withProtocolHeaders(origin, headers)
         .post(`${pathname}${search}`, requestBody)
         .reply(statusCode, replyBody, replyHeaders);
 };


### PR DESCRIPTION
## Summary

Align the NodeJS wallet SDK `VCLError` API with the WalletIOS and WalletAndroid shape by replacing the positional constructor with an object-style constructor and migrating in-package call sites to use explicit fields.

## What Changed

- changed `VCLError` to accept an object argument with `payload`, `error`, `errorCode`, `requestId`, `message`, and `statusCode`
- removed the constructor-side `payload` auto-serialization behavior so `payload` now remains a stored raw payload value instead of a synthesized snapshot
- kept `fromPayloadJson(...)` and `fromError(...)` as specialized factories
- aligned network error handling with the mobile SDK intent: JSON error responses go through `fromPayloadJson(...)`, non-JSON responses become plain `VCLError` instances
- restored protocol-header matching in the absolute-url nock helpers and updated the low-level network tests to provide that header explicitly
- removed the unused `lodash` dependency from `@verii/vnf-nodejs-wallet-sdk`
- removed in-package reliance on positional `new VCLError(...)` calls and converted all current NodeJS wallet SDK call sites to object form
- updated the `VCLError` and network tests to cover the new object-style creation paths and JSON-vs-text error behavior

## Why

The previous NodeJS constructor stored human-readable text outside the standard `message` field when callers passed a single string. It also had confusing `payload` behavior because the constructor synthesized `payload` by serializing the instance while construction was still in progress. The new shape matches the mobile SDKs more closely and makes error construction explicit.

## Validation

- `yarn install`
- `./node_modules/.bin/eslint --fix` on the touched TypeScript files
- `node --enable-source-maps --import=tsx --test --test-reporter=spec test/entities/VCLError.test.ts test/infrastructure/network/NetworkServiceImpl.test.ts`
- `node --enable-source-maps --import=tsx --test --test-reporter=spec test/infrastructure/network/NetworkServiceImpl.test.ts test/usecases/GenerateOffersUseCase.test.ts test/usecases/PresentationRequestUseCase.test.ts test/usecases/AuthTokenUseCase.test.ts test/usecases/CredentialManifestUseCase.test.ts test/usecases/ExchangeProgressUseCase.test.ts test/usecases/SubmissionUseCase.test.ts test/usecases/IdentificationSubmissionUseCase.test.ts test/usecases/FinalizeOffersUseCase.test.ts`
- `yarn workspace @verii/vnf-nodejs-wallet-sdk build`

## Notes

This PR intentionally changes the local NodeJS wallet SDK constructor contract because the library is not believed to have external consumers yet, and aligning with the mobile SDKs now is cheaper than carrying the positional API forward.
