### PR TITLE
fix(registrar): refresh access tokens after org create

### DIFF
--- a/packages/components-organizations-registrar/src/pages/invitations/CreateOrganisationFromInvitation.jsx
+++ b/packages/components-organizations-registrar/src/pages/invitations/CreateOrganisationFromInvitation.jsx
@@ -31,6 +31,7 @@ import { formatWebSiteUrl, formatRegistrationNumbers, parseJwt } from '@/utils/i
 import useCountryCodes from '@/utils/countryCodes.js';
 import { dataResources } from '@/utils/remoteDataProvider.js';
 import { useAuth } from '@/utils/auth/AuthContext.js';
+import { refreshAccessToken } from '@/utils/auth/refreshAccessTokens.js';
 import useSelectedOrganization from '@/state/selectedOrganizationState.js';
 import { SecretKeysPopup } from '../services/components/SecretKeysPopup/index.jsx';
 
@@ -40,7 +41,7 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
   const refresh = useRefresh();
   const redirect = useRedirect();
   const auth = useAuth();
-  const { user, getAccessToken } = auth;
+  const { user, getAccessToken, getAccessTokenWithPopup } = auth;
   const logout = useLogout();
 
   const [, setDid] = useSelectedOrganization();
@@ -210,9 +211,9 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
         <SecretKeysPopup
           isOpen={isOpenSecretPopup}
           secretKeys={secretKeys}
-          onClose={() => {
+          onClose={async () => {
             setIsOpenSecretPopup(false);
-            getAccessToken({ cacheMode: 'off' });
+            await refreshAccessToken({ getAccessToken, getAccessTokenWithPopup });
             redirect('/');
           }}
           wording={{

--- a/packages/components-organizations-registrar/src/pages/invitations/CreateOrganisationFromInvitation.jsx
+++ b/packages/components-organizations-registrar/src/pages/invitations/CreateOrganisationFromInvitation.jsx
@@ -211,10 +211,14 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
         <SecretKeysPopup
           isOpen={isOpenSecretPopup}
           secretKeys={secretKeys}
-          onClose={async () => {
+          onClose={() => {
             setIsOpenSecretPopup(false);
-            await refreshAccessToken({ getAccessToken, getAccessTokenWithPopup });
-            redirect('/');
+            // SecretKeysPopup does not await onClose, so absorb refresh failures here and always redirect.
+            refreshAccessToken({ getAccessToken, getAccessTokenWithPopup })
+              .catch(() => undefined)
+              .finally(() => {
+                redirect('/');
+              });
           }}
           wording={{
             title: 'Your organization is now registered on Velocity Network™.',

--- a/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
+++ b/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
@@ -149,7 +149,11 @@ const OrganizationCreate = ({
         setSecretKeys({ keys: resp.keys, authClients: resp.authClients });
         setServiceCreated(true);
         setCreateRequestLoading(false);
-        await refreshAccessToken({ getAccessToken, getAccessTokenWithPopup });
+        try {
+          await refreshAccessToken({ getAccessToken, getAccessTokenWithPopup });
+        } catch {
+          // refreshAccessToken logs non-interaction failures internally; do not block success flow.
+        }
         refetch();
         navigate(-1);
       },

--- a/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
+++ b/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
@@ -60,6 +60,7 @@ import {
 } from '@/utils/index.jsx';
 import useCountryCodes from '@/utils/countryCodes.js';
 import { useAuth } from '@/utils/auth/AuthContext.js';
+import { refreshAccessToken } from '@/utils/auth/refreshAccessTokens.js';
 import { dataResources } from '@/utils/remoteDataProvider.js';
 
 import AuthorityRegistrationNumbersInput from './components/AuthorityRegistrationInput.jsx';
@@ -95,7 +96,7 @@ const OrganizationCreate = ({
   const notify = useNotify();
   const redirect = useRedirect();
 
-  const { logout, user, getAccessToken } = useAuth();
+  const { logout, user, getAccessToken, getAccessTokenWithPopup } = useAuth();
 
   const { data: countryCodes, isLoading } = useCountryCodes();
   const [did, setDid] = useSelectedOrganization();
@@ -144,13 +145,13 @@ const OrganizationCreate = ({
     resource: 'organizations',
     mutationOptions: {
       onSuccess: async (resp) => {
-        refetch();
         setDid(resp.id);
         setSecretKeys({ keys: resp.keys, authClients: resp.authClients });
         setServiceCreated(true);
         setCreateRequestLoading(false);
+        await refreshAccessToken({ getAccessToken, getAccessTokenWithPopup });
+        refetch();
         navigate(-1);
-        getAccessToken({ cacheMode: 'off' });
       },
       onError: ({ body }) => {
         setCreateRequestLoading(false);

--- a/packages/components-organizations-registrar/src/pages/organizations/__tests__/OrganizationCreate.test.jsx
+++ b/packages/components-organizations-registrar/src/pages/organizations/__tests__/OrganizationCreate.test.jsx
@@ -218,4 +218,45 @@ describe('OrganizationCreate', () => {
     expect(navigateMock.mock.calls.length).toEqual(1);
     expect(navigateMock.mock.calls[0].arguments).toEqual([-1]);
   });
+
+  it('continues navigation when refresh fails with a non-interaction error', async () => {
+    createControllerOptions = undefined;
+    navigateMock.mock.resetCalls();
+    refetchMock.mock.resetCalls();
+    getAccessTokenMock.mock.resetCalls();
+    getAccessTokenWithPopupMock.mock.resetCalls();
+
+    let tokenCallCount = 0;
+    const refreshError = new Error('network timeout');
+    getAccessTokenMock.mock.mockImplementation(() => {
+      tokenCallCount += 1;
+      if (tokenCallCount === 1) {
+        return Promise.resolve(
+          buildToken({
+            scope: 'write:organizations',
+          }),
+        );
+      }
+
+      return Promise.reject(refreshError);
+    });
+
+    renderOrganizationCreate(OrganizationCreate);
+
+    await waitFor(() => expect(createControllerOptions).toBeDefined());
+    await waitFor(() => expect(getAccessTokenMock.mock.calls.length).toEqual(1));
+
+    await expect(
+      createControllerOptions.mutationOptions.onSuccess({
+        id: 'did:test:new-org',
+        keys: [],
+        authClients: [],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(getAccessTokenWithPopupMock.mock.calls.length).toEqual(0);
+    expect(refetchMock.mock.calls.length).toEqual(1);
+    expect(navigateMock.mock.calls.length).toEqual(1);
+    expect(navigateMock.mock.calls[0].arguments).toEqual([-1]);
+  });
 });

--- a/packages/components-organizations-registrar/src/pages/organizations/__tests__/OrganizationCreate.test.jsx
+++ b/packages/components-organizations-registrar/src/pages/organizations/__tests__/OrganizationCreate.test.jsx
@@ -1,0 +1,221 @@
+import { before, describe, it, mock } from 'node:test';
+import { expect } from 'expect';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import * as reactAdminActual from 'react-admin';
+import * as reactRouterActual from 'react-router';
+
+import { AuthContext } from '@/utils/auth/AuthContext.js';
+import { ConfigContext } from '@/utils/ConfigContext.js';
+
+expect.extend(matchers);
+
+const theme = createTheme({
+  customColors: {
+    grey2: '#9aa4b2',
+  },
+});
+
+const createDeferred = () => {
+  let resolve;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+const buildToken = (payload) => {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
+  return `${encode({ alg: 'RS256', typ: 'JWT' })}.${encode(payload)}.signature`;
+};
+
+const navigateMock = mock.fn();
+const redirectMock = mock.fn();
+const notifyMock = mock.fn();
+const refetchMock = mock.fn();
+
+let createControllerOptions;
+
+const getAccessTokenMock = mock.fn();
+const getAccessTokenWithPopupMock = mock.fn();
+
+mock.module('react-router', {
+  namedExports: {
+    ...reactRouterActual,
+    useNavigate: () => navigateMock,
+    useLocation: () => ({ pathname: '/organizations/create/service' }),
+  },
+});
+
+mock.module('react-admin', {
+  namedExports: {
+    ...reactAdminActual,
+    useCreateController: (options) => {
+      createControllerOptions = options;
+      return { save: mock.fn() };
+    },
+    useRedirect: () => redirectMock,
+    useGetOne: () => ({
+      data: { givenName: 'New', familyName: 'User' },
+      isLoading: false,
+    }),
+    useNotify: () => notifyMock,
+    useGetList: () => ({
+      refetch: refetchMock,
+    }),
+  },
+});
+
+mock.module('@/utils/countryCodes.js', {
+  defaultExport: () => ({
+    data: [{ id: 'AU', name: 'Australia' }],
+    isLoading: false,
+  }),
+});
+
+const renderOrganizationCreate = (OrganizationCreate) => {
+  return render(
+    <AuthContext.Provider
+      value={{
+        isLoading: false,
+        isAuthenticated: true,
+        user: { sub: 'auth0|new-user' },
+        login: mock.fn(),
+        logout: mock.fn(),
+        getAccessToken: getAccessTokenMock,
+        getAccessTokenWithPopup: getAccessTokenWithPopupMock,
+      }}
+    >
+      <ConfigContext.Provider value={{ chainName: 'Devnet' }}>
+        <ThemeProvider theme={theme}>
+          <reactAdminActual.AdminContext store={reactAdminActual.memoryStore()} theme={theme}>
+            <reactAdminActual.ResourceContextProvider value="organizations">
+              <OrganizationCreate CreateServiceComponent={() => <div>Service Modal</div>} />
+            </reactAdminActual.ResourceContextProvider>
+          </reactAdminActual.AdminContext>
+        </ThemeProvider>
+      </ConfigContext.Provider>
+    </AuthContext.Provider>,
+  );
+};
+
+describe('OrganizationCreate', () => {
+  let OrganizationCreate;
+
+  before(async () => {
+    OrganizationCreate = (await import('../OrganizationCreate.jsx')).default;
+  });
+
+  it('waits for access token refresh before navigating after organization creation', async () => {
+    createControllerOptions = undefined;
+    navigateMock.mock.resetCalls();
+    refetchMock.mock.resetCalls();
+    getAccessTokenMock.mock.resetCalls();
+    getAccessTokenWithPopupMock.mock.resetCalls();
+
+    const refreshDeferred = createDeferred();
+    let tokenCallCount = 0;
+    getAccessTokenMock.mock.mockImplementation(() => {
+      tokenCallCount += 1;
+      if (tokenCallCount === 1) {
+        return Promise.resolve(
+          buildToken({
+            scope: 'write:organizations',
+          }),
+        );
+      }
+      return refreshDeferred.promise;
+    });
+
+    renderOrganizationCreate(OrganizationCreate);
+
+    await waitFor(() => expect(createControllerOptions).toBeDefined());
+    await waitFor(() => expect(getAccessTokenMock.mock.calls.length).toEqual(1));
+
+    let onSuccessSettled = false;
+    const onSuccessPromise = createControllerOptions.mutationOptions.onSuccess({
+      id: 'did:test:new-org',
+      keys: [],
+      authClients: [],
+    });
+    onSuccessPromise.then(() => {
+      onSuccessSettled = true;
+    });
+
+    await Promise.resolve();
+
+    expect(getAccessTokenMock.mock.calls.length).toEqual(2);
+    expect(refetchMock.mock.calls).toEqual([]);
+    expect(navigateMock.mock.calls).toEqual([]);
+    expect(onSuccessSettled).toEqual(false);
+
+    refreshDeferred.resolve(
+      buildToken({
+        scope: 'write:organizations',
+        'http://velocitynetwork.foundation/groupId': 'did:test:new-org',
+      }),
+    );
+    await onSuccessPromise;
+
+    expect(refetchMock.mock.calls.length).toEqual(1);
+    expect(navigateMock.mock.calls.length).toEqual(1);
+    expect(navigateMock.mock.calls[0].arguments).toEqual([-1]);
+  });
+
+  it('falls back to popup refresh and still waits before navigating when silent refresh errors', async () => {
+    createControllerOptions = undefined;
+    navigateMock.mock.resetCalls();
+    refetchMock.mock.resetCalls();
+    getAccessTokenMock.mock.resetCalls();
+    getAccessTokenWithPopupMock.mock.resetCalls();
+
+    const popupDeferred = createDeferred();
+    let tokenCallCount = 0;
+    getAccessTokenMock.mock.mockImplementation(() => {
+      tokenCallCount += 1;
+      if (tokenCallCount === 1) {
+        return Promise.resolve(
+          buildToken({
+            scope: 'write:organizations',
+          }),
+        );
+      }
+      throw Object.assign(new Error('Consent required'), {
+        error: 'consent_required',
+      });
+    });
+    getAccessTokenWithPopupMock.mock.mockImplementation(() => popupDeferred.promise);
+
+    renderOrganizationCreate(OrganizationCreate);
+
+    await waitFor(() => expect(createControllerOptions).toBeDefined());
+    await waitFor(() => expect(getAccessTokenMock.mock.calls.length).toEqual(1));
+
+    const onSuccessPromise = createControllerOptions.mutationOptions.onSuccess({
+      id: 'did:test:new-org',
+      keys: [],
+      authClients: [],
+    });
+    onSuccessPromise.catch(() => {});
+
+    await Promise.resolve();
+
+    expect(getAccessTokenMock.mock.calls.length).toEqual(2);
+    expect(getAccessTokenWithPopupMock.mock.calls.length).toEqual(1);
+    expect(navigateMock.mock.calls).toEqual([]);
+
+    popupDeferred.resolve(
+      buildToken({
+        scope: 'write:organizations',
+        'http://velocitynetwork.foundation/groupId': 'did:test:new-org',
+      }),
+    );
+    await onSuccessPromise;
+
+    expect(refetchMock.mock.calls.length).toEqual(1);
+    expect(navigateMock.mock.calls.length).toEqual(1);
+    expect(navigateMock.mock.calls[0].arguments).toEqual([-1]);
+  });
+});

--- a/packages/components-organizations-registrar/src/utils/auth/__tests__/refreshAccessTokens.test.js
+++ b/packages/components-organizations-registrar/src/utils/auth/__tests__/refreshAccessTokens.test.js
@@ -1,0 +1,29 @@
+import { describe, it, mock } from 'node:test';
+import { expect } from 'expect';
+import { refreshAccessToken } from '../refreshAccessTokens.js';
+
+describe('refreshAccessToken', () => {
+  it('returns a fresh token silently when possible', async () => {
+    const getAccessToken = mock.fn(() => Promise.resolve('silent-token'));
+    const getAccessTokenWithPopup = mock.fn();
+
+    await expect(refreshAccessToken({ getAccessToken, getAccessTokenWithPopup })).resolves.toEqual(
+      'silent-token',
+    );
+
+    expect(getAccessToken.mock.calls[0].arguments).toEqual([{ cacheMode: 'off' }]);
+    expect(getAccessTokenWithPopup.mock.calls.length).toEqual(0);
+  });
+
+  it('falls back to popup when silent refresh fails', async () => {
+    const getAccessToken = mock.fn(() => Promise.reject(new Error('Consent required')));
+    const getAccessTokenWithPopup = mock.fn(() => Promise.resolve('popup-token'));
+
+    await expect(refreshAccessToken({ getAccessToken, getAccessTokenWithPopup })).resolves.toEqual(
+      'popup-token',
+    );
+
+    expect(getAccessToken.mock.calls[0].arguments).toEqual([{ cacheMode: 'off' }]);
+    expect(getAccessTokenWithPopup.mock.calls[0].arguments).toEqual([{ cacheMode: 'off' }]);
+  });
+});

--- a/packages/components-organizations-registrar/src/utils/auth/__tests__/refreshAccessTokens.test.js
+++ b/packages/components-organizations-registrar/src/utils/auth/__tests__/refreshAccessTokens.test.js
@@ -15,8 +15,14 @@ describe('refreshAccessToken', () => {
     expect(getAccessTokenWithPopup.mock.calls.length).toEqual(0);
   });
 
-  it('falls back to popup when silent refresh fails', async () => {
-    const getAccessToken = mock.fn(() => Promise.reject(new Error('Consent required')));
+  it('falls back to popup when silent refresh requires user interaction', async () => {
+    const getAccessToken = mock.fn(() =>
+      Promise.reject(
+        Object.assign(new Error('Consent required'), {
+          error: 'consent_required',
+        }),
+      ),
+    );
     const getAccessTokenWithPopup = mock.fn(() => Promise.resolve('popup-token'));
 
     await expect(refreshAccessToken({ getAccessToken, getAccessTokenWithPopup })).resolves.toEqual(
@@ -25,5 +31,18 @@ describe('refreshAccessToken', () => {
 
     expect(getAccessToken.mock.calls[0].arguments).toEqual([{ cacheMode: 'off' }]);
     expect(getAccessTokenWithPopup.mock.calls[0].arguments).toEqual([{ cacheMode: 'off' }]);
+  });
+
+  it('rethrows silent refresh errors that are not interaction related', async () => {
+    const error = new Error('network timeout');
+    const getAccessToken = mock.fn(() => Promise.reject(error));
+    const getAccessTokenWithPopup = mock.fn();
+
+    await expect(refreshAccessToken({ getAccessToken, getAccessTokenWithPopup })).rejects.toThrow(
+      error,
+    );
+
+    expect(getAccessToken.mock.calls[0].arguments).toEqual([{ cacheMode: 'off' }]);
+    expect(getAccessTokenWithPopup.mock.calls.length).toEqual(0);
   });
 });

--- a/packages/components-organizations-registrar/src/utils/auth/refreshAccessTokens.js
+++ b/packages/components-organizations-registrar/src/utils/auth/refreshAccessTokens.js
@@ -1,3 +1,19 @@
+const INTERACTION_REQUIRED_ERRORS = new Set([
+  'consent_required',
+  'interaction_required',
+  'login_required',
+]);
+
+const isInteractionRequiredError = (error) => {
+  return [error?.error, error?.errorCode, error?.code].some((code) =>
+    INTERACTION_REQUIRED_ERRORS.has(code),
+  );
+};
+
+const logNonInteractionRefreshError = (error) => {
+  console.error('Non-interaction access token refresh failure', error);
+};
+
 export const refreshAccessToken = async ({
   getAccessToken,
   getAccessTokenWithPopup,
@@ -5,7 +21,12 @@ export const refreshAccessToken = async ({
 }) => {
   try {
     return await getAccessToken(options);
-  } catch {
+  } catch (error) {
+    if (!isInteractionRequiredError(error)) {
+      logNonInteractionRefreshError(error);
+      throw error;
+    }
+
     return getAccessTokenWithPopup(options);
   }
 };

--- a/packages/components-organizations-registrar/src/utils/auth/refreshAccessTokens.js
+++ b/packages/components-organizations-registrar/src/utils/auth/refreshAccessTokens.js
@@ -1,0 +1,11 @@
+export const refreshAccessToken = async ({
+  getAccessToken,
+  getAccessTokenWithPopup,
+  options = { cacheMode: 'off' },
+}) => {
+  try {
+    return await getAccessToken(options);
+  } catch {
+    return getAccessTokenWithPopup(options);
+  }
+};

--- a/samples/sample-registrar-app/src/AuthProviderBridge.jsx
+++ b/samples/sample-registrar-app/src/AuthProviderBridge.jsx
@@ -49,22 +49,10 @@ export const AuthProviderBridge = ({ config: { authConfig }, children }) => {
             returnTo: window.location.origin,
           },
         }),
-      getAccessToken: (options = defaultAccessTokenOptions) => {
-        try {
-          return getAccessTokenSilently(options);
-        } catch (e) {
-          console.error(e);
-          return null;
-        }
-      },
-      getAccessTokenWithPopup: (options = defaultAccessTokenOptions) => {
-        try {
-          return getAccessTokenWithPopup(options);
-        } catch (e) {
-          console.error(e);
-          return null;
-        }
-      },
+      getAccessToken: (options) =>
+        getAccessTokenSilently({ ...defaultAccessTokenOptions, ...options }),
+      getAccessTokenWithPopup: (options) =>
+        getAccessTokenWithPopup({ ...defaultAccessTokenOptions, ...options }),
     };
   }, [
     user,


### PR DESCRIPTION
## Summary
- backport the registrar access-token refresh helper with popup fallback
- wait for the forced refresh before refetching and navigating after org create
- preserve default Auth0 audience and scope when overriding token options in the sample app bridge

## Testing
- test components-registrar-app