### PR TITLE
[codex] fix publish workflow yaml quoting

### DIFF
--- a/.github/workflows/publish-packages.workflow.yml
+++ b/.github/workflows/publish-packages.workflow.yml
@@ -125,7 +125,7 @@ jobs:
         if: env.VERSION_TYPE == 'release'
       # Commit Version Locally for Npmjs
       - name: Commit Version Locally for Npmjs
-        run: git commit -am "chore(release): create version ${{ env.NPM_VER_NUM }}"
+        run: 'git commit -am "chore(release): create version ${{ env.NPM_VER_NUM }}"'
       # Publish to NpmJS with trusted publishing (OIDC + provenance)
       # Lerna v9+ has native support for npm trusted publishing
       # See: https://lerna.js.org/docs/features/version-and-publish


### PR DESCRIPTION
## Summary
This fixes the `Publish Packages` workflow after the previous commitlint-related change introduced a YAML parsing error.

## Why
The prior fix changed the generated release commit message to `chore(release): create version ...`, which is correct for commitlint, but the `run:` line remained an unquoted YAML plain scalar.

Because the command string contained `: `, GitHub Actions treated the workflow file as invalid YAML and failed the workflow before any jobs were created.

## What changed
The `run:` value for the release commit step is now quoted as a single YAML string while preserving the exact shell command.

## Impact
This restores workflow parsing and keeps the conventional commit message needed for the Husky/commitlint hook.

## Validation
- Parsed `.github/workflows/publish-packages.workflow.yml` locally with Ruby's YAML parser
- Verified the change is limited to the single `run:` line
- Confirmed the command content itself is unchanged aside from YAML quoting
