### PR TITLE
[codex] Switch Docker compose flows to pnpm

### DIFF
--- a/eng/docker/Dockerfile-NodeE2E
+++ b/eng/docker/Dockerfile-NodeE2E
@@ -15,9 +15,10 @@ RUN apt-get update \
 USER node
 
 COPY --chown=node:node package*.json pnpm-lock.yaml pnpm-workspace.yaml lerna.json ./
+COPY --chown=node:node .husky ./.husky
 COPY --chown=node:node packages ./packages
 COPY --chown=node:node servers ./servers
-RUN pnpm install --prod --frozen-lockfile
+RUN HUSKY=0 pnpm install --frozen-lockfile
 
 FROM node:24.14.1-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c
 ARG SERVICE

--- a/eng/docker/Dockerfile-NodeE2E
+++ b/eng/docker/Dockerfile-NodeE2E
@@ -26,6 +26,7 @@ WORKDIR /app
 RUN corepack enable \
   && corepack prepare pnpm@10.30.2 --activate
 COPY --chown=node:node --from=builder /app .
+USER node
 WORKDIR "/app/servers/$SERVICE"
 
 EXPOSE 3000

--- a/eng/docker/Dockerfile-NodeE2E
+++ b/eng/docker/Dockerfile-NodeE2E
@@ -12,10 +12,10 @@ RUN apt-get update \
 
 USER node
 
-COPY --chown=node:node package*.json yarn.lock lerna.json ./
+COPY --chown=node:node package*.json pnpm-lock.yaml pnpm-workspace.yaml lerna.json ./
 COPY --chown=node:node packages ./packages
 COPY --chown=node:node servers ./servers
-RUN yarn --production --pure-lockfile
+RUN corepack enable && pnpm install --prod --frozen-lockfile
 
 FROM node:24.14.1-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c
 WORKDIR /app
@@ -23,4 +23,4 @@ COPY --chown=node:node --from=builder /app .
 WORKDIR "/app/servers/$SERVICE"
 
 EXPOSE 3000
-ENTRYPOINT ["yarn", "start"]
+ENTRYPOINT ["pnpm", "start"]

--- a/eng/docker/Dockerfile-NodeE2E
+++ b/eng/docker/Dockerfile-NodeE2E
@@ -8,17 +8,22 @@ USER root
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends  python3 make g++ \
-  && ln -sf python3 /usr/bin/python
+  && ln -sf python3 /usr/bin/python \
+  && corepack enable \
+  && corepack prepare pnpm@10.30.2 --activate
 
 USER node
 
 COPY --chown=node:node package*.json pnpm-lock.yaml pnpm-workspace.yaml lerna.json ./
 COPY --chown=node:node packages ./packages
 COPY --chown=node:node servers ./servers
-RUN corepack enable && pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod --frozen-lockfile
 
 FROM node:24.14.1-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c
+ARG SERVICE
 WORKDIR /app
+RUN corepack enable \
+  && corepack prepare pnpm@10.30.2 --activate
 COPY --chown=node:node --from=builder /app .
 WORKDIR "/app/servers/$SERVICE"
 

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "check-packages": "pnpm run clean && pnpm run compile && pnpm run test && pnpm run lint",
     "check-licenses": "pnpm licenses list --prod --json | node ./check-license.js",
     "prepare": "node .husky/install.mjs",
