### PR TITLE
[codex] migrate commit hooks from husky v4 to husky v9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+repo_root=$(cd -- "$(dirname "$0")/.." && pwd)
+
+exec "$repo_root/node_modules/.bin/commitlint" --edit "$1"

--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,20 @@
+const main = async () => {
+  if (
+    process.env.NODE_ENV === 'production' ||
+    process.env.CI ||
+    process.env.IS_CI
+  ) {
+    process.exit(0);
+  }
+
+  // Husky is intentionally a devDependency; this wrapper skips importing it in CI/production.
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  const husky = (await import('husky')).default;
+
+  process.stdout.write(`${husky()}\n`);
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,26 +1,6 @@
-const isEnabledEnvFlag = (value) =>
-  value === '1' || value?.toLowerCase() === 'true';
-
-const omitIncludesDevDependency = (value) =>
-  value
-    ?.split(',')
-    .map((entry) => entry.trim())
-    .includes('dev') ?? false;
-
-const shouldSkipInstall = () =>
-  process.env.NODE_ENV === 'production' ||
-  isEnabledEnvFlag(process.env.CI) ||
-  isEnabledEnvFlag(process.env.IS_CI) ||
-  isEnabledEnvFlag(process.env.npm_config_production) ||
-  omitIncludesDevDependency(process.env.npm_config_omit);
-
 const main = async () => {
-  if (shouldSkipInstall()) {
-    process.exit(0);
-  }
-
   try {
-    // Husky is intentionally a devDependency; this wrapper skips importing it in CI/production.
+    // Husky is intentionally a devDependency; skip install when it is absent.
     // eslint-disable-next-line import/no-extraneous-dependencies
     const husky = (await import('husky')).default;
 

--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,17 +1,37 @@
+const isEnabledEnvFlag = (value) =>
+  value === '1' || value?.toLowerCase() === 'true';
+
+const omitIncludesDevDependency = (value) =>
+  value
+    ?.split(',')
+    .map((entry) => entry.trim())
+    .includes('dev') ?? false;
+
+const shouldSkipInstall = () =>
+  process.env.NODE_ENV === 'production' ||
+  isEnabledEnvFlag(process.env.CI) ||
+  isEnabledEnvFlag(process.env.IS_CI) ||
+  isEnabledEnvFlag(process.env.npm_config_production) ||
+  omitIncludesDevDependency(process.env.npm_config_omit);
+
 const main = async () => {
-  if (
-    process.env.NODE_ENV === 'production' ||
-    process.env.CI ||
-    process.env.IS_CI
-  ) {
+  if (shouldSkipInstall()) {
     process.exit(0);
   }
 
-  // Husky is intentionally a devDependency; this wrapper skips importing it in CI/production.
-  // eslint-disable-next-line import/no-extraneous-dependencies
-  const husky = (await import('husky')).default;
+  try {
+    // Husky is intentionally a devDependency; this wrapper skips importing it in CI/production.
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    const husky = (await import('husky')).default;
 
-  process.stdout.write(`${husky()}\n`);
+    process.stdout.write(`${husky()}\n`);
+  } catch (error) {
+    if (error?.code === 'ERR_MODULE_NOT_FOUND') {
+      process.exit(0);
+    }
+
+    throw error;
+  }
 };
 
 main().catch((error) => {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "contracts:test:post-upgrade": "pnpm run contracts:assert-target-env && pnpm --filter @verii/permissions-contract run test:post-upgrade && pnpm --filter @verii/verification-coupon-contract run test:post-upgrade && pnpm --filter @verii/metadata-registry-contract run test:post-upgrade && pnpm --filter @verii/revocation-list-contract run test:post-upgrade",
     "check-packages": "pnpm run clean && pnpm run compile && pnpm run test && pnpm run lint",
     "check-licenses": "pnpm licenses list --prod --json | node ./check-license.js",
+    "prepare": "husky",
     "start": "docker-compose up",
     "start:rebuild": "docker-compose up --build",
     "stop": "docker-compose down -v"
@@ -73,7 +74,7 @@
     "eslint-plugin-prettier": "5.5.5",
     "globals": "17.5.0",
     "hardhat": "2.28.6",
-    "husky": "4.3.8",
+    "husky": "9.1.7",
     "lodash-es": "4.18.1",
     "nx": "22.6.5",
     "typescript": "5.9.3",
@@ -86,11 +87,6 @@
     "tools/*",
     "samples/*"
   ],
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E  HUSKY_GIT_PARAMS"
-    }
-  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "contracts:test:post-upgrade": "pnpm run contracts:assert-target-env && pnpm --filter @verii/permissions-contract run test:post-upgrade && pnpm --filter @verii/verification-coupon-contract run test:post-upgrade && pnpm --filter @verii/metadata-registry-contract run test:post-upgrade && pnpm --filter @verii/revocation-list-contract run test:post-upgrade",
     "check-packages": "pnpm run clean && pnpm run compile && pnpm run test && pnpm run lint",
     "check-licenses": "pnpm licenses list --prod --json | node ./check-license.js",
-    "prepare": "husky",
+    "prepare": "node .husky/install.mjs",
     "start": "docker-compose up",
     "start:rebuild": "docker-compose up --build",
     "stop": "docker-compose down -v"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: 2.28.6
         version: 2.28.6(typescript@5.9.3)
       husky:
-        specifier: 4.3.8
-        version: 4.3.8
+        specifier: 9.1.7
+        version: 9.1.7
       lodash-es:
         specifier: 4.18.1
         version: 4.18.1
@@ -7357,9 +7357,6 @@ packages:
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
-  compare-versions@3.6.0:
-    resolution: {integrity: sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==}
-
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
@@ -8220,10 +8217,6 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  find-versions@4.0.0:
-    resolution: {integrity: sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==}
-    engines: {node: '>=10'}
-
   findup-sync@5.0.0:
     resolution: {integrity: sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==}
     engines: {node: '>= 10.13.0'}
@@ -8527,9 +8520,9 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
-  husky@4.3.8:
-    resolution: {integrity: sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==}
-    engines: {node: '>=10'}
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   hyphen@1.14.1:
@@ -9567,10 +9560,6 @@ packages:
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
-  opencollective-postinstall@2.0.3:
-    resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
-    hasBin: true
-
   openid-client@6.8.2:
     resolution: {integrity: sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==}
 
@@ -9717,10 +9706,6 @@ packages:
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
-
-  pkg-dir@5.0.0:
-    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
-    engines: {node: '>=10'}
 
   please-upgrade-node@3.2.0:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
@@ -10180,10 +10165,6 @@ packages:
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
-
-  semver-regex@3.1.4:
-    resolution: {integrity: sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==}
-    engines: {node: '>=8'}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -10878,10 +10859,6 @@ packages:
   which-collection@1.0.2:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
-
-  which-pm-runs@1.1.0:
-    resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
-    engines: {node: '>=4'}
 
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
@@ -15639,8 +15616,6 @@ snapshots:
       array-ify: 1.0.0
       dot-prop: 5.3.0
 
-  compare-versions@3.6.0: {}
-
   compare-versions@6.1.1: {}
 
   concat-map@0.0.1: {}
@@ -16823,10 +16798,6 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  find-versions@4.0.0:
-    dependencies:
-      semver-regex: 3.1.4
-
   findup-sync@5.0.0:
     dependencies:
       detect-file: 1.0.0
@@ -17202,18 +17173,7 @@ snapshots:
 
   human-signals@2.1.0: {}
 
-  husky@4.3.8:
-    dependencies:
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      compare-versions: 3.6.0
-      cosmiconfig: 7.1.0
-      find-versions: 4.0.0
-      opencollective-postinstall: 2.0.3
-      pkg-dir: 5.0.0
-      please-upgrade-node: 3.2.0
-      slash: 3.0.0
-      which-pm-runs: 1.1.0
+  husky@9.1.7: {}
 
   hyphen@1.14.1: {}
 
@@ -18245,8 +18205,6 @@ snapshots:
 
   openapi-types@12.1.3: {}
 
-  opencollective-postinstall@2.0.3: {}
-
   openid-client@6.8.2:
     dependencies:
       jose: 6.1.3
@@ -18441,10 +18399,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
-
-  pkg-dir@5.0.0:
-    dependencies:
-      find-up: 5.0.0
 
   please-upgrade-node@3.2.0:
     dependencies:
@@ -19000,8 +18954,6 @@ snapshots:
   secure-json-parse@4.1.0: {}
 
   semver-compare@1.0.0: {}
-
-  semver-regex@3.1.4: {}
 
   semver@5.7.2: {}
 
@@ -19735,8 +19687,6 @@ snapshots:
       is-set: 2.0.3
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
-
-  which-pm-runs@1.1.0: {}
 
   which-typed-array@1.1.20:
     dependencies:


### PR DESCRIPTION
## What changed
- removed the old Husky v4 root dependency/config that was still driving commit hooks through the legacy shim path
- added Husky `9.1.7` as the root dev dependency and wired the root `prepare` script through `.husky/install.mjs`
- added `.husky/install.mjs` so CI/production installs skip Husky setup when devDependencies are not present
- moved the `commit-msg` hook to `.husky/commit-msg`
- made the `commit-msg` hook invoke the repo-local `commitlint` binary directly instead of depending on `yarn`
- updated `pnpm-lock.yaml` for the Husky migration

## Why
The repo was still relying on the old Husky v4 flow, which no longer matched the current package-manager/tooling setup. Migrating to current Husky keeps commit message linting in place while delegating hook installation back to a maintained tool instead of growing a custom installer.

## Impact
- contributors still get local commit message linting
- hook installation is handled by current Husky instead of repo-specific `core.hooksPath` setup logic
- the `commit-msg` hook no longer depends on `yarn`, so it remains compatible as the repo moves to pnpm
- CI and production-only installs no longer fail when Husky isn't installed as a devDependency

## Validation
- `pnpm install`
- `CI=1 pnpm run prepare`
- `CI=true pnpm run prepare`
- `IS_CI=1 pnpm run prepare`
- `NODE_ENV=production pnpm run prepare`
- `git config core.hooksPath` returns `.husky/_`
- `.husky/commit-msg <valid-message-file>` passes for a conventional commit message
- `.husky/commit-msg <invalid-message-file>` fails for a non-conventional commit message
