### PR TITLE
docs(release): add 1.1.0 release notes

### DIFF
--- a/.github/releases/v1.1.0.md
+++ b/.github/releases/v1.1.0.md
@@ -1,0 +1,51 @@
+# Verii v1.1.0
+
+This release notes draft was prepared from a cherry-pick-aware comparison between `release/v1.0.x` and `release/1.1.x`, so backports that landed on both lines are intentionally not repeated here just because they have different SHAs.
+
+## Changes
+
+### [#351](https://github.com/LFDT-Verii/core/pull/351) Contracts migration and upgrade tooling modernization
+- Added a Hardhat-based deployment and upgrade stack alongside post-upgrade smoke coverage for the metadata, permissions, revocation-list, and verification-coupon contracts.
+- Landed the combined OpenZeppelin 5 upgrade work for contracts and restored the SPDX / Solidity 0.8.20 contract baseline.
+- Added contract-targeted CI gating and supporting deployment utilities and runbooks to make contract changes safer to ship.
+
+### [#485](https://github.com/LFDT-Verii/core/pull/485) Issuing and presentation handling hardening
+- Switched credential issuing challenges to a stateless flow in `credentialagent`.
+- Expanded presentation handling to accept additional presentation contexts, include VP context in submissions, and allow `kid` to override `jwk` in `jwt_vp`.
+- Improved wallet / verifier interoperability by accepting mixed DID aliases and tightening presentation-related error handling.
+
+### [#227](https://github.com/LFDT-Verii/core/pull/227) Wallet and provider flow improvements
+- Added the one-provider flow and related wallet SDK behavior updates.
+- Made the ID content hash optional where required and fixed matching for single-credential Velocity DIDs.
+- Included expired VC handling fixes plus work permit and sample app corrections that landed on the `1.1` line.
+
+### [#324](https://github.com/LFDT-Verii/core/pull/324) Nonce management and blockchain transaction resilience
+- Prevented nonce reuse in shared signer clients and added retries for nonce conflicts during gas estimation.
+- Added a resyncing nonce manager, sequential queue coverage, and targeted tests around contract transaction coordination.
+- Updated related blockchain client dependencies, including ethers and supporting contract-IO packages.
+
+### [#380](https://github.com/LFDT-Verii/core/pull/380) Registrar and service packaging cleanup
+- Declared dependencies that had previously been masked by Yarn hoisting in the organizations registrar package.
+- Kept test factories out of published registrar output and cleaned up local-only artifacts handling in the repo.
+- Removed the Sentry profiling integration that was no longer wanted in this line.
+
+### [#277](https://github.com/LFDT-Verii/core/pull/277) CI, publishing, and release process overhaul
+- Moved package publishing to npm trusted publishing and hardened the package publish workflow.
+- Added shared dependency caching, improved JUnit / LCOV reporting, refreshed artifact actions, and simplified code coverage publishing.
+- Codified the new `VERSION` + `release/X.Y.x` release process with checked-in release notes, release branch validation, and the main-worktree policy.
+
+### [#429](https://github.com/LFDT-Verii/core/pull/429) Platform, runtime, and security dependency refresh
+- Upgraded major platform dependencies across the repo, including Auth0 v5, MongoDB v7, Fastify 5.8.x, Vite 8, React Router 7.13.x, Nx 22.6.5, AWS SDK v3.999, and the Spence package set v1.
+- Pulled in security-driven updates for dependencies such as axios, qs, ajv, serialize-javascript, lodash, nanoid, tar, dompurify, immutable, handlebars, and multiple Fastify packages.
+- Refreshed Node and tooling references through the repo, including the Node 24 line used by current CI and development workflows.
+
+### [#498](https://github.com/LFDT-Verii/core/pull/498) Test infrastructure and mock modernization
+- Migrated wallet SDK network service mocks to `nock` and expanded test coverage around request/response behavior.
+- Added broader CI-side test reporting and cleanup improvements, including runner cleanup and generated artifact handling.
+- Continued the repo-wide movement to modernized lint/test configuration, including ESLint flat-config adoption across more packages and samples.
+
+## Backward incompatibilities
+
+- Repository release operations now follow the `VERSION` + `.github/releases/vX.Y.Z.md` + `release/X.Y.x` model. Maintainers should not continue using the older `release/v1.0.x` naming convention for new release lines.
+- Contract deployment and upgrade workflows now center on the Hardhat migration stack. Teams with local automation built around the older Truffle-first flow should validate and update those scripts before adopting the `1.1.x` line.
+- This line includes multiple major dependency upgrades across application, SDK, and tooling surfaces, including Auth0 v5, MongoDB v7, Fastify 5, Vite 8, React Router 7.13.x, UUID 13, Commander 14, and Spence v1 packages. Downstream consumers and operators should validate any local integrations that depend on previous major-version behavior.

--- a/.github/releases/v1.1.0.md
+++ b/.github/releases/v1.1.0.md
@@ -1,6 +1,6 @@
 # Verii v1.1.0
 
-This release notes draft was prepared from a cherry-pick-aware comparison between `release/v1.0.x` and `release/1.1.x`, so backports that landed on both lines are intentionally not repeated here just because they have different SHAs.
+These release notes were prepared from a cherry-pick-aware comparison between `release/v1.0.x` and `release/1.1.x`, so backports that landed on both lines are intentionally not repeated here just because they have different SHAs.
 
 ## Changes
 


### PR DESCRIPTION
## Summary
- add `.github/releases/v1.1.0.md` for the `1.1.0` release line
- summarize the `1.1.0` line from a cherry-pick-aware comparison against `release/v1.0.x`
- avoid repeating equivalent fixes that landed on both lines under different SHAs

## Testing
- `./.github/scripts/validate-release-notes.sh .github/releases/v1.1.0.md`
