### PR TITLE
[codex] Fix registrar logout redirect handling

### DIFF
--- a/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
+++ b/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
@@ -97,14 +97,10 @@ export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
 
   useEffect(() => {
     trace({
-      event: 'auth-gate-state-changed',
-      isAuthenticated,
-      isLoading,
-      isSignupProcess,
-      hasAuthenticatedOnce,
+      event: 'auth-state-changed',
       authState,
     });
-  }, [authState, hasAuthenticatedOnce, isAuthenticated, isLoading, isSignupProcess]);
+  }, [authState]);
 
   useEffect(() => {
     if (!hasAuthenticatedOnce && isAuthenticated) {

--- a/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
+++ b/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
@@ -38,12 +38,40 @@ import theme from './theme/theme.js';
 
 const trace = initTrace('PrivateAppRoot');
 
+const AUTH_STATES = Object.freeze({
+  SIGNUP_REDIRECT: 'signupRedirect',
+  RESOLVING: 'resolving',
+  AUTHENTICATED: 'authenticated',
+  REFRESHING_AUTHENTICATED: 'refreshingAuthenticated',
+  LOGGED_OUT: 'loggedOut',
+});
+
+const getAuthState = ({ isSignupProcess, isAuthenticated, isLoading, hasAuthenticatedOnce }) => {
+  if (isSignupProcess) {
+    return AUTH_STATES.SIGNUP_REDIRECT;
+  }
+
+  if (isAuthenticated) {
+    return AUTH_STATES.AUTHENTICATED;
+  }
+
+  if (isLoading && hasAuthenticatedOnce) {
+    return AUTH_STATES.REFRESHING_AUTHENTICATED;
+  }
+
+  if (isLoading) {
+    return AUTH_STATES.RESOLVING;
+  }
+
+  return AUTH_STATES.LOGGED_OUT;
+};
+
 export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
   const auth = useAuth();
+  const { isAuthenticated, isLoading, login } = auth;
   const config = useConfig();
   const location = useLocation();
-  const hasResolvedAuth = auth.isAuthenticated || !auth.isLoading;
-  const [isAuthBootstrapped, setIsAuthBootstrapped] = useState(auth.isAuthenticated);
+  const [hasAuthenticatedOnce, setHasAuthenticatedOnce] = useState(isAuthenticated);
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -55,6 +83,12 @@ export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
       }),
   );
   const { isSignupProcess } = useSignupRedirect({ auth });