-    "start": "docker-compose up",
-    "start:rebuild": "docker-compose up --build",
-    "stop": "docker-compose down -v"
+    "start": "docker compose up",
+    "start:rebuild": "docker compose up --build",
+    "stop": "docker compose down -v"
   },
   "// fast-xml-parser-override-note": "Temporary: remove this fast-xml-parser override once @aws-sdk/xml-builder no longer pulls fast-xml-parser 5.3.4 (i.e., upstream resolves to >=5.3.6).",
   "pnpm": {

--- a/samples/sample-registrar-server/docker/compose.yml
+++ b/samples/sample-registrar-server/docker/compose.yml
@@ -24,7 +24,7 @@ services:
       - /app/servers/registrar-migrations/node_modules
       - ..:/app/servers/registrar-migrations
       - ../../sample-lib-app:/app/samples/sample-lib-app
-    command: "yarn --cwd servers/registrar-migrations migrate:up"
+    command: "pnpm --dir servers/registrar-migrations run migrate:up"
     env_file:
       - ../.localdev.env
 
@@ -52,7 +52,7 @@ services:
       - /app/servers/registrar/node_modules
       - ..:/app/servers/registrar
       - httpscert:/certs
-    command: npx nodemon --exec "cd servers/registrar && yarn start"
+    command: npx nodemon --exec "cd servers/registrar && pnpm start"
     env_file:
       - ../.localdev.env
     environment:

--- a/samples/sample-registrar-server/docker/compose.yml
+++ b/samples/sample-registrar-server/docker/compose.yml
@@ -52,7 +52,7 @@ services:
       - /app/servers/registrar/node_modules
       - ..:/app/servers/registrar
       - httpscert:/certs
-    command: npx nodemon --exec "cd servers/registrar && pnpm start"
+    command: pnpm --dir servers/registrar exec nodemon --exec "pnpm start"
     env_file:
       - ../.localdev.env
     environment:

--- a/servers/credentialagent/docker/compose.yml
+++ b/servers/credentialagent/docker/compose.yml
@@ -24,7 +24,7 @@ services:
       - ../../../packages:/app/packages
       - /app/servers/credentialagent/node_modules
       - ..:/app/servers/credentialagent
-    command: npx nodemon --exec "cd servers/credentialagent && yarn start"
+    command: npx nodemon --exec "cd servers/credentialagent && pnpm start"
     env_file:
       - ../.localdev.e2e.env
     environment:

--- a/servers/credentialagent/docker/compose.yml
+++ b/servers/credentialagent/docker/compose.yml
@@ -24,7 +24,7 @@ services:
       - ../../../packages:/app/packages
       - /app/servers/credentialagent/node_modules
       - ..:/app/servers/credentialagent
-    command: npx nodemon --exec "cd servers/credentialagent && pnpm start"
+    command: pnpm --dir servers/credentialagent exec nodemon --exec "pnpm start"
     env_file:
       - ../.localdev.e2e.env
     environment:

--- a/servers/mockvendor/docker/compose.yml
+++ b/servers/mockvendor/docker/compose.yml
@@ -18,7 +18,7 @@ services:
       - ../../../packages:/app/packages
       - /app/servers/mockvendor/node_modules
       - ..:/app/servers/mockvendor
-    command: npx nodemon --exec "cd servers/mockvendor && yarn start"
+    command: npx nodemon --exec "cd servers/mockvendor && pnpm start"
     env_file:
       - ../.localdev.env
     ports:

--- a/servers/mockvendor/docker/compose.yml
+++ b/servers/mockvendor/docker/compose.yml
@@ -18,7 +18,7 @@ services:
       - ../../../packages:/app/packages
       - /app/servers/mockvendor/node_modules
       - ..:/app/servers/mockvendor
-    command: npx nodemon --exec "cd servers/mockvendor && pnpm start"
+    command: pnpm --dir servers/mockvendor exec nodemon --exec "pnpm start"
     env_file:
       - ../.localdev.env
     ports:


### PR DESCRIPTION
## What changed
- switched `eng/docker/Dockerfile-NodeE2E` from Yarn to pnpm by copying `pnpm-lock.yaml` and `pnpm-workspace.yaml`, enabling Corepack, and using `pnpm start` as the runtime entrypoint
- changed the `builder` stage to install full workspace dependencies with `HUSKY=0 pnpm install --frozen-lockfile` because all local Docker compose flows build `target: builder` and require dev tools such as `nodemon` and `migrate-mongo`
- kept the final runtime stage separate, with its own Corepack/pnpm availability
- updated Docker compose commands for the affected services to run pnpm instead of Yarn
- updated the root `package.json` Docker helper scripts from `docker-compose` to `docker compose`

## Why
The workspace has already migrated to pnpm, but the Docker and compose flows had been reverted back to Yarn. This put container installs and runtime commands out of step with the rest of the repo.

The compose consumers of `eng/docker/Dockerfile-NodeE2E` are dev/E2E-style containers that build `target: builder`, mount source, and invoke tools from workspace-local bins. Because of that, the `builder` target now intentionally installs full dependencies rather than production-only dependencies.

## Impact
Docker-based local and E2E flows now use the same package manager and lockfile as the workspace and CI, and the compose/dev target has the dependencies it needs for `nodemon` and migration commands.

## Validation
- `git diff --cached --check`
- `docker build -f eng/docker/Dockerfile-NodeE2E --target builder --build-arg SERVICE=credentialagent .`
- `docker build -t verii-issue-540-dockerfile-test -f eng/docker/Dockerfile-NodeE2E --build-arg SERVICE=credentialagent .`
- `docker run --rm --entrypoint pnpm verii-issue-540-dockerfile-test --version`
- `docker build -t verii-issue-540-builder-test -f eng/docker/Dockerfile-NodeE2E --target builder --build-arg SERVICE=credentialagent .`
- `docker run --rm --entrypoint sh verii-issue-540-builder-test -lc "./servers/credentialagent/node_modules/.bin/nodemon --version && ./servers/credentialagent/node_modules/.bin/migrate-mongo --version && ./servers/mockvendor/node_modules/.bin/nodemon --version"`