### PR TITLE
[codex] Scope Hardhat serialize-javascript resolution for Dependabot 148

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ yarn test
 yarn lint
 ```
 
+## Security Resolutions
+
+- Prefer the narrowest possible `resolutions` entry for transitive security fixes.
+- Scope overrides to the affected parent chain when feasible, such as `hardhat/mocha/serialize-javascript` for Hardhat-only remediation.
+- Document each temporary resolution in `package.json` with the advisory or alert reference and the condition for removal.
+- Remove the resolution once the upstream dependency path resolves the patched version without the override.
+
 ## Package Publishing
 
 - Package publishing is handled by GitHub Actions via `.github/workflows/publish-packages.workflow.yml`.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "stop": "docker-compose down -v"
   },
   "// lodash-resolution-note": "Temporary: remove these package-specific lodash resolutions once eslint-plugin-better-mutation, ra-data-local-storage, and ra-ui-materialui stop pinning lodash 4.17.x.",
+  "// hardhat-serialize-javascript-resolution-note": "Temporary: remove this hardhat/mocha/serialize-javascript resolution once the Hardhat dependency path no longer resolves serialize-javascript 6.x (Dependabot alert #148 / GHSA-5c6j-r48x-rmvq).",
   "resolutions": {
+    "hardhat/mocha/serialize-javascript": "7.0.3",
     "eslint-plugin-better-mutation/lodash": "^4.18.0",
     "**/ra-data-local-storage/lodash": "^4.18.0",
     "**/ra-ui-materialui/lodash": "^4.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11160,12 +11160,10 @@ semver@^7.3.5, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semve
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
-serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.0.3, serialize-javascript@^6.0.2:
+  version "7.0.3"
+  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz#c92008d8a21bc7b2307c2e885a4bd0f03b2aee6c"
+  integrity sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==
 
 set-cookie-parser@^2.6.0:
   version "2.7.2"


### PR DESCRIPTION
## What changed
- add a Hardhat-scoped Yarn resolution for `hardhat/mocha/serialize-javascript` to pin `serialize-javascript` to `7.0.3`
- document the temporary override in `package.json` with the alert and removal condition
- add a short README section describing the repo policy for narrow transitive security resolutions
- refresh `yarn.lock` so the Hardhat dependency path resolves the patched package

## Why
Dependabot alert #148 flags `serialize-javascript` through the `hardhat -> mocha -> serialize-javascript` path in `yarn.lock`.

This keeps the fix as narrow as possible instead of applying a repo-wide override, which matches the repo's current pattern of using specific `resolutions` when we can.

## Impact
- Hardhat's Mocha path now resolves `serialize-javascript@7.0.3`
- the override is explicitly documented as temporary and removable once upstream no longer resolves `serialize-javascript` 6.x through Hardhat
- the repo now documents how to apply and retire narrow security resolutions

## Validation
- `yarn install`
- `yarn why serialize-javascript`
- `yarn contracts:build:hardhat`