### PR TITLE
[codex] resolve remaining fastify lockfile alert

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-prettier": "5.5.5",
     "eslint-watch": "8.0.0",
     "expect": "30.3.0",
+    "fastify": "5.8.5",
     "globals": "17.5.0",
     "h2url": "0.2.0",
     "prettier": "3.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2103,9 +2103,6 @@ importers:
       ajv-formats:
         specifier: 3.0.1
         version: 3.0.1(ajv@8.18.0)
-      fastify:
-        specifier: '>=4.29.0'
-        version: 5.7.4
       fastify-plugin:
         specifier: '>=4.5.1'
         version: 5.1.0
@@ -2158,6 +2155,9 @@ importers:
       expect:
         specifier: 30.3.0
         version: 30.3.0
+      fastify:
+        specifier: 5.8.5
+        version: 5.8.5
       globals:
         specifier: 17.5.0
         version: 17.5.0
@@ -8171,9 +8171,6 @@ packages:
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
-
-  fastify@5.7.4:
-    resolution: {integrity: sha512-e6l5NsRdaEP8rdD8VR0ErJASeyaRbzXYpmkrpr2SuvuMq6Si3lvsaVy5C+7gLanEkvjpMDzBXWE5HPeb/hgTxA==}
 
   fastify@5.8.5:
     resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
@@ -16749,24 +16746,6 @@ snapshots:
       node-cache: 5.1.2
 
   fastify-plugin@5.1.0: {}
-
-  fastify@5.7.4:
-    dependencies:
-      '@fastify/ajv-compiler': 4.0.5
-      '@fastify/error': 4.2.0
-      '@fastify/fast-json-stringify-compiler': 5.0.3
-      '@fastify/proxy-addr': 5.1.0
-      abstract-logging: 2.0.1
-      avvio: 9.2.0
-      fast-json-stringify: 6.3.0
-      find-my-way: 9.5.0
-      light-my-request: 6.6.0
-      pino: 10.3.1
-      process-warning: 5.0.0
-      rfdc: 1.4.1
-      secure-json-parse: 4.1.0
-      semver: 7.7.4
-      toad-cache: 3.7.0
 
   fastify@5.8.5:
     dependencies:


### PR DESCRIPTION
## What changed
- add `fastify@5.8.5` as a dev dependency for `@verii/server-provider`
- regenerate `pnpm-lock.yaml` so `packages/server` no longer resolves Fastify to `5.7.4`
- remove the stale `fastify@5.7.4` package and snapshot entries from the lockfile

## Why
Dependabot alert #279 remained open because `origin/main` still had one `pnpm-lock.yaml` importer entry for `packages/server` resolving the broad `fastify` peer range to vulnerable `5.7.4`, even after other Fastify resolutions had already moved to `5.8.5`.

## Impact
- clears the remaining vulnerable Fastify resolution from the default branch lockfile
- keeps the published peer dependency contract for `packages/server` unchanged
- makes the workspace's local development resolution explicit and patched

## Validation
- `pnpm install --ignore-scripts`
- `pnpm --filter @verii/server-provider test` *(fails in this environment because Mongo is not available on `localhost:27017`)*