### PR TITLE
[codex] fix publish workflow commit message

### DIFF
--- a/.github/workflows/publish-packages.workflow.yml
+++ b/.github/workflows/publish-packages.workflow.yml
@@ -125,7 +125,7 @@ jobs:
         if: env.VERSION_TYPE == 'release'
       # Commit Version Locally for Npmjs
       - name: Commit Version Locally for Npmjs
-        run: git commit -am "Creating Version ${{ env.NPM_VER_NUM }}"
+        run: git commit -am "chore(release): create version ${{ env.NPM_VER_NUM }}"
       # Publish to NpmJS with trusted publishing (OIDC + provenance)
       # Lerna v9+ has native support for npm trusted publishing
       # See: https://lerna.js.org/docs/features/version-and-publish


### PR DESCRIPTION
## Summary
This updates the package publish workflow to use a conventional commit message for the local release-version commit.

## Why
The publish job was failing before `lerna publish` ran. After `pnpm install`, the workflow installs Husky and enables the `commit-msg` hook, so the generated commit message also has to satisfy `commitlint`.

The previous message, `Creating Version ...`, failed with `type-empty` and `subject-empty`, which stopped the workflow at the local `git commit` step.

## Impact
This lets the `Publish Packages` workflow get past the version-commit step and proceed to the actual publish logic.

## Validation
- Inspected recent failing workflow runs and confirmed they stopped at `Commit Version Locally for Npmjs`
- Updated the generated commit message to `chore(release): create version ...`
- Verified the diff locally

## Notes
No runtime or package code changed; this is a CI workflow-only fix.