### PR TITLE
chore(deps): raise undici minimum to ^7.25.0

### DIFF
--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -20,7 +20,7 @@
     "http-errors": "^2.0.0",
     "lodash": "^4.17.21",
     "nanoid": "^5.1.0",
-    "undici": "^7.0.0",
+    "undici": "^7.25.0",
     "undici-oidc-interceptor": "0.9.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1697,8 +1697,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.9
       undici:
-        specifier: ^7.0.0
-        version: 7.24.0
+        specifier: ^7.25.0
+        version: 7.25.0
       undici-oidc-interceptor:
         specifier: 0.9.0
         version: 0.9.0
@@ -10727,10 +10727,6 @@ packages:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.24.0:
-    resolution: {integrity: sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
@@ -19618,8 +19614,6 @@ snapshots:
   undici@6.23.0: {}
 
   undici@7.22.0: {}
-
-  undici@7.24.0: {}
 
   undici@7.25.0: {}
 


### PR DESCRIPTION
## Summary
- raise `packages/http-client` runtime `undici` range from `^7.0.0` to `^7.25.0`
- refresh `pnpm-lock.yaml` with `corepack pnpm@10.30.2 install --lockfile-only --no-frozen-lockfile`
- keep direct `undici` declarations aligned at `^7.25.0` across manifests

## Why
Dependabot runtime alerts are for transitive `undici` versions below the patched floor. This sets a non-vulnerable minimum and locks the workspace to 7.25.0 for `packages/http-client`.