### PR TITLE
[codex] serialize lerna publish for provenance

### DIFF
--- a/.github/workflows/publish-packages.workflow.yml
+++ b/.github/workflows/publish-packages.workflow.yml
@@ -130,7 +130,8 @@ jobs:
       # Lerna v9+ has native support for npm trusted publishing
       # See: https://lerna.js.org/docs/features/version-and-publish
       - name: Publish NpmJS
-        run: pnpm dlx lerna@${{ env.LERNA_VERSION }} publish --dist-tag ${{ env.DIST_TAG }} from-package --yes --registry "https://registry.npmjs.org/"
+        # Serialize publishes to avoid intermittent npm provenance/tlog 409s.
+        run: pnpm dlx lerna@${{ env.LERNA_VERSION }} publish --concurrency 1 --dist-tag ${{ env.DIST_TAG }} from-package --yes --registry "https://registry.npmjs.org/"
         env:
           NPM_CONFIG_PROVENANCE: true
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

- serialize `lerna publish` in the package publish workflow by adding `--concurrency 1`
- keep the pnpm-based publish flow intact while reducing bursty npm provenance submissions

## Root cause

The failing publish run on April 21, 2026 reached the `Publish NpmJS` step and then intermittently failed packages with `TLOG_CREATE_ENTRY_ERROR` and `equivalent entry already exists in the transparency log` while other packages in the same run published successfully. That points at npm provenance/transparency-log behavior during multi-package publish, not a pnpm install failure.

## Validation

- loaded `.github/workflows/publish-packages.workflow.yml` with Ruby `YAML.load_file`
- reviewed the workflow diff to confirm the publish step is the only change