+  const authState = getAuthState({
+    isSignupProcess,
+    isAuthenticated,
+    isLoading,
+    hasAuthenticatedOnce,
+  });
 
   useEffect(() => {
     trace({ event: 'mounted' });
@@ -64,50 +98,40 @@ export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
   useEffect(() => {
     trace({
       event: 'auth-gate-state-changed',
-      isAuthenticated: auth.isAuthenticated,
-      isLoading: auth.isLoading,
-      hasResolvedAuth,
-      isAuthBootstrapped,
+      isAuthenticated,
+      isLoading,
       isSignupProcess,
+      hasAuthenticatedOnce,
+      authState,
     });
-  }, [auth.isAuthenticated, auth.isLoading, hasResolvedAuth, isAuthBootstrapped, isSignupProcess]);
+  }, [authState, hasAuthenticatedOnce, isAuthenticated, isLoading, isSignupProcess]);
 
   useEffect(() => {
-    if (!isAuthBootstrapped && auth.isAuthenticated) {
+    if (!hasAuthenticatedOnce && isAuthenticated) {
       trace({
-        event: 'auth-bootstrapped',
-        isAuthenticated: auth.isAuthenticated,
-        isLoading: auth.isLoading,
+        event: 'auth-authenticated-once',
+        isAuthenticated,
+        isLoading,
       });
-      // This is a one-way latch: once authenticated auth has resolved for this mount,
-      // keep the app bootstrapped so later token refreshes cannot remount the root by
-      // flipping auth.isLoading back on.
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setIsAuthBootstrapped(true);
+      setHasAuthenticatedOnce(true);
     }
-  }, [auth.isAuthenticated, auth.isLoading, isAuthBootstrapped]);
+  }, [hasAuthenticatedOnce, isAuthenticated, isLoading]);
 
   useEffect(() => {
-    if (isSignupProcess || auth.isLoading || auth.isAuthenticated || isAuthBootstrapped) {
+    if (authState !== AUTH_STATES.LOGGED_OUT) {
       return;
     }
 
     const returnTo = localStorage.getItem('afterSignupRedirectUrl') || location.pathname;
 
     trace({ event: 'login-redirect-requested', returnTo });
-    auth.login({ appState: { returnTo } }).then(() => {
+    login({ appState: { returnTo } }).then(() => {
       localStorage.removeItem('afterSignupRedirectUrl');
     });
-  }, [
-    auth,
-    auth.isAuthenticated,
-    auth.isLoading,
-    isAuthBootstrapped,
-    isSignupProcess,
-    location.pathname,
-  ]);
+  }, [authState, location.pathname, login]);
 
-  if (isSignupProcess || !isAuthBootstrapped || !auth.isAuthenticated) {
+  if (![AUTH_STATES.AUTHENTICATED, AUTH_STATES.REFRESHING_AUTHENTICATED].includes(authState)) {
     return <Loading sx={{ pt: '60px' }} />;
   }
 

--- a/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
+++ b/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
@@ -16,6 +16,7 @@
 import React, { useEffect, useState } from 'react';
 // react admin
 import { Admin } from 'react-admin';
+import { useLocation } from 'react-router';
 
 import PropTypes from 'prop-types';
 
@@ -40,6 +41,7 @@ const trace = initTrace('PrivateAppRoot');
 export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
   const auth = useAuth();
   const config = useConfig();
+  const location = useLocation();
   const hasResolvedAuth = auth.isAuthenticated || !auth.isLoading;
   const [isAuthBootstrapped, setIsAuthBootstrapped] = useState(auth.isAuthenticated);
   const [queryClient] = useState(
@@ -85,7 +87,27 @@ export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
     }
   }, [auth.isAuthenticated, auth.isLoading, isAuthBootstrapped]);
 
-  if (!isAuthBootstrapped || isSignupProcess) {
+  useEffect(() => {
+    if (isSignupProcess || auth.isLoading || auth.isAuthenticated || isAuthBootstrapped) {
+      return;
+    }
+
+    const returnTo = localStorage.getItem('afterSignupRedirectUrl') || location.pathname;
+
+    trace({ event: 'login-redirect-requested', returnTo });
+    auth.login({ appState: { returnTo } }).then(() => {
+      localStorage.removeItem('afterSignupRedirectUrl');
+    });
+  }, [
+    auth,
+    auth.isAuthenticated,
+    auth.isLoading,
+    isAuthBootstrapped,
+    isSignupProcess,
+    location.pathname,
+  ]);
+
+  if (isSignupProcess || !isAuthBootstrapped || !auth.isAuthenticated) {
     return <Loading sx={{ pt: '60px' }} />;
   }
 

--- a/packages/components-organizations-registrar/src/components/organizations/CreateOrganization.jsx
+++ b/packages/components-organizations-registrar/src/components/organizations/CreateOrganization.jsx
@@ -312,7 +312,7 @@ const CreateOrganization = ({
                     sx={sxStyles.cancelButton}
                     onClick={() => (hasOrganisations ? navigate('/') : logout())}
                   >
-                    Cancel
+                    {hasOrganisations ? 'Cancel' : 'Log out & discard'}
                   </Button>
                   <OrganizationSubmitButton
                     title={buttonTitle}

--- a/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
+++ b/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
@@ -593,7 +593,7 @@ const OrganizationCreate = ({
                     sx={sx.cancelButton}
                     onClick={() => (hasOrganisations ? navigate('/') : logout())}
                   >
-                    Cancel
+                    {hasOrganisations ? 'Cancel' : 'Log out & discard'}
                   </Button>
                   <OrganizationSubmitButton />
                 </Box>

--- a/packages/components-organizations-registrar/src/utils/__tests__/reactAdminAuthProvider.test.js
+++ b/packages/components-organizations-registrar/src/utils/__tests__/reactAdminAuthProvider.test.js
@@ -1,5 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import { expect } from 'expect';
+// eslint-disable-next-line import/extensions
 import initReactAdminAuthProvider from '../reactAdminAuthProvider.js';
 
 describe('initReactAdminAuthProvider', () => {

--- a/packages/components-organizations-registrar/src/utils/__tests__/reactAdminAuthProvider.test.js
+++ b/packages/components-organizations-registrar/src/utils/__tests__/reactAdminAuthProvider.test.js
@@ -1,0 +1,35 @@
+import { describe, it, mock } from 'node:test';
+import { expect } from 'expect';
+import initReactAdminAuthProvider from '../reactAdminAuthProvider.js';
+
+describe('initReactAdminAuthProvider', () => {
+  it('returns the Auth0 user identity', () => {
+    const authProvider = initReactAdminAuthProvider({
+      logout: mock.fn(),
+      user: {
+        sub: 'auth0|user-id',
+        name: 'Auth User',
+        picture: 'https://example.com/avatar.png',
+      },
+    });
+
+    expect(authProvider.getIdentity()).toEqual({
+      id: 'auth0|user-id',
+      fullName: 'Auth User',
+      avatar: 'https://example.com/avatar.png',
+    });
+  });
+
+  it('does not throw when Auth0 clears the user during logout', () => {
+    const authProvider = initReactAdminAuthProvider({
+      logout: mock.fn(),
+      user: undefined,
+    });
+
+    expect(authProvider.getIdentity()).toEqual({
+      id: '',
+      fullName: undefined,
+      avatar: undefined,
+    });
+  });
+});

--- a/packages/components-organizations-registrar/src/utils/auth/__tests__/useSignupRedirect.test.jsx
+++ b/packages/components-organizations-registrar/src/utils/auth/__tests__/useSignupRedirect.test.jsx
@@ -32,17 +32,15 @@ describe('useSignupRedirect', () => {
     auth: PropTypes.shape({
       isAuthenticated: PropTypes.bool.isRequired,
       isLoading: PropTypes.bool.isRequired,
-      login: PropTypes.func.isRequired,
       logout: PropTypes.func.isRequired,
     }).isRequired,
   };
 
-  it('starts the normal login redirect after auth resolves logged out', async () => {
+  it('does not own the normal logged-out login redirect', async () => {
     const login = mock.fn(() => Promise.resolve());
     const auth = {
       isLoading: false,
       isAuthenticated: false,
-      login,
       logout: mock.fn(() => Promise.resolve()),
     };
 
@@ -52,8 +50,7 @@ describe('useSignupRedirect', () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => expect(login.mock.calls.length).toEqual(1));
-    expect(login.mock.calls[0].arguments).toEqual([{ appState: { returnTo: '/organizations' } }]);
+    expect(login.mock.calls.length).toEqual(0);
   });
 
   it('does not start normal login while an invitation signup URL is pending', async () => {

--- a/packages/components-organizations-registrar/src/utils/auth/__tests__/useSignupRedirect.test.jsx
+++ b/packages/components-organizations-registrar/src/utils/auth/__tests__/useSignupRedirect.test.jsx
@@ -36,23 +36,6 @@ describe('useSignupRedirect', () => {
     }).isRequired,
   };
 
-  it('does not own the normal logged-out login redirect', async () => {
-    const login = mock.fn(() => Promise.resolve());
-    const auth = {
-      isLoading: false,
-      isAuthenticated: false,
-      logout: mock.fn(() => Promise.resolve()),
-    };
-
-    render(
-      <MemoryRouter initialEntries={['/organizations']}>
-        <TestComponent auth={auth} />
-      </MemoryRouter>,
-    );
-
-    expect(login.mock.calls.length).toEqual(0);
-  });
-
   it('does not start normal login while an invitation signup URL is pending', async () => {
     const login = mock.fn(() => Promise.resolve());
     const logout = mock.fn(() => new Promise(() => {}));

--- a/packages/components-organizations-registrar/src/utils/auth/useSignupRedirect.js
+++ b/packages/components-organizations-registrar/src/utils/auth/useSignupRedirect.js
@@ -20,15 +20,15 @@ import { useEffect } from 'react';
 import { initTrace } from '../tracing.js';
 
 const trace = initTrace('useSignupRedirect');
+const REDIRECT_KEY = 'afterSignupRedirectUrl';
 
-const useSignupRedirect = ({ auth, options = {} }) => {
+const useSignupRedirect = ({ auth }) => {
   const [searchParams] = useSearchParams();
   const signupUrlParam = searchParams.get('signup_url');
 
   const [signupUrl, setSignupUrl] = useStore('signupUrl', null);
   const isSignupProcess = signupUrlParam != null || signupUrl != null;
 
-  const redirectKey = options.redirectKey ?? 'afterSignupRedirectUrl';
   const location = useLocation();
 
   useEffect(() => {
@@ -54,25 +54,12 @@ const useSignupRedirect = ({ auth, options = {} }) => {
     }
 
     trace({ event: 'signup-url-redirect-requested', pathname: location.pathname });
-    localStorage.setItem(redirectKey, location.pathname);
+    localStorage.setItem(REDIRECT_KEY, location.pathname);
 
     auth.logout().then(() => {
       window.location.replace(decodeURIComponent(signupUrl));
     });
-  }, [signupUrl, signupUrlParam, redirectKey, location.pathname, auth]);
-
-  useEffect(() => {
-    if (isSignupProcess || auth.isLoading || auth.isAuthenticated) {
-      return;
-    }
-
-    const returnTo = localStorage.getItem(redirectKey) || location.pathname;
-
-    trace({ event: 'login-redirect-requested', returnTo });
-    auth.login({ appState: { returnTo } }).then(() => {
-      localStorage.removeItem(redirectKey);
-    });
-  }, [isSignupProcess, auth.isLoading, auth.isAuthenticated, auth, location.pathname, redirectKey]);
+  }, [signupUrl, signupUrlParam, location.pathname, auth]);
 
   return { isSignupProcess };
 };

--- a/packages/components-organizations-registrar/src/utils/reactAdminAuthProvider.js
+++ b/packages/components-organizations-registrar/src/utils/reactAdminAuthProvider.js
@@ -35,7 +35,11 @@ const initReactAdminAuthProvider = (auth) => ({
   getPermissions: async () => {},
   // called when getting the user details. Ignore calls
   getIdentity: () => {
-    return { id: auth.user.sub, fullName: auth.user.name, avatar: auth.user.picture };
+    return {
+      id: auth.user?.sub ?? '',
+      fullName: auth.user?.name,
+      avatar: auth.user?.picture,
+    };
   },
 });
 


### PR DESCRIPTION
## Summary
- Make the registrar React Admin auth provider tolerate Auth0 clearing user data during logout.
- Move the normal logged-out login redirect into PrivateAppRoot so signup URL handling only owns invitation signup redirects.
- Clarify the no-organization cancel action as "Log out & discard".
- Add/update regression coverage for logout identity lookup and signup redirect ownership.

## Root cause
During logout, Auth0 can clear auth.user while React Admin still requests identity, causing the previous getIdentity implementation to dereference auth.user.sub. Separately, useSignupRedirect owned both signup redirects and normal logged-out login redirects, which made the logout/sign-up transition harder to reason about and could re-enter login flow from the wrong layer.

## Validation
- NODE_OPTIONS=--experimental-specifier-resolution=node ../../node_modules/.bin/eslint src/PrivateAppRoot.jsx src/components/organizations/CreateOrganization.jsx src/pages/organizations/OrganizationCreate.jsx src/utils/auth/useSignupRedirect.js src/utils/auth/__tests__/useSignupRedirect.test.jsx --fix
- ./node_modules/.bin/eslint --fix packages/components-organizations-registrar/src/utils/reactAdminAuthProvider.js packages/components-organizations-registrar/src/utils/__tests__/reactAdminAuthProvider.test.js
- node --enable-source-maps --import=global-jsdom/register --import=./setup-tests.js --test --test-concurrency=1 --experimental-test-module-mocks --test-reporter=spec --test-reporter-destination=stdout src/utils/auth/__tests__/useSignupRedirect.test.jsx src/utils/__tests__/reactAdminAuthProvider.test.js