### PR TITLE
[codex] fix(deps): narrow pnpm security overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
     "start:rebuild": "docker compose up --build",
     "stop": "docker compose down -v"
   },
-  "// fast-xml-parser-override-note": "Temporary: remove this fast-xml-parser override once @aws-sdk/xml-builder no longer pulls fast-xml-parser 5.3.4 (i.e., upstream resolves to >=5.3.6).",
+  "// mocha-serialize-javascript-override-note": "Temporary: remove this mocha>serialize-javascript override once the Hardhat dependency path no longer resolves serialize-javascript 6.x (Dependabot alert #148 / GHSA-5c6j-r48x-rmvq).",
+  "// lodash-override-note": "Temporary: remove these package-specific lodash overrides once eslint-plugin-better-mutation, ra-data-local-storage, and ra-ui-materialui stop pinning lodash 4.17.x.",
   "pnpm": {
     "overrides": {
-      "fast-xml-parser": "^5.3.6",
-      "serialize-javascript": "7.0.5",
-      "lodash": "^4.18.0"
+      "mocha>serialize-javascript": "7.0.5",
+      "eslint-plugin-better-mutation>lodash": "^4.18.0",
+      "ra-data-local-storage>lodash": "^4.18.0",
+      "ra-ui-materialui>lodash": "^4.18.0"
     },
     "onlyBuiltDependencies": [
       "@sentry/profiling-node",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-xml-parser: ^5.3.6
-  serialize-javascript: 7.0.5
-  lodash: ^4.18.0
+  mocha>serialize-javascript: 7.0.5
+  eslint-plugin-better-mutation>lodash: ^4.18.0
+  ra-data-local-storage>lodash: ^4.18.0
+  ra-ui-materialui>lodash: ^4.18.0
 
 importers:
 
@@ -107,7 +108,7 @@ importers:
         specifier: 6.16.0
         version: 6.16.0
       lodash:
-        specifier: ^4.18.0
+        specifier: 4.18.1
         version: 4.18.1
 
   contracts/permissions:
@@ -175,7 +176,7 @@ importers:
         specifier: ~2.0.0
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       eslint:
@@ -251,7 +252,7 @@ importers:
         specifier: ^5.0.0
         version: 5.1.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       twilio:
         specifier: ^5.10.1
@@ -321,7 +322,7 @@ importers:
         specifier: ^5.0.0
         version: 5.1.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       '@spencejs/spence-config':
@@ -346,7 +347,7 @@ importers:
         specifier: ~6.16.0
         version: 6.16.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       '@verii/crypto':
@@ -392,7 +393,7 @@ importers:
   packages/common-fetchers:
     dependencies:
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       eslint:
@@ -438,7 +439,7 @@ importers:
         specifier: ^4.0.0
         version: 4.1.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       eslint:
@@ -628,7 +629,7 @@ importers:
         specifier: ^7.0.0
         version: 7.5.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       eslint-plugin-autofix:
@@ -675,7 +676,7 @@ importers:
         specifier: 4.5.8
         version: 4.5.8
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       '@verii/crypto':
@@ -730,7 +731,7 @@ importers:
         specifier: 2.3.11
         version: 2.3.11
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       eslint:
@@ -794,7 +795,7 @@ importers:
         specifier: ^6.6.1
         version: 6.6.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       random-number-csprng:
         specifier: ^1.0.2
@@ -843,7 +844,7 @@ importers:
         specifier: ^5.0.7
         version: 5.0.7
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       eslint:
@@ -901,7 +902,7 @@ importers:
         specifier: ^5.0.0
         version: 5.1.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ~4.18.0
         version: 4.18.1
       mongodb:
         specifier: 7.1.1
@@ -992,7 +993,7 @@ importers:
         specifier: ~5.10.0
         version: 5.10.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       '@verii/sample-data':
@@ -1014,7 +1015,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       web-did-resolver:
         specifier: ^2.0.27
@@ -1087,7 +1088,7 @@ importers:
         specifier: ~2.0.0
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ~4.18.0
         version: 4.18.1
       nanoid:
         specifier: ~5.1.0
@@ -1238,7 +1239,7 @@ importers:
         specifier: ~5.1.0
         version: 5.1.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ~4.18.0
         version: 4.18.1
     devDependencies:
       '@spencejs/spence-factories':
@@ -1425,7 +1426,7 @@ importers:
         specifier: ~2.0.0
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ~4.18.0
         version: 4.18.1
       mongodb:
         specifier: ~7.1.0
@@ -1565,7 +1566,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       quick-lru:
         specifier: ~7.3.0
@@ -1629,7 +1630,7 @@ importers:
         specifier: 2.0.1
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       '@verii/http-client':
@@ -1690,7 +1691,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       nanoid:
         specifier: ~5.1.0
@@ -1799,7 +1800,7 @@ importers:
         specifier: ~5.10.0
         version: 5.10.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       '@verii/sample-data':
@@ -1854,7 +1855,7 @@ importers:
         specifier: 0.5.0-build
         version: link:../jwt
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       pino:
         specifier: ~10.3.0
@@ -1906,7 +1907,7 @@ importers:
         specifier: 10.0.2
         version: 10.0.2
       lodash:
-        specifier: ^4.18.0
+        specifier: 4.18.1
         version: 4.18.1
     devDependencies:
       eslint:
@@ -1973,7 +1974,7 @@ importers:
         specifier: 1.0.4
         version: 1.0.4
       lodash:
-        specifier: ^4.18.0
+        specifier: 4.18.1
         version: 4.18.1
     devDependencies:
       '@spencejs/spence-config':
@@ -2004,7 +2005,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       '@verii/test-regexes':
@@ -2020,7 +2021,7 @@ importers:
   packages/rest-queries:
     dependencies:
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       qs:
         specifier: 6.15.1
@@ -2110,7 +2111,7 @@ importers:
         specifier: 2.0.1
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       nanoid:
         specifier: ~5.1.0
@@ -2177,7 +2178,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       mongodb:
         specifier: 7.1.1
@@ -2295,7 +2296,7 @@ importers:
         specifier: 30.3.0
         version: 30.3.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       mongodb:
         specifier: ~7.1.0
@@ -2350,7 +2351,7 @@ importers:
         specifier: ^5.0.0
         version: 5.1.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       '@verii/config':
@@ -2414,7 +2415,7 @@ importers:
         specifier: ^4.0.0
         version: 4.1.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       '@verii/sample-data':
@@ -2493,7 +2494,7 @@ importers:
         specifier: 6.1.1
         version: 6.1.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       '@verii/contract-permissions':
@@ -2587,7 +2588,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       '@verii/crypto':
@@ -2750,7 +2751,7 @@ importers:
         specifier: ^3.3.4
         version: 3.3.4
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       prop-types:
         specifier: ^15.8.1
@@ -2895,7 +2896,7 @@ importers:
         specifier: 2.0.1
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ~4.18.0
         version: 4.18.1
     devDependencies:
       '@spencejs/spence-factories':
@@ -3291,7 +3292,7 @@ importers:
         specifier: ^10.3.0
         version: 10.4.0
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       mongodb:
         specifier: ~7.1.0
@@ -3451,7 +3452,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.1
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       mongodb:
         specifier: ~7.1.0
@@ -3524,7 +3525,7 @@ importers:
         specifier: ~14.0.0
         version: 14.0.3
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       mongodb:
         specifier: ~7.1.0
@@ -3603,7 +3604,7 @@ importers:
         specifier: ^8.0.0
         version: 8.2.7(@types/node@24.12.2)
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       nanoid:
         specifier: 5.1.7
@@ -3682,7 +3683,7 @@ importers:
         specifier: ~14.0.0
         version: 14.0.3
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
       nanoid:
         specifier: ~5.1.0
@@ -3725,7 +3726,7 @@ importers:
         specifier: ~14.0.0
         version: 14.0.3
       lodash:
-        specifier: ^4.18.0
+        specifier: ^4.17.21
         version: 4.18.1
     devDependencies:
       eslint:
@@ -8149,8 +8150,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-parser@5.3.7:
-    resolution: {integrity: sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==}
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
+  fast-xml-parser@5.5.8:
+    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -9661,6 +9665,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -10421,8 +10429,8 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
-  strnum@2.1.2:
-    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
@@ -11828,7 +11836,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.17':
     dependencies:
       '@smithy/types': 4.14.0
-      fast-xml-parser: 5.3.7
+      fast-xml-parser: 5.5.8
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -16716,9 +16724,15 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-parser@5.3.7:
+  fast-xml-builder@1.1.5:
     dependencies:
-      strnum: 2.1.2
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.5.8:
+    dependencies:
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   fastest-levenshtein@1.0.16: {}
 
@@ -18339,6 +18353,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
@@ -19238,7 +19254,7 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  strnum@2.1.2: {}
+  strnum@2.2.3: {}
 
   stylis@4.2.0: {}
 


### PR DESCRIPTION
## What changed
- removed the stale global `fast-xml-parser` pnpm override
- restored inline `package.json` notes for the remaining temporary security overrides
- narrowed the remaining overrides to single-hop pnpm selectors:
  - `mocha>serialize-javascript`
  - `eslint-plugin-better-mutation>lodash`
  - `ra-data-local-storage>lodash`
  - `ra-ui-materialui>lodash`
- refreshed `pnpm-lock.yaml`

## Why
The prior global overrides were broader than necessary after the move from Yarn `resolutions` to pnpm `overrides`.

For `fast-xml-parser`, the global pin was now counterproductive: upstream `@aws-sdk/xml-builder` already resolves to a patched `fast-xml-parser`, but the repo override kept `origin/main` on the vulnerable `5.3.x` line.

For `serialize-javascript` and `lodash`, the old Yarn-era intent was to scope the security overrides to the specific parent packages that needed them. This change restores that narrower intent using the single-hop selector syntax pnpm supports.

## Impact
- keeps `fast-xml-parser` on the patched `5.5.8` line in the lockfile
- keeps `serialize-javascript` on `7.0.5`
- keeps resolved `lodash` on `4.18.1`
- reduces unnecessary override breadth while preserving the current security posture

## Validation
- `pnpm install --ignore-scripts`
- `pnpm why lodash`
- verified lockfile resolutions for `fast-xml-parser@5.5.8`, `serialize-javascript@7.0.5`, and `lodash@4.18.1`