### PR TITLE
[codex] remove sentry profiling integration

### DIFF
--- a/packages/endpoints-credential-types-registrar/src/config.js
+++ b/packages/endpoints-credential-types-registrar/src/config.js
@@ -64,7 +64,6 @@ const createConfig = (packageJson) => {
     version: packageJson.version,
     allowedCorsOrigins: env.get('ALLOWED_CORS_ORIGINS').default('').asArray(),
     sentryDsn: env.get('SENTRY_DSN').required(!isTest).asString(),
-    enableProfiling: env.get('ENABLE_PROFILING').default('false').asBool(),
     enableSentryDebug: env.get('ENABLE_SENTRY_DEBUG').default('false').asBool(),
   };
 

--- a/packages/endpoints-organizations-registrar/src/config/config.js
+++ b/packages/endpoints-organizations-registrar/src/config/config.js
@@ -65,7 +65,6 @@ const createConfig = (packageJson) => {
     mongoSecret: env.get('MONGO_SECRET').required(!isTest).asString(),
     allowedCorsOrigins: env.get('ALLOWED_CORS_ORIGINS').default('').asArray(),
     sentryDsn: env.get('SENTRY_DSN').required(!isTest).asString(),
-    enableProfiling: env.get('ENABLE_PROFILING').default('false').asBool(),
     enableSentryDebug: env.get('ENABLE_SENTRY_DEBUG').default('false').asBool(),
   };
 

--- a/packages/endpoints-organizations-registrar/test/authorization.test.js
+++ b/packages/endpoints-organizations-registrar/test/authorization.test.js
@@ -23,12 +23,6 @@ const mockInitSendError = mock.fn(() =>
     sendError: (err) => {
       console.log(`fake capturing exception: ${err.message}`);
     },
-    startProfiling: () => {
-      console.log('fake start sentry profiling');
-    },
-    finishProfiling: () => {
-      console.log('fake finish sentry profiling');
-    },
   }),
 );
 

--- a/packages/endpoints-organizations-registrar/test/organization-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/organization-controller.test.js
@@ -30,12 +30,6 @@ const mockInitSendError = mock.fn(() =>
     sendError: (err) => {
       console.log(`fake capturing exception: ${err.message}`);
     },
-    startProfiling: () => {
-      console.log('fake start sentry profiling');
-    },
-    finishProfiling: () => {
-      console.log('fake finish sentry profiling');
-    },
   }),
 );
 

--- a/packages/endpoints-organizations-registrar/test/organization-did-invitations.test.js
+++ b/packages/endpoints-organizations-registrar/test/organization-did-invitations.test.js
@@ -22,12 +22,6 @@ const mockSendError = mock.fn(() => undefined);
 const mockInitSendError = mock.fn(() =>
   Promise.resolve({
     sendError: mockSendError,
-    startProfiling: () => {
-      console.log('fake start sentry profiling');
-    },
-    finishProfiling: () => {
-      console.log('fake finish sentry profiling');
-    },
   }),
 );
 
@@ -95,7 +89,6 @@ const {
   testRegistrarSuperUser,
   errorResponseMatcher,
 } = require('@verii/tests-helpers');
-const console = require('console');
 const { NANO_ID_FORMAT } = require('@verii/test-regexes/src/regexes');
 const buildFastify = require('./helpers/build-fastify');
 const { expectedInvitationSentEmail } = require('./helpers/email-matchers');

--- a/packages/endpoints-organizations-registrar/test/organization-keys-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/organization-keys-controller.test.js
@@ -23,12 +23,6 @@ const mockInitSendError = mock.fn(() =>
     sendError: (err) => {
       console.log(`fake capturing exception: ${err.message}`);
     },
-    startProfiling: () => {
-      console.log('fake start sentry profiling');
-    },
-    finishProfiling: () => {
-      console.log('fake finish sentry profiling');
-    },
   }),
 );
 

--- a/packages/endpoints-organizations-registrar/test/organization-services-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/organization-services-controller.test.js
@@ -24,12 +24,6 @@ const mockSendError = mock.fn(() => {
 const mockInitSendError = mock.fn(() =>
   Promise.resolve({
     sendError: mockSendError,
-    startProfiling: () => {
-      console.log('fake start sentry profiling');
-    },
-    finishProfiling: () => {
-      console.log('fake finish sentry profiling');
-    },
   }),
 );
 mock.module('@verii/error-aggregation', {

--- a/packages/endpoints-organizations-registrar/test/organizations-full-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/organizations-full-controller.test.js
@@ -23,12 +23,6 @@ const mockSendError = mock.fn(() => {
 const mockInitSendError = mock.fn(() =>
   Promise.resolve({
     sendError: mockSendError,
-    startProfiling: () => {
-      console.log('fake start sentry profiling');
-    },
-    finishProfiling: () => {
-      console.log('fake finish sentry profiling');
-    },
   }),
 );
 

--- a/packages/error-aggregation/package.json
+++ b/packages/error-aggregation/package.json
@@ -19,9 +19,6 @@
   "dependencies": {
     "@sentry/node": "^8.0.0"
   },
-  "optionalDependencies": {
-    "@sentry/profiling-node": "^8.0.0"
-  },
   "devDependencies": {
     "eslint": "9.39.4",
     "eslint-config-airbnb-extended": "3.0.1",

--- a/packages/error-aggregation/src/sentry.js
+++ b/packages/error-aggregation/src/sentry.js
@@ -14,62 +14,25 @@
  * limitations under the License.
  */
 
-const buildProfilingOptions = (enableProfiling) => {
-  if (process.env.NODE_ENV != null && enableProfiling) {
-    const { nodeProfilingIntegration } = require('@sentry/profiling-node');
-    return {
-      tracesSampleRate: 1.0,
-      profilesSampleRate: 1.0,
-      integrations: [nodeProfilingIntegration()],
-    };
-  }
-  return {
-    integrations: [],
-  };
-};
-const initSentry = async ({
-  dsn,
-  enableProfiling,
-  release,
-  environment,
-  debug,
-}) => {
+const initSentry = async ({ dsn, release, environment, debug }) => {
   const Sentry = await import('@sentry/node');
 
   Sentry.init({
     dsn,
-    ...buildProfilingOptions(enableProfiling),
     release,
     environment,
     debug,
   });
   return Sentry;
 };
-
-const initStartProfiling = (sentry, enableProfiling) =>
-  enableProfiling ? sentry.startTransaction : () => undefined;
-
-const finishProfiling = (transaction) => {
-  if (transaction) {
-    transaction.finish();
-  }
-};
-
 const initSendError = async ({
   dsn,
-  enableProfiling,
   release,
   environment,
   debug = false,
 } = {}) => {
   if (dsn) {
-    const sentry = await initSentry({
-      dsn,
-      enableProfiling,
-      release,
-      environment,
-      debug,
-    });
+    const sentry = await initSentry({ dsn, release, environment, debug });
     return {
       sendError: (error) => {
         const code = error?.status || error?.statusCode;
@@ -78,14 +41,10 @@ const initSendError = async ({
         }
         sentry.captureException(error);
       },
-      startProfiling: initStartProfiling(sentry, enableProfiling),
-      finishProfiling,
     };
   }
   return {
     sendError: () => {},
-    startProfiling: () => {},
-    finishProfiling: () => {},
   };
 };
 

--- a/packages/error-aggregation/test/sentry.test.js
+++ b/packages/error-aggregation/test/sentry.test.js
@@ -19,14 +19,11 @@ const { expect } = require('expect');
 
 const mockSentryInit = mock.fn();
 const mockSentryCaptureException = mock.fn();
-const mockSentryStartTransaction = mock.fn();
-const mockFinishTransaction = mock.fn();
 
 mock.module('@sentry/node', {
   namedExports: {
     init: mockSentryInit,
     captureException: mockSentryCaptureException,
-    startTransaction: mockSentryStartTransaction,
   },
 });
 
@@ -36,29 +33,22 @@ describe('Sentry test suite', () => {
   beforeEach(() => {
     mockSentryInit.mock.resetCalls();
     mockSentryCaptureException.mock.resetCalls();
-    mockSentryStartTransaction.mock.resetCalls();
-    mockFinishTransaction.mock.resetCalls();
   });
 
   after(() => {
     mock.reset();
   });
 
-  it('should initialize sentry with captureException and startTransaction when dsn is provided and profiling is enabled', async () => {
-    const { sendError, startProfiling } = await initSendError({
+  it('should initialize sentry with captureException when dsn is provided', async () => {
+    const { sendError } = await initSendError({
       dsn: 'test',
-      enableProfiling: true,
     });
     const mockError = new Error('mock');
     sendError(mockError);
-    startProfiling();
     expect(mockSentryInit.mock.callCount()).toEqual(1);
     expect(mockSentryInit.mock.calls[0].arguments).toEqual([
       {
         dsn: 'test',
-        tracesSampleRate: 1.0,
-        profilesSampleRate: 1.0,
-        integrations: [expect.any(Object)],
         debug: expect.any(Boolean),
       },
     ]);
@@ -66,67 +56,14 @@ describe('Sentry test suite', () => {
     expect(mockSentryCaptureException.mock.calls[0].arguments).toEqual([
       mockError,
     ]);
-    expect(mockSentryStartTransaction.mock.callCount()).toEqual(1);
-    expect(mockSentryStartTransaction.mock.calls[0].arguments).toEqual([]);
   });
 
-  it('should initialize sentry with captureException and without startTransaction when dsn is provided and profiling is disabled', async () => {
-    const { sendError, startProfiling } = await initSendError({
-      dsn: 'test',
-    });
+  it('await initSendError should not initialize sentry and return a no-op sender when dsn is not provided', async () => {
+    const { sendError } = await initSendError();
     const mockError = new Error('mock');
     sendError(mockError);
-    startProfiling();
-    expect(mockSentryInit.mock.callCount()).toEqual(1);
-    expect(mockSentryInit.mock.calls[0].arguments).toEqual([
-      {
-        dsn: 'test',
-        integrations: [],
-        debug: expect.any(Boolean),
-      },
-    ]);
-    expect(mockSentryCaptureException.mock.callCount()).toEqual(1);
-    expect(mockSentryCaptureException.mock.calls[0].arguments).toEqual([
-      mockError,
-    ]);
-    expect(mockSentryStartTransaction.mock.callCount()).toEqual(0);
-  });
-
-  it('await initSendError should not initialize sentry and return no-op functions when dsn is not provided', async () => {
-    const { sendError, startProfiling } = await initSendError();
-    const mockError = new Error('mock');
-    sendError(mockError);
-    startProfiling();
     expect(mockSentryInit.mock.callCount()).toEqual(0);
     expect(mockSentryCaptureException.mock.callCount()).toEqual(0);
-    expect(mockSentryStartTransaction.mock.callCount()).toEqual(0);
-  });
-
-  it('finishProfiling should no-op when nothing passed to it', async () => {
-    const { finishProfiling } = await initSendError();
-    finishProfiling();
-    expect(mockFinishTransaction.mock.callCount()).toEqual(0);
-  });
-
-  it('finishProfiling should call finish function when transaction is passed', async () => {
-    const { finishProfiling } = await initSendError({ dsn: 'test' });
-    const finishableTransaction = {
-      finish: mockFinishTransaction,
-    };
-    finishProfiling(finishableTransaction);
-    expect(mockFinishTransaction.mock.callCount()).toEqual(1);
-  });
-
-  it('finishProfiling should no-op transaction is not passed', async () => {
-    const { finishProfiling } = await initSendError({ dsn: 'test' });
-    finishProfiling();
-    expect(mockFinishTransaction.mock.callCount()).toEqual(0);
-  });
-
-  it('finishProfiling should no-op if dsn is not passed', async () => {
-    const { finishProfiling } = await initSendError();
-    finishProfiling();
-    expect(mockFinishTransaction.mock.callCount()).toEqual(0);
   });
 
   it('sendError should skip 4xx errors', async () => {

--- a/packages/fastify-plugins/src/send-error-plugin.js
+++ b/packages/fastify-plugins/src/send-error-plugin.js
@@ -19,11 +19,10 @@ const fp = require('fastify-plugin');
 
 const sendErrorPlugin = async (fastify) => {
   const {
-    config: { sentryDsn, enableProfiling, enableSentryDebug, nodeEnv, version },
+    config: { sentryDsn, enableSentryDebug, nodeEnv, version },
   } = fastify;
-  const { sendError, startProfiling, finishProfiling } = await initSendError({
+  const { sendError } = await initSendError({
     dsn: sentryDsn,
-    enableProfiling,
     release: version,
     environment: nodeEnv,
     debug: enableSentryDebug,
@@ -32,19 +31,6 @@ const sendErrorPlugin = async (fastify) => {
   fastify.decorateRequest('sendError', null);
   fastify.addHook('preHandler', async (req) => {
     req.sendError = sendError;
-  });
-  fastify.decorate('startProfiling', startProfiling);
-  fastify.decorate('finishProfiling', finishProfiling);
-  fastify.decorateRequest('profilingContext', null);
-  fastify.addHook('onRequest', async (req) => {
-    req.profilingContext = req.server.startProfiling({
-      name: req.routeOptions.url,
-      op: req.routeOptions.method,
-      url: req.url,
-    });
-  });
-  fastify.addHook('onResponse', async (req) => {
-    req.server.finishProfiling(req.profilingContext);
   });
 };
 

--- a/packages/fastify-plugins/test/send-error-plugin.test.js
+++ b/packages/fastify-plugins/test/send-error-plugin.test.js
@@ -19,8 +19,6 @@ const { expect } = require('expect');
 const initSendError = mock.fn(() =>
   Promise.resolve({
     sendError: 'sendErrorFn',
-    startProfiling: 'startProfilingFn',
-    finishProfiling: 'finishProfilingFn',
   }),
 );
 mock.module('@verii/error-aggregation', {
@@ -55,7 +53,6 @@ describe('Capture Exception to Sentry plugin tests', () => {
       [
         {
           dsn: 'testDsn',
-          enableProfiling: undefined,
           environment: 'testEnv',
           release: 'testVersion',
         },
@@ -63,23 +60,12 @@ describe('Capture Exception to Sentry plugin tests', () => {
     ]);
     expect(
       fakeServer.decorate.mock.calls.map((call) => call.arguments),
-    ).toEqual([
-      ['sendError', 'sendErrorFn'],
-      ['startProfiling', 'startProfilingFn'],
-      ['finishProfiling', 'finishProfilingFn'],
-    ]);
+    ).toEqual([['sendError', 'sendErrorFn']]);
     expect(
       fakeServer.decorateRequest.mock.calls.map((call) => call.arguments),
-    ).toEqual([
-      ['sendError', null],
-      ['profilingContext', null],
-    ]);
+    ).toEqual([['sendError', null]]);
     expect(fakeServer.addHook.mock.calls.map((call) => call.arguments)).toEqual(
-      [
-        ['preHandler', expect.any(Function)],
-        ['onRequest', expect.any(Function)],
-        ['onResponse', expect.any(Function)],
-      ],
+      [['preHandler', expect.any(Function)]],
     );
   });
 });

--- a/servers/credentialagent/src/config/core-config.js
+++ b/servers/credentialagent/src/config/core-config.js
@@ -93,7 +93,6 @@ const coreConfig = {
   caoDid: env.get('CAO_DID').required(!isTest).asString(),
   validateCaoDid: env.get('VALIDATE_CAO_DID').default('true').asBool(),
   sentryDsn: env.get('SENTRY_DSN').default('').asString(),
-  enableProfiling: env.get('ENABLE_PROFILING').default('false').asBool(),
   enableSentryDebug: env.get('ENABLE_SENTRY_DEBUG').default('false').asBool(),
   deepLinkProtocol: env.get('DEEP_LINK_PROTOCOL').required().asString(),
   oidcTokensExpireIn: env.get('OIDC_TOKENS_EXPIRE_IN').default(600).asInt(),

--- a/servers/mockvendor/src/config/config.js
+++ b/servers/mockvendor/src/config/config.js
@@ -40,7 +40,6 @@ module.exports = {
     http2: false,
   },
   sentryDsn: env.get('SENTRY_DSN').required(!isTest).asString(),
-  enableProfiling: env.get('ENABLE_PROFILING').default('false').asBool(),
   enableSentryDebug: env.get('ENABLE_SENTRY_DEBUG').default('false').asBool(),
   omitOfferId: env.get('OMIT_OFFER_ID').default('false').asBool(),
   noOffers200: env.get('NO_OFFERS_200').default('true').asBool(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3461,7 +3461,22 @@
     "@sentry/types" "5.30.0"
     tslib "^1.9.3"
 
-"@sentry/node@8.55.1", "@sentry/node@^8.0.0":
+"@sentry/node@^5.18.1":
+  version "5.30.0"
+  resolved "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz#4ca479e799b1021285d7fe12ac0858951c11cd48"
+  integrity sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==
+  dependencies:
+    "@sentry/core" "5.30.0"
+    "@sentry/hub" "5.30.0"
+    "@sentry/tracing" "5.30.0"
+    "@sentry/types" "5.30.0"
+    "@sentry/utils" "5.30.0"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/node@^8.0.0":
   version "8.55.1"
   resolved "https://registry.npmjs.org/@sentry/node/-/node-8.55.1.tgz#b8632018c12e5c3e74e6904336f2abdc9c3a95cc"
   integrity sha512-s8ydn/OxZFIxc9Fvt23gJkrXkCvPnUu2bDKwjQBCx0M1b4DdNdp4FaimT6B9reya7buj+tsNkZAoT11KqFhG/g==
@@ -3502,37 +3517,12 @@
     "@sentry/opentelemetry" "8.55.1"
     import-in-the-middle "^1.11.2"
 
-"@sentry/node@^5.18.1":
-  version "5.30.0"
-  resolved "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz#4ca479e799b1021285d7fe12ac0858951c11cd48"
-  integrity sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==
-  dependencies:
-    "@sentry/core" "5.30.0"
-    "@sentry/hub" "5.30.0"
-    "@sentry/tracing" "5.30.0"
-    "@sentry/types" "5.30.0"
-    "@sentry/utils" "5.30.0"
-    cookie "^0.4.1"
-    https-proxy-agent "^5.0.0"
-    lru_map "^0.3.3"
-    tslib "^1.9.3"
-
 "@sentry/opentelemetry@8.55.1":
   version "8.55.1"
   resolved "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.55.1.tgz#bf066af16f2dfbd5d6c38e37271ec5ab47e88341"
   integrity sha512-ipiM/k3Hzt8visoBfkDb4AQBWHkJeou3SjoPec7NlDabH/Jj8x6VlK5Hex4z+WOv99rRy+5MUtga/CZnOjvh0A==
   dependencies:
     "@sentry/core" "8.55.1"
-
-"@sentry/profiling-node@^8.0.0":
-  version "8.55.1"
-  resolved "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-8.55.1.tgz#b3ea7dd5290e270b76be67d49df8a4dda2dce961"
-  integrity sha512-kPkSloBynqQ3bjPc+QtMlb/DVXL+u5rqkhuJ9BWkpLbdsWtmqu2DpY50VumeFmPC+dKuUUK+dhh4vDARdqISoQ==
-  dependencies:
-    "@sentry/core" "8.55.1"
-    "@sentry/node" "8.55.1"
-    detect-libc "^2.0.2"
-    node-abi "^3.61.0"
 
 "@sentry/tracing@5.30.0":
   version "5.30.0"
@@ -6388,7 +6378,7 @@ detect-file@^1.0.0:
   resolved "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==
 
-detect-libc@^2.0.2, detect-libc@^2.0.3:
+detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
@@ -9745,13 +9735,6 @@ nock@15.0.0-beta.10:
   dependencies:
     "@mswjs/interceptors" "^0.41.2"
 
-node-abi@^3.61.0:
-  version "3.89.0"
-  resolved "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz#eea98bf89d4534743bbbf2defa9f4f9bd3bdccfd"
-  integrity sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==
-  dependencies:
-    semver "^7.3.5"
-
 node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
@@ -11155,7 +11138,7 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3, semver@^7.7.1, semver@^7.7.2, semver@^7.7.3, semver@^7.7.4:
+semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3, semver@^7.7.1, semver@^7.7.2, semver@^7.7.3, semver@^7.7.4:
   version "7.7.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==


### PR DESCRIPTION
## Summary
- remove the Sentry profiling integration from `@verii/error-aggregation`
- stop exposing profiling hooks from the Fastify error plugin
- remove the dead `ENABLE_PROFILING` config surface and update related tests

## Why
Profiling is no longer functioning in this codepath, so leaving the integration and config toggle in place creates dead behavior and extra dependency surface.

## Root Cause
The repo still carried a Node profiling setup built around `@sentry/profiling-node` and Fastify request lifecycle hooks even though profiling was not actually producing useful results anymore.

## Impact
- runtime error reporting via Sentry remains intact
- the broken profiling path and dependency are removed
- services no longer advertise an `ENABLE_PROFILING` setting that does nothing useful

## Validation
- `yarn install`
- `./node_modules/.bin/eslint --fix packages/error-aggregation/src/sentry.js packages/error-aggregation/test/sentry.test.js packages/fastify-plugins/src/send-error-plugin.js packages/fastify-plugins/test/send-error-plugin.test.js servers/mockvendor/src/config/config.js packages/endpoints-organizations-registrar/src/config/config.js servers/credentialagent/src/config/core-config.js packages/endpoints-credential-types-registrar/src/config.js packages/endpoints-organizations-registrar/test/authorization.test.js packages/endpoints-organizations-registrar/test/organization-controller.test.js packages/endpoints-organizations-registrar/test/organization-did-invitations.test.js packages/endpoints-organizations-registrar/test/organization-keys-controller.test.js packages/endpoints-organizations-registrar/test/organization-services-controller.test.js packages/endpoints-organizations-registrar/test/organizations-full-controller.test.js`
- `NODE_ENV=test node --test --test-concurrency=1 --experimental-test-module-mocks --test-reporter=spec packages/error-aggregation/test/sentry.test.js`
- `NODE_ENV=test node --test --test-concurrency=1 --experimental-test-module-mocks --test-reporter=spec packages/fastify-plugins/test/send-error-plugin.test.js`
- `NODE_ENV=test node --test --test-concurrency=1 --test-timeout=900000 --experimental-test-module-mocks --test-reporter=spec packages/endpoints-organizations-registrar/test/authorization.test.js packages/endpoints-organizations-registrar/test/organization-controller.test.js packages/endpoints-organizations-registrar/test/organization-did-invitations.test.js packages/endpoints-organizations-registrar/test/organization-keys-controller.test.js packages/endpoints-organizations-registrar/test/organization-services-controller.test.js packages/endpoints-organizations-registrar/test/organizations-full-controller.test.js`