### PR TITLE
docs(agents): reserve main worktree for main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,6 @@
 ## New Worktree policy
+- Keep `/Users/andresolave/Projects/velocity/verii` checked out on `main` as the primary worktree.
+- Do not switch this worktree to feature branches. Create a new sibling worktree for any non-`main` branch work.
 - Default Base branch: `origin/main`
 - If user specifies target branch use `origin/<target-branch>`.
 - Use branch names prefixed with `codex/` and place them in the parent directory.


### PR DESCRIPTION
## Summary
- document that `/Users/andresolave/Projects/velocity/verii` should remain the primary `main` worktree
- document that non-`main` work should use sibling worktrees instead of switching this checkout

## Testing
- not run (documentation-only change)
