### PR TITLE
[codex] Forward-port #587 to main

### DIFF
--- a/packages/components-organizations-registrar/package.json
+++ b/packages/components-organizations-registrar/package.json
@@ -69,6 +69,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:tracing": "cross-env TRACING_ENABLED=1 vite build",
     "build:watch": "vite build --watch",
     "prepublish": "vite build",
     "test": "node --enable-source-maps --import=global-jsdom/register --import=./setup-tests.js --test --test-concurrency=1 --experimental-test-module-mocks --test-reporter=spec --test-reporter-destination=stdout '**/*.test.js' '**/*.test.jsx'",

--- a/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
+++ b/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 // react admin
 import { Admin } from 'react-admin';
 
 import PropTypes from 'prop-types';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import { QueryClient } from '@tanstack/react-query';
 
 // components
@@ -32,21 +32,60 @@ import { useAuth } from './utils/auth/AuthContext.js';
 import useSignupRedirect from './utils/auth/useSignupRedirect.js';
 import remoteDataProvider from './utils/remoteDataProvider.js';
 import { useConfig } from './utils/ConfigContext.js';
+import { initTrace } from './utils/tracing.js';
 import theme from './theme/theme.js';
+
+const trace = initTrace('PrivateAppRoot');
 
 export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
   const auth = useAuth();
   const config = useConfig();
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnWindowFocus: false,
-      },
-    },
-  });
+  const hasResolvedAuth = auth.isAuthenticated || !auth.isLoading;
+  const [isAuthBootstrapped, setIsAuthBootstrapped] = useState(auth.isAuthenticated);
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
   const { isSignupProcess } = useSignupRedirect({ auth });
 
-  if (!auth.isAuthenticated || auth.isLoading || isSignupProcess) {
+  useEffect(() => {
+    trace({ event: 'mounted' });
+    return () => trace({ event: 'unmounted' });
+  }, []);
+
+  useEffect(() => {
+    trace({
+      event: 'auth-gate-state-changed',
+      isAuthenticated: auth.isAuthenticated,
+      isLoading: auth.isLoading,
+      hasResolvedAuth,
+      isAuthBootstrapped,
+      isSignupProcess,
+    });
+  }, [auth.isAuthenticated, auth.isLoading, hasResolvedAuth, isAuthBootstrapped, isSignupProcess]);
+
+  useEffect(() => {
+    if (!isAuthBootstrapped && auth.isAuthenticated) {
+      trace({
+        event: 'auth-bootstrapped',
+        isAuthenticated: auth.isAuthenticated,
+        isLoading: auth.isLoading,
+      });
+      // This is a one-way latch: once authenticated auth has resolved for this mount,
+      // keep the app bootstrapped so later token refreshes cannot remount the root by
+      // flipping auth.isLoading back on.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsAuthBootstrapped(true);
+    }
+  }, [auth.isAuthenticated, auth.isLoading, isAuthBootstrapped]);
+
+  if (!isAuthBootstrapped || isSignupProcess) {
     return <Loading sx={{ pt: '60px' }} />;
   }
 

--- a/packages/components-organizations-registrar/src/PublicAppRoot.jsx
+++ b/packages/components-organizations-registrar/src/PublicAppRoot.jsx
@@ -15,27 +15,38 @@
  *
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { QueryClient } from '@tanstack/react-query';
 import { Admin, CustomRoutes } from 'react-admin';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Dashboard from './components/Dashboard.jsx';
 import MainLayout from './layouts/MainLayout.jsx';
 import Footer from './components/Footer.jsx';
 import theme from './theme/theme.js';
 import remoteDataProvider from './utils/remoteDataProvider.js';
 import { useConfig } from './utils/ConfigContext.js';
+import { initTrace } from './utils/tracing.js';
+
+const trace = initTrace('PublicAppRoot');
 
 export const PublicAppRoot = ({ children }) => {
   const config = useConfig();
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnWindowFocus: false,
-      },
-    },
-  });
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
+
+  useEffect(() => {
+    trace({ event: 'mounted' });
+    return () => trace({ event: 'unmounted' });
+  }, []);
+
   return (
     <>
       <Admin

--- a/packages/components-organizations-registrar/src/components/common/CustomBooleanInput.jsx
+++ b/packages/components-organizations-registrar/src/components/common/CustomBooleanInput.jsx
@@ -16,7 +16,7 @@
 
 import { useCallback } from 'react';
 import PropTypes from 'prop-types';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import clsx from 'clsx';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormHelperText from '@mui/material/FormHelperText';

--- a/packages/components-organizations-registrar/src/pages/invitations/CreateOrganisationFromInvitation.jsx
+++ b/packages/components-organizations-registrar/src/pages/invitations/CreateOrganisationFromInvitation.jsx
@@ -32,11 +32,14 @@ import useCountryCodes from '@/utils/countryCodes.js';
 import { dataResources } from '@/utils/remoteDataProvider.js';
 import { useAuth } from '@/utils/auth/AuthContext.js';
 import { refreshAccessToken } from '@/utils/auth/refreshAccessTokens.js';
+import { initTrace } from '@/utils/tracing.js';
 import useSelectedOrganization from '@/state/selectedOrganizationState.js';
 import { SecretKeysPopup } from '../services/components/SecretKeysPopup/index.jsx';
 
+const trace = initTrace('CreateOrganizationFromInvitation');
+
 // eslint-disable-next-line complexity
-const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
+const CreateOrganizationFromInvitation = ({ InterceptOnOrganizationCreation }) => {
   const { code } = useParams();
   const refresh = useRefresh();
   const redirect = useRedirect();
@@ -51,6 +54,7 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
 
   const [isLoader, setIsLoader] = useState(false);
   const [secretKeys, setSecretKeys] = useState(null);
+  const [isFinalizingPostCreate, setIsFinalizingPostCreate] = useState(false);
   // popups
   const [isOpenSecretPopup, setIsOpenSecretPopup] = useState(false);
   const [isOpenNotExistingPopup, setIsOpenNotExistingPopup] = useState(false);
@@ -61,14 +65,22 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
     resource: 'organizations',
     mutationOptions: {
       onSuccess: async (resp) => {
-        refresh();
+        trace({
+          event: 'organization-create-succeeded',
+          organizationId: resp.id,
+          hasInvitationService: Boolean(resp.serviceEndpoints?.length),
+        });
         setDid(resp.id);
         setSecretKeys({ keys: resp.keys, authClients: resp.authClients });
       },
     },
   });
 
-  const { data: userData, isLoading: isUserDataLoading } = useGetOne(dataResources.USERS, {
+  const {
+    data: userData,
+    isLoading: isUserDataLoading,
+    refetch: refetchUserData,
+  } = useGetOne(dataResources.USERS, {
     id: user.sub,
   });
 
@@ -81,12 +93,14 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
       // eslint-disable-next-line complexity
       onError: (error) => {
         if (error?.body?.statusCode === 404) {
+          trace({ event: 'invitation-not-found', code });
           setIsOpenNotExistingPopup(true);
         }
         if (
           error?.body?.statusCode === 400 &&
           error?.body?.errorCode === MESSAGE_CODES.INVITATION_EXPIRED
         ) {
+          trace({ event: 'invitation-expired', code });
           setIsOpenExpiredPopup(true);
         }
       },
@@ -99,6 +113,22 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
       { id: invitationData?.inviterDid },
       { enabled: !!invitationData?.inviterDid },
     );
+
+  useEffect(() => {
+    trace({ event: 'mounted', code });
+    return () => trace({ event: 'unmounted', code });
+  }, [code]);
+
+  useEffect(() => {
+    trace({
+      event: 'load-state-changed',
+      isLoading,
+      invitationIsLoading,
+      isLoadingOrgData,
+      isUserDataLoading,
+      isFinalizingPostCreate,
+    });
+  }, [invitationIsLoading, isFinalizingPostCreate, isLoading, isLoadingOrgData, isUserDataLoading]);
 
   // Check if the user has an organization
   useEffect(() => {
@@ -123,6 +153,11 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
     const userEmail = userData?.email;
 
     if (inviteeEmail && userEmail && userEmail !== inviteeEmail) {
+      trace({
+        event: 'invitee-email-mismatch',
+        inviteeEmail,
+        userEmail,
+      });
       localStorage.setItem('createInvitationURL', window.location.pathname);
       logout(auth, window.location.href, true);
     }
@@ -130,17 +165,24 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
 
   useEffect(() => {
     if (secretKeys) {
-      if (InterceptOnCreate) {
+      if (InterceptOnOrganizationCreation) {
+        trace({ event: 'intercept-popup-opened' });
         // eslint-disable-next-line react-hooks/set-state-in-effect
         setIsInterceptOnCreateOpen(true);
       } else {
+        trace({ event: 'keys-popup-opened' });
         setIsOpenSecretPopup(true);
       }
     }
-  }, [InterceptOnCreate, secretKeys]);
+  }, [InterceptOnOrganizationCreation, secretKeys]);
 
   const handleSubmit = useCallback(
     async (formData) => {
+      trace({
+        event: 'organization-create-requested',
+        code,
+        hasInvitationService: Boolean(invitationData?.inviteeService?.length),
+      });
       await save({
         profile: {
           ...formData,
@@ -170,7 +212,7 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
         </Toolbar>
       </AppBar>
       <Stack sx={{ flexGrow: 1 }}>
-        {isLoader ? (
+        {isLoader || isFinalizingPostCreate ? (
           <Loading sx={sxStyles.loader} />
         ) : (
           <CreateOrganisation
@@ -192,15 +234,16 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
           </CreateOrganisation>
         )}
 
-        {InterceptOnCreate && (
-          <InterceptOnCreate
+        {InterceptOnOrganizationCreation && (
+          <InterceptOnOrganizationCreation
             isInterceptOnCreateOpen={isInterceptOnCreateOpen}
             serviceId={invitationData?.inviteeService?.[0]?.id}
-            // did={did}
             onNext={() => {
+              trace({ event: 'intercept-step-completed' });
               setIsOpenSecretPopup(true);
             }}
             onClose={() => {
+              trace({ event: 'intercept-step-closed' });
               setIsOpenSecretPopup(true);
             }}
             isIssueOrInspection={true}
@@ -211,14 +254,22 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
         <SecretKeysPopup
           isOpen={isOpenSecretPopup}
           secretKeys={secretKeys}
-          onClose={() => {
+          onClose={async () => {
+            trace({ event: 'keys-close-requested' });
+            setIsFinalizingPostCreate(true);
             setIsOpenSecretPopup(false);
-            // SecretKeysPopup does not await onClose, so absorb refresh failures here and always redirect.
-            refreshAccessToken({ getAccessToken, getAccessTokenWithPopup })
-              .catch(() => undefined)
-              .finally(() => {
-                redirect('/');
-              });
+            try {
+              await refreshAccessToken({ getAccessToken, getAccessTokenWithPopup });
+              trace({ event: 'access-token-refreshed' });
+            } catch {
+              trace({ event: 'access-token-refresh-failed' });
+              // refreshAccessToken logs non-interaction failures internally; do not block exit.
+            }
+            await refetchUserData().catch(() => undefined);
+            trace({ event: 'react-admin-refresh-requested' });
+            refresh();
+            trace({ event: 'redirect-requested', to: '/' });
+            redirect('/');
           }}
           wording={{
             title: 'Your organization is now registered on Velocity Network™.',
@@ -227,8 +278,6 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
           }}
           warningWording={{
             title: 'You must download a copy of your keys before exiting',
-            subtitle:
-              'They will not be available again and are critical for managing your organization data.',
           }}
         />
 
@@ -263,7 +312,7 @@ const CreateOrganizationFromInvitation = ({ InterceptOnCreate }) => {
 
 // eslint-disable-next-line better-mutation/no-mutation
 CreateOrganizationFromInvitation.propTypes = {
-  InterceptOnCreate: PropTypes.elementType,
+  InterceptOnOrganizationCreation: PropTypes.elementType,
 };
 
 export default CreateOrganizationFromInvitation;

--- a/packages/components-organizations-registrar/src/pages/organizations/OrganizationAddService.jsx
+++ b/packages/components-organizations-registrar/src/pages/organizations/OrganizationAddService.jsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback } from 'react';
 import { useGetList } from 'react-admin';
 import PropTypes from 'prop-types';
-import { kebabCase } from 'lodash-es';
 
 import Loading from '../../components/Loading.jsx';
 import Popup from '../../components/common/Popup.jsx';
@@ -25,78 +24,40 @@ import { dataResources } from '../../utils/remoteDataProvider.js';
 
 import { ServiceEndpointSelection } from '../services/components/ServiceEndpointSelection/index.jsx';
 import { ServiceTypeSelection } from '../services/components/ServiceTypeSelection/index.jsx';
-import { SecretKeysPopup } from '../services/components/SecretKeysPopup/index.jsx';
-import { useIsIssuingInspection } from '../services/hooks/useIsIssuingInspection.js';
 import { buildPayload } from '../services/utils/buildPayload.js';
+
+export const ORGANIZATION_ADD_SERVICE_STEPS = {
+  SELECT_TYPE: 'selectType',
+  CONFIGURE_SERVICE: 'configureService',
+};
 
 const OrganizationAddService = ({
   isModalOpened,
   isSending,
   onCreate,
-  isCreated,
-  secretKeys,
+  onDoLater,
   onClose,
-  // did,
+  selectedStep,
+  setSelectedStep,
   selectedServiceType,
   setSelectedServiceType,
-  selectedCAO,
-  setSelectedCAO,
-  InterceptOnCreate,
 }) => {
-  const [selectedStep, setSelectedStep] = useState(1);
-  const [isKeysPopupOpened, setIsKeysPopupOpened] = useState(false);
-  const [isInterceptOnCreateOpen, setIsInterceptOnCreateOpen] = useState(false);
-
-  const serviceId = useMemo(() => {
-    if (selectedServiceType) {
-      const type = selectedServiceType.id.match(/.+v1/);
-      return `${kebabCase(type[0])}-1`;
-    }
-    return '';
-  }, [selectedServiceType]);
-
-  const openedStateRef = useRef(isModalOpened);
-
-  const { isIssuingOrInspection, isCAO } = useIsIssuingInspection(selectedServiceType);
-
-  const { data: credentialAgentOperators, isLoading: isLoadingCAO } = useGetList(
+  const { data: credentialAgentOperators = [], isLoading: isLoadingCAO } = useGetList(
     dataResources.SEARCH_PROFILES,
     {
       filter: { serviceTypes: 'CredentialAgentOperator' },
     },
   );
 
-  // clear previous state after close
-  useEffect(() => {
-    const reset = () => {
-      setSelectedStep(1);
-    };
-    if (openedStateRef.current === false && isModalOpened && !isCreated) {
-      reset();
-    }
-
-    // eslint-disable-next-line better-mutation/no-mutation
-    openedStateRef.current = isModalOpened;
-    return reset;
-  }, [isModalOpened, isCreated]);
-
-  useEffect(() => {
-    if (InterceptOnCreate && isCreated) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setIsInterceptOnCreateOpen(true);
-    }
-  }, [InterceptOnCreate, isCreated]);
-
   const onCreateCallback = useCallback(
     (service) => {
       const type = selectedServiceType.id.match(/.+v1/);
-      setSelectedCAO(service.serviceEndpoint.split('#')[0]);
-      const payload = buildPayload(service, type[0]);
       onCreate({
-        ...payload,
+        selectedCAO: service.serviceEndpoint.split('#')[0],
+        serviceData: buildPayload(service, type[0]),
       });
     },
-    [onCreate, selectedServiceType.id, setSelectedCAO],
+    [onCreate, selectedServiceType],
   );
 
   return (
@@ -110,57 +71,26 @@ const OrganizationAddService = ({
       >
         {isSending && <Loading color="error" sx={{ pl: '10px' }} size={26} />}
 
-        {selectedStep === 1 && (
+        {selectedStep === ORGANIZATION_ADD_SERVICE_STEPS.SELECT_TYPE && (
           <ServiceTypeSelection
-            handleNext={() => setSelectedStep(2)}
+            handleNext={() => setSelectedStep(ORGANIZATION_ADD_SERVICE_STEPS.CONFIGURE_SERVICE)}
             isLoading={isLoadingCAO}
             selectedServiceType={selectedServiceType}
             setSelectedServiceType={setSelectedServiceType}
-            onDoLater={() => {
-              onCreate(null);
-            }}
+            onDoLater={onDoLater}
           />
         )}
-        {selectedStep === 2 && (
-          <ServiceEndpointSelection
-            credentialAgentOperators={credentialAgentOperators}
-            isIssueOrInspection={isIssuingOrInspection}
-            selectedServiceType={selectedServiceType}
-            inProgress={isSending}
-            onCreate={onCreateCallback}
-            handleBack={() => setSelectedStep(1)}
-          />
-        )}
+        {selectedStep === ORGANIZATION_ADD_SERVICE_STEPS.CONFIGURE_SERVICE &&
+          selectedServiceType && (
+            <ServiceEndpointSelection
+              credentialAgentOperators={credentialAgentOperators}
+              selectedServiceType={selectedServiceType}
+              inProgress={isSending}
+              onCreate={onCreateCallback}
+              showBackButton={false}
+            />
+          )}
       </Popup>
-
-      <InterceptOnCreate
-        isInterceptOnCreateOpen={isInterceptOnCreateOpen}
-        serviceId={serviceId}
-        onNext={() => setIsKeysPopupOpened(true)}
-        onClose={() => setIsKeysPopupOpened(true)}
-        isIssueOrInspection={isIssuingOrInspection}
-        selectedCAO={selectedCAO}
-        isCAO={isCAO}
-      />
-
-      <SecretKeysPopup
-        isOpen={isKeysPopupOpened}
-        secretKeys={secretKeys}
-        onClose={() => {
-          setIsKeysPopupOpened(false);
-          onClose();
-        }}
-        wording={{
-          title: 'Your organization is now registered on Velocity Network™.',
-          subtitle:
-            'Please save your organization’s unique keys in a secure location, as they will not be available once you close this window.',
-        }}
-        warningWording={{
-          title: 'You must download a copy of your keys before exiting',
-          subtitle:
-            'They will not be available again and are critical for managing your organization data.',
-        }}
-      />
     </>
   );
 };
@@ -174,19 +104,15 @@ OrganizationAddService.propTypes = {
   isModalOpened: PropTypes.bool,
   isSending: PropTypes.bool,
   onCreate: PropTypes.func,
-  isCreated: PropTypes.bool,
-  // eslint-disable-next-line react/forbid-prop-types
-  secretKeys: PropTypes.object,
+  onDoLater: PropTypes.func,
   onClose: PropTypes.func,
-  did: PropTypes.string,
+  selectedStep: PropTypes.string.isRequired,
+  setSelectedStep: PropTypes.func.isRequired,
   selectedServiceType: PropTypes.shape({
     id: PropTypes.string,
     title: PropTypes.string,
   }),
   setSelectedServiceType: PropTypes.func,
-  selectedCAO: PropTypes.string,
-  setSelectedCAO: PropTypes.func,
-  InterceptOnCreate: PropTypes.func,
 };
 
 export default OrganizationAddService;

--- a/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
+++ b/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { useState, useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router';
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router';
 import {
   AutocompleteInput,
   Button,
@@ -30,7 +30,7 @@ import {
   FormDataConsumer,
   useGetOne,
   useNotify,
-  useGetList,
+  useRefresh,
 } from 'react-admin';
 
 import { Box, Stack, Tooltip, Typography, Grid } from '@mui/material';
@@ -62,19 +62,24 @@ import useCountryCodes from '@/utils/countryCodes.js';
 import { useAuth } from '@/utils/auth/AuthContext.js';
 import { refreshAccessToken } from '@/utils/auth/refreshAccessTokens.js';
 import { dataResources } from '@/utils/remoteDataProvider.js';
+import { initTrace } from '@/utils/tracing.js';
 
 import AuthorityRegistrationNumbersInput from './components/AuthorityRegistrationInput.jsx';
 import { LinkedInRegistrationInput } from './components/LinkedInRegistrationInput.jsx';
 import { OrganizationBrand } from './components/OrganizationBrand.jsx';
 import { OrganizationSubmitButton } from './components/OrganizationSubmitButton.jsx';
 import { OrganizationCreateTitle } from './components/OrganizationCreateTitle.jsx';
-import ServiceCreateFormContainer from './OrganizationAddService.jsx';
+import ServiceCreateFormContainer, {
+  ORGANIZATION_ADD_SERVICE_STEPS,
+} from './OrganizationAddService.jsx';
 import {
   requestOptions,
   organizationPlaceholder,
   validateName,
   validateEmail,
 } from './utils/index.js';
+import { SecretKeysPopup } from '../services/components/SecretKeysPopup/index.jsx';
+import { useIsIssuingInspection } from '../services/hooks/useIsIssuingInspection.js';
 
 export const defaultBrandValue = [
   {
@@ -87,14 +92,25 @@ export const isAddBrandDisabled = (values) => {
   return values && !allBrandsFilled(values) && (values.length % 2 === 0 || values.length !== 1);
 };
 
+const ORGANIZATION_CREATE_FLOW_STEPS = {
+  DETAILS: 'details',
+  INTERCEPT: 'intercept',
+  KEYS: 'keys',
+  ...ORGANIZATION_ADD_SERVICE_STEPS,
+};
+
+const trace = initTrace('OrganizationCreate');
+
+/* eslint-disable complexity */
 const OrganizationCreate = ({
   CreateServiceComponent = ServiceCreateFormContainer,
   MockOrganization,
+  InterceptOnOrganizationCreation,
 }) => {
   const navigate = useNavigate();
-  const location = useLocation();
   const notify = useNotify();
   const redirect = useRedirect();
+  const refresh = useRefresh();
 
   const { logout, user, getAccessToken, getAccessTokenWithPopup } = useAuth();
 
@@ -102,18 +118,33 @@ const OrganizationCreate = ({
   const [did, setDid] = useSelectedOrganization();
 
   const [organizationData, setOrganizationData] = useState(null);
-  const [isServiceCreated, setServiceCreated] = useState(false);
   const [secretKeys, setSecretKeys] = useState(null);
   const [isCreateRequestLoading, setCreateRequestLoading] = useState(false);
+  const [isFinalizingPostCreate, setIsFinalizingPostCreate] = useState(false);
   const [hasOrganisations, setHasOrganisations] = useState(false);
-  const [serviceType, setServiceType] = useState('');
+  const [serviceType, setServiceType] = useState(null);
   const [selectedCAO, setSelectedCAO] = useState('');
   const [initialRecord, setInitialRecord] = useState({ profile: { name: '' } });
+  const [flowStep, setFlowStep] = useState(ORGANIZATION_CREATE_FLOW_STEPS.DETAILS);
 
-  const { refetch } = useGetList('organizations', undefined, {
-    enabled: false,
-  });
-  const { data: userData, isLoading: isUserDataLoading } = useGetOne(
+  const isServiceFlowOpened =
+    flowStep === ORGANIZATION_CREATE_FLOW_STEPS.SELECT_TYPE ||
+    flowStep === ORGANIZATION_CREATE_FLOW_STEPS.CONFIGURE_SERVICE;
+  const { isIssuingOrInspection, isCAO } = useIsIssuingInspection(serviceType);
+  const serviceId = useMemo(() => {
+    if (!serviceType?.id) {
+      return '';
+    }
+
+    const type = serviceType.id.match(/.+v1/);
+    return type ? `${kebabCase(type[0])}-1` : '';
+  }, [serviceType]);
+
+  const {
+    data: userData,
+    isLoading: isUserDataLoading,
+    refetch: refetchUserData,
+  } = useGetOne(
     dataResources.USERS,
     {
       id: user.sub,
@@ -123,6 +154,21 @@ const OrganizationCreate = ({
       ...requestOptions,
     },
   );
+
+  useEffect(() => {
+    trace({ event: 'mounted' });
+    return () => trace({ event: 'unmounted' });
+  }, []);
+
+  useEffect(() => {
+    trace({
+      event: 'load-state-changed',
+      isLoading,
+      isUserDataLoading,
+      isFinalizingPostCreate,
+      flowStep,
+    });
+  }, [flowStep, isFinalizingPostCreate, isLoading, isUserDataLoading]);
 
   useEffect(() => {
     (async () => {
@@ -144,50 +190,102 @@ const OrganizationCreate = ({
   const { save } = useCreateController({
     resource: 'organizations',
     mutationOptions: {
-      onSuccess: async (resp) => {
+      onSuccess: (resp) => {
+        const hasInitialService = Boolean(resp.serviceEndpoints?.length);
+        const toFlowStep =
+          InterceptOnOrganizationCreation && hasInitialService
+            ? ORGANIZATION_CREATE_FLOW_STEPS.INTERCEPT
+            : ORGANIZATION_CREATE_FLOW_STEPS.KEYS;
+        trace({
+          event: 'organization-create-succeeded',
+          organizationId: resp.id,
+          toFlowStep,
+          hasInitialService,
+        });
         setDid(resp.id);
         setSecretKeys({ keys: resp.keys, authClients: resp.authClients });
-        setServiceCreated(true);
         setCreateRequestLoading(false);
-        try {
-          await refreshAccessToken({ getAccessToken, getAccessTokenWithPopup });
-        } catch {
-          // refreshAccessToken logs non-interaction failures internally; do not block success flow.
-        }
-        refetch();
-        navigate(-1);
+        setFlowStep(toFlowStep);
       },
       onError: ({ body }) => {
+        trace({ event: 'organization-create-failed', errorCode: body.errorCode });
         setCreateRequestLoading(false);
         if (body.errorCode === 'website_already_exists') {
           notify(ERRORS.websiteExists, { type: 'error' }, { autoHideDuration: 5000 });
         } else {
           notify(body.message || ERRORS.default, { type: 'error' }, { autoHideDuration: 5000 });
         }
-        navigate(-1);
-        setServiceCreated(false);
       },
     },
   });
 
+  const resetCreateFlow = () => {
+    trace({ event: 'create-flow-reset', fromFlowStep: flowStep, serviceTypeId: serviceType?.id });
+    setCreateRequestLoading(false);
+    setFlowStep(ORGANIZATION_CREATE_FLOW_STEPS.DETAILS);
+    setOrganizationData(null);
+    setSecretKeys(null);
+    setServiceType(null);
+    setSelectedCAO('');
+  };
+
   const goToCreateServiceStep = (data) => {
+    trace({
+      event: 'service-popup-step-requested',
+      fromFlowStep: flowStep,
+      toFlowStep: ORGANIZATION_CREATE_FLOW_STEPS.SELECT_TYPE,
+      serviceTypeId: serviceType?.id,
+    });
     setOrganizationData(data);
-    navigate('service');
+    setServiceType(null);
+    setFlowStep(ORGANIZATION_CREATE_FLOW_STEPS.SELECT_TYPE);
+  };
+
+  const onServicePopupStepRequested = (toFlowStepOrUpdater) => {
+    const toFlowStep =
+      typeof toFlowStepOrUpdater === 'function'
+        ? toFlowStepOrUpdater(flowStep)
+        : toFlowStepOrUpdater;
+    trace({
+      event: 'service-popup-step-requested',
+      fromFlowStep: flowStep,
+      toFlowStep,
+      serviceTypeId: serviceType?.id,
+    });
+    setFlowStep(toFlowStep);
   };
 
   const onClose = () => {
-    if (isServiceCreated === true) {
-      redirect('list', 'services');
-    } else {
-      navigate(-1);
-      setOrganizationData(null);
-      setServiceCreated(false);
-    }
+    resetCreateFlow();
   };
 
-  // eslint-disable-next-line complexity
-  const onCreate = async (serviceData) => {
+  const onKeysClose = async () => {
+    trace({ event: 'keys-close-requested', flowStep, serviceTypeId: serviceType?.id });
+    setIsFinalizingPostCreate(true);
+    try {
+      await refreshAccessToken({ getAccessToken, getAccessTokenWithPopup });
+      trace({ event: 'access-token-refreshed' });
+    } catch {
+      trace({ event: 'access-token-refresh-failed' });
+      // refreshAccessToken logs non-interaction failures internally; do not block exit.
+    }
+    await refetchUserData().catch(() => undefined);
+    trace({ event: 'react-admin-refresh-requested' });
+    refresh();
+    trace({ event: 'redirect-requested', resource: 'services', type: 'list' });
+    redirect('list', 'services');
+  };
+
+  const onCreate = async ({ serviceData = null, selectedCAO: nextSelectedCAO = '' } = {}) => {
+    trace({
+      event: 'organization-create-requested',
+      flowStep,
+      serviceTypeId: serviceType?.id,
+      selectedCAO: nextSelectedCAO,
+      hasInitialService: Boolean(serviceData),
+    });
     setCreateRequestLoading(true);
+    setSelectedCAO(nextSelectedCAO);
     const organization = {
       ...organizationData,
       profile: {
@@ -210,7 +308,7 @@ const OrganizationCreate = ({
       serviceEndpoints: serviceData
         ? [
             {
-              id: `${did}#${kebabCase(serviceData.type)}-1`,
+              id: `${did ? `${did}` : ''}#${kebabCase(serviceData.type)}-1`,
               ...serviceData,
             },
           ]
@@ -218,7 +316,7 @@ const OrganizationCreate = ({
     });
   };
 
-  if (isLoading || isUserDataLoading) {
+  if (isLoading || isUserDataLoading || isFinalizingPostCreate) {
     return <Loading sx={{ pt: '60px' }} />;
   }
   return (
@@ -230,303 +328,343 @@ const OrganizationCreate = ({
 
         <Form record={initialRecord} onSubmit={goToCreateServiceStep} noValidate mode="onTouched">
           <FormDataConsumer>
-            {
-              // eslint-disable-next-line complexity
-              ({ formData }) => (
-                <>
-                  <Grid container spacing={4} rowSpacing={1}>
-                    <Grid size={{ xs: 6 }}>
-                      <Stack container flex={1} flexDirection="column">
-                        <Grid size={{ xs: 12 }}>
-                          <Stack flexDirection="row" gap={1.75}>
-                            <TextInput
-                              fullWidth
-                              label="Legal Name"
-                              source="profile.name"
-                              validate={validateName}
-                            />
-                          </Stack>
-                        </Grid>
-                        <Grid size={{ xs: 12 }}>
-                          <Stack flexDirection="row" gap={1.75}>
-                            <TextInput
-                              fullWidth
-                              label="Website"
-                              source="profile.website"
-                              validate={[...validateWebsiteStrict, required()]}
-                            />
-                            <Box mt={2}>
-                              <Tooltip title={WEBSITE_HINT}>
-                                <InfoIcon color="info" fontSize="small" cursor="pointer" />
-                              </Tooltip>
-                            </Box>
-                          </Stack>
-                        </Grid>
-                        <Grid size={{ xs: 12 }}>
+            {({ formData }) => (
+              <>
+                <Grid container spacing={4} rowSpacing={1}>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack container flex={1} flexDirection="column">
+                      <Grid size={{ xs: 12 }}>
+                        <Stack flexDirection="row" gap={1.75}>
                           <TextInput
                             fullWidth
-                            label="Address"
-                            source="profile.physicalAddress.line1"
-                            validate={[required(), maxLength(1024)]}
+                            label="Legal Name"
+                            source="profile.name"
+                            validate={validateName}
                           />
-                        </Grid>
-                        <Grid size={{ xs: 12 }}>
-                          <AutocompleteInput
-                            label="Country"
-                            source="profile.location.countryCode"
-                            choices={countryCodes}
-                            validate={required()}
+                        </Stack>
+                      </Grid>
+                      <Grid size={{ xs: 12 }}>
+                        <Stack flexDirection="row" gap={1.75}>
+                          <TextInput
+                            fullWidth
+                            label="Website"
+                            source="profile.website"
+                            validate={[...validateWebsiteStrict, required()]}
                           />
-                        </Grid>
-                      </Stack>
-                    </Grid>
-                    <Grid size={{ xs: 6 }} pb={1}>
-                      <CustomImageInput label={false} editMode addTo="profile" />
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <TextInput
-                        fullWidth
-                        label="LinkedIn Page"
-                        source="profile.linkedInProfile"
-                        validate={[...validateWebsite, required()]}
-                      />
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <LinkedInRegistrationInput
-                        formData={formData.profile}
-                        source="profile.registrationNumbers"
-                      />
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <Stack flexDirection="row" gap={1.75}>
+                          <Box mt={2}>
+                            <Tooltip title={WEBSITE_HINT}>
+                              <InfoIcon color="info" fontSize="small" cursor="pointer" />
+                            </Tooltip>
+                          </Box>
+                        </Stack>
+                      </Grid>
+                      <Grid size={{ xs: 12 }}>
                         <TextInput
                           fullWidth
-                          label="Support Email"
-                          source="profile.contactEmail"
-                          validate={validateEmail}
+                          label="Address"
+                          source="profile.physicalAddress.line1"
+                          validate={[required(), maxLength(1024)]}
                         />
-                        <Box mt={2}>
-                          <Tooltip title={SUPPORT_EMAIL_HINT}>
-                            <InfoIcon color="info" fontSize="small" cursor="pointer" />
-                          </Tooltip>
-                        </Box>
-                      </Stack>
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <Stack flexDirection="row" gap={1.75}>
-                        <TextInput
-                          fullWidth
-                          label="Technical Contact Email"
-                          source="profile.technicalEmail"
-                          validate={validateEmail}
+                      </Grid>
+                      <Grid size={{ xs: 12 }}>
+                        <AutocompleteInput
+                          label="Country"
+                          source="profile.location.countryCode"
+                          choices={countryCodes}
+                          validate={required()}
                         />
-                        <Box mt={2}>
-                          <Tooltip title={TECHNICAL_EMAIL_HINT}>
-                            <InfoIcon color="info" fontSize="small" cursor="pointer" />
-                          </Tooltip>
-                        </Box>
-                      </Stack>
-                    </Grid>
-                    <AuthorityRegistrationNumbersInput
-                      source="profile.registrationNumbers"
-                      orientation="horizontal"
-                    />
-                    <Grid size={{ xs: 12 }}>
-                      <TextInput
-                        fullWidth
-                        multiline
-                        label="Short Description"
-                        placeholder={organizationPlaceholder}
-                        source="profile.description"
-                        validate={required()}
-                      />
-                    </Grid>
-                    <Grid size={{ xs: 12 }}>
-                      <Typography variant="h5">Key individuals</Typography>
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <Stack flexDirection="row" gap={1.75}>
-                        <Typography variant="body1" my={2} sx={sx.sectionTitle}>
-                          Administrator’s Details
-                        </Typography>
-                        <Box mt={2}>
-                          <Tooltip title={ADMINISTRATOR_DETAILS_HINT}>
-                            <InfoIcon color="info" fontSize="small" cursor="pointer" />
-                          </Tooltip>
-                        </Box>
-                      </Stack>
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <Stack flexDirection="row" gap={1.75}>
-                        <Typography variant="body1" my={2} sx={sx.sectionTitle}>
-                          Signatory Authority’s Details
-                        </Typography>
-                        <Box mt={2}>
-                          <Tooltip title={SIGNATORY_DETAILS_HINT}>
-                            <InfoIcon color="info" fontSize="small" cursor="pointer" />
-                          </Tooltip>
-                        </Box>
-                      </Stack>
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <Stack flexDirection="row" gap={1.75}>
-                        <TextInput
-                          fullWidth
-                          label="First name"
-                          source="profile.adminGivenName"
-                          validate={[maxLength(1024), required()]}
-                          defaultValue={userData ? userData.givenName : ''}
-                        />
-                      </Stack>
-                      <Stack flexDirection="row" gap={1.75}>
-                        <TextInput
-                          fullWidth
-                          label="Last name"
-                          source="profile.adminFamilyName"
-                          validate={[maxLength(1024), required()]}
-                          defaultValue={userData ? userData.familyName : ''}
-                        />
-                      </Stack>
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <Stack flexDirection="row" gap={1.75}>
-                        <TextInput
-                          fullWidth
-                          label="First name"
-                          source="profile.signatoryGivenName"
-                          validate={[maxLength(1024), required()]}
-                        />
-                      </Stack>
-                      <Stack flexDirection="row" gap={1.75}>
-                        <TextInput
-                          fullWidth
-                          label="Last name"
-                          source="profile.signatoryFamilyName"
-                          validate={[maxLength(1024), required()]}
-                        />
-                      </Stack>
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <Stack flexDirection="row" gap={1.75}>
-                        <TextInput
-                          fullWidth
-                          label="Job Title"
-                          source="profile.adminTitle"
-                          validate={[maxLength(1024), required()]}
-                        />
-                      </Stack>
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <Stack flexDirection="row" gap={1.75}>
-                        <TextInput
-                          fullWidth
-                          label="Job Title"
-                          source="profile.signatoryTitle"
-                          validate={[maxLength(1024), required()]}
-                        />
-                      </Stack>
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <Stack flexDirection="row" gap={1.75}>
-                        <TextInput
-                          fullWidth
-                          label="Email"
-                          source="profile.adminEmail"
-                          validate={validateEmail}
-                          defaultValue={userData ? userData.email : ''}
-                        />
-                      </Stack>
-                    </Grid>
-                    <Grid size={{ xs: 6 }}>
-                      <Stack flexDirection="row" gap={1.75}>
-                        <TextInput
-                          fullWidth
-                          label="Email"
-                          source="profile.signatoryEmail"
-                          validate={validateEmail}
-                        />
-                        <Box mt={2}>
-                          <Tooltip title={SIGNATORY_EMAIL_HINT}>
-                            <InfoIcon color="info" fontSize="small" cursor="pointer" />
-                          </Tooltip>
-                        </Box>
-                      </Stack>
-                    </Grid>
-                    <Grid size={{ xs: 12 }}>
-                      <Typography variant="h4" mb={2} mt={4}>
-                        Commercial Names
-                      </Typography>
-                    </Grid>
-                    <Grid size={{ xs: 12 }}>
-                      <ArrayInput
-                        source="profile.commercialEntities"
-                        defaultValue={defaultBrandValue}
-                        sx={{ '& .RaArrayInput-label': { display: 'none' } }}
-                      >
-                        <SimpleFormIterator
-                          addButton={
-                            <PlusButtonBlock
-                              style={sx.plusButtonBlock}
-                              disabled={!allBrandsFilled(formData.profile.commercialEntities)}
-                              position={formData.profile?.commercialEntities?.length}
-                            />
-                          }
-                          disableAdd={isAddBrandDisabled(formData.profile.commercialEntities)}
-                          fullWidth
-                          sx={sx.brandList}
-                        >
-                          <FormDataConsumer>
-                            {({ scopedFormData }) => {
-                              return (
-                                <OrganizationBrand
-                                  formData={formData}
-                                  scopedFormData={scopedFormData}
-                                />
-                              );
-                            }}
-                          </FormDataConsumer>
-                        </SimpleFormIterator>
-                      </ArrayInput>
-                    </Grid>
+                      </Grid>
+                    </Stack>
                   </Grid>
-                  <Box display="flex" justifyContent="center" pt={4}>
-                    <Button
-                      variant="outlined"
-                      color="secondary"
-                      size="large"
-                      sx={sx.cancelButton}
-                      onClick={() => (hasOrganisations ? navigate('/') : logout())}
-                    >
-                      Cancel
-                    </Button>
-                    <OrganizationSubmitButton />
-                  </Box>
-                  <CreateServiceComponent
-                    isModalOpened={/create\/service/.test(location.pathname) || isServiceCreated}
-                    isSending={isCreateRequestLoading}
-                    onClose={onClose}
-                    onCreate={onCreate}
-                    isCreated={isServiceCreated}
-                    secretKeys={secretKeys}
-                    did={did}
-                    selectedServiceType={serviceType}
-                    setSelectedServiceType={setServiceType}
-                    selectedCAO={selectedCAO}
-                    setSelectedCAO={setSelectedCAO}
+                  <Grid size={{ xs: 6 }} pb={1}>
+                    <CustomImageInput label={false} editMode addTo="profile" />
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <TextInput
+                      fullWidth
+                      label="LinkedIn Page"
+                      source="profile.linkedInProfile"
+                      validate={[...validateWebsite, required()]}
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <LinkedInRegistrationInput
+                      formData={formData.profile}
+                      source="profile.registrationNumbers"
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <TextInput
+                        fullWidth
+                        label="Support Email"
+                        source="profile.contactEmail"
+                        validate={validateEmail}
+                      />
+                      <Box mt={2}>
+                        <Tooltip title={SUPPORT_EMAIL_HINT}>
+                          <InfoIcon color="info" fontSize="small" cursor="pointer" />
+                        </Tooltip>
+                      </Box>
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <TextInput
+                        fullWidth
+                        label="Technical Contact Email"
+                        source="profile.technicalEmail"
+                        validate={validateEmail}
+                      />
+                      <Box mt={2}>
+                        <Tooltip title={TECHNICAL_EMAIL_HINT}>
+                          <InfoIcon color="info" fontSize="small" cursor="pointer" />
+                        </Tooltip>
+                      </Box>
+                    </Stack>
+                  </Grid>
+                  <AuthorityRegistrationNumbersInput
+                    source="profile.registrationNumbers"
+                    orientation="horizontal"
                   />
-                </>
-              )
-            }
+                  <Grid size={{ xs: 12 }}>
+                    <TextInput
+                      fullWidth
+                      multiline
+                      label="Short Description"
+                      placeholder={organizationPlaceholder}
+                      source="profile.description"
+                      validate={required()}
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 12 }}>
+                    <Typography variant="h5">Key individuals</Typography>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <Typography variant="body1" my={2} sx={sx.sectionTitle}>
+                        Administrator’s Details
+                      </Typography>
+                      <Box mt={2}>
+                        <Tooltip title={ADMINISTRATOR_DETAILS_HINT}>
+                          <InfoIcon color="info" fontSize="small" cursor="pointer" />
+                        </Tooltip>
+                      </Box>
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <Typography variant="body1" my={2} sx={sx.sectionTitle}>
+                        Signatory Authority’s Details
+                      </Typography>
+                      <Box mt={2}>
+                        <Tooltip title={SIGNATORY_DETAILS_HINT}>
+                          <InfoIcon color="info" fontSize="small" cursor="pointer" />
+                        </Tooltip>
+                      </Box>
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <TextInput
+                        fullWidth
+                        label="First name"
+                        source="profile.adminGivenName"
+                        validate={[maxLength(1024), required()]}
+                        defaultValue={userData ? userData.givenName : ''}
+                      />
+                    </Stack>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <TextInput
+                        fullWidth
+                        label="Last name"
+                        source="profile.adminFamilyName"
+                        validate={[maxLength(1024), required()]}
+                        defaultValue={userData ? userData.familyName : ''}
+                      />
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <TextInput
+                        fullWidth
+                        label="First name"
+                        source="profile.signatoryGivenName"
+                        validate={[maxLength(1024), required()]}
+                      />
+                    </Stack>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <TextInput
+                        fullWidth
+                        label="Last name"
+                        source="profile.signatoryFamilyName"
+                        validate={[maxLength(1024), required()]}
+                      />
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <TextInput
+                        fullWidth
+                        label="Job Title"
+                        source="profile.adminTitle"
+                        validate={[maxLength(1024), required()]}
+                      />
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <TextInput
+                        fullWidth
+                        label="Job Title"
+                        source="profile.signatoryTitle"
+                        validate={[maxLength(1024), required()]}
+                      />
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <TextInput
+                        fullWidth
+                        label="Email"
+                        source="profile.adminEmail"
+                        validate={validateEmail}
+                        defaultValue={userData ? userData.email : ''}
+                      />
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 6 }}>
+                    <Stack flexDirection="row" gap={1.75}>
+                      <TextInput
+                        fullWidth
+                        label="Email"
+                        source="profile.signatoryEmail"
+                        validate={validateEmail}
+                      />
+                      <Box mt={2}>
+                        <Tooltip title={SIGNATORY_EMAIL_HINT}>
+                          <InfoIcon color="info" fontSize="small" cursor="pointer" />
+                        </Tooltip>
+                      </Box>
+                    </Stack>
+                  </Grid>
+                  <Grid size={{ xs: 12 }}>
+                    <Typography variant="h4" mb={2} mt={4}>
+                      Commercial Names
+                    </Typography>
+                  </Grid>
+                  <Grid size={{ xs: 12 }}>
+                    <ArrayInput
+                      source="profile.commercialEntities"
+                      defaultValue={defaultBrandValue}
+                      sx={{ '& .RaArrayInput-label': { display: 'none' } }}
+                    >
+                      <SimpleFormIterator
+                        addButton={
+                          <PlusButtonBlock
+                            style={sx.plusButtonBlock}
+                            disabled={!allBrandsFilled(formData.profile.commercialEntities)}
+                            position={formData.profile?.commercialEntities?.length}
+                          />
+                        }
+                        disableAdd={isAddBrandDisabled(formData.profile.commercialEntities)}
+                        fullWidth
+                        sx={sx.brandList}
+                      >
+                        <FormDataConsumer>
+                          {({ scopedFormData }) => {
+                            return (
+                              <OrganizationBrand
+                                formData={formData}
+                                scopedFormData={scopedFormData}
+                              />
+                            );
+                          }}
+                        </FormDataConsumer>
+                      </SimpleFormIterator>
+                    </ArrayInput>
+                  </Grid>
+                </Grid>
+                <Box display="flex" justifyContent="center" pt={4}>
+                  <Button
+                    variant="outlined"
+                    color="secondary"
+                    size="large"
+                    sx={sx.cancelButton}
+                    onClick={() => (hasOrganisations ? navigate('/') : logout())}
+                  >
+                    Cancel
+                  </Button>
+                  <OrganizationSubmitButton />
+                </Box>
+              </>
+            )}
           </FormDataConsumer>
         </Form>
+        <CreateServiceComponent
+          isModalOpened={isServiceFlowOpened}
+          isSending={isCreateRequestLoading}
+          onClose={onClose}
+          onCreate={onCreate}
+          onDoLater={() => onCreate()}
+          selectedStep={flowStep}
+          setSelectedStep={onServicePopupStepRequested}
+          selectedServiceType={serviceType}
+          setSelectedServiceType={setServiceType}
+        />
+        {InterceptOnOrganizationCreation && (
+          <InterceptOnOrganizationCreation
+            isInterceptOnCreateOpen={flowStep === ORGANIZATION_CREATE_FLOW_STEPS.INTERCEPT}
+            serviceId={serviceId}
+            onNext={() => {
+              trace({
+                event: 'intercept-step-completed',
+                fromFlowStep: flowStep,
+                toFlowStep: ORGANIZATION_CREATE_FLOW_STEPS.KEYS,
+                serviceTypeId: serviceType?.id,
+              });
+              setFlowStep(ORGANIZATION_CREATE_FLOW_STEPS.KEYS);
+            }}
+            onClose={() => {
+              trace({
+                event: 'intercept-step-closed',
+                fromFlowStep: flowStep,
+                toFlowStep: ORGANIZATION_CREATE_FLOW_STEPS.KEYS,
+                serviceTypeId: serviceType?.id,
+              });
+              setFlowStep(ORGANIZATION_CREATE_FLOW_STEPS.KEYS);
+            }}
+            isIssueOrInspection={isIssuingOrInspection}
+            selectedCAO={selectedCAO}
+            isCAO={isCAO}
+          />
+        )}
+        {flowStep === ORGANIZATION_CREATE_FLOW_STEPS.KEYS && secretKeys && (
+          <SecretKeysPopup
+            isOpen
+            secretKeys={secretKeys}
+            onClose={onKeysClose}
+            wording={{
+              title: 'Your organization is now registered on Velocity Network™.',
+              subtitle:
+                'Please save your organization’s unique keys in a secure location, ' +
+                'as they will not be available once you close this window.',
+            }}
+            warningWording={{
+              title: 'You must download a copy of your keys before exiting',
+            }}
+          />
+        )}
       </Stack>
     </Box>
   );
 };
+/* eslint-enable complexity */
 
 // eslint-disable-next-line better-mutation/no-mutation
 OrganizationCreate.propTypes = {
   CreateServiceComponent: PropTypes.elementType,
+  InterceptOnOrganizationCreation: PropTypes.elementType,
   MockOrganization: PropTypes.elementType,
 };
 

--- a/packages/components-organizations-registrar/src/pages/organizations/__tests__/OrganizationCreate.integration.test.jsx
+++ b/packages/components-organizations-registrar/src/pages/organizations/__tests__/OrganizationCreate.integration.test.jsx
@@ -1,0 +1,429 @@
+import { before, beforeEach, describe, it, mock } from 'node:test';
+import { expect } from 'expect';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { QueryClient } from '@tanstack/react-query';
+import { useLocation } from 'react-router';
+import { CoreAdminContext, ResourceContextProvider, TestMemoryRouter } from 'ra-core';
+import { memoryStore, testDataProvider } from 'react-admin';
+
+import { AuthContext } from '@/utils/auth/AuthContext.js';
+import { ConfigContext } from '@/utils/ConfigContext.js';
+
+expect.extend(matchers);
+
+const TEST_USER = {
+  id: 'auth0|new-user',
+  givenName: 'New',
+  familyName: 'User',
+  email: 'new.user@acme.example',
+};
+const TEST_ORGANIZATION_ID = 'did:test:new-org';
+const EXPECTED_KEYS_DIALOG_TITLE = 'Your organization is now registered on Velocity Network™.';
+const EXPECTED_KEYS_DIALOG_TEXT =
+  'Please save your organization’s unique keys in a secure location, as they will not be available once you close this window.';
+const EXPECTED_WARNING_TITLE = 'You must download a copy of your keys before exiting';
+const EXPECTED_WARNING_TEXT =
+  'Your organization’s unique keys are critical for managing your organization’s data ' +
+  'on Velocity Network™. They will not be available once you close this window.';
+const ORGANIZATION_CREATE_RESPONSE = {
+  data: {
+    id: TEST_ORGANIZATION_ID,
+    keys: [
+      {
+        didDocumentKey: {
+          id: '#auth-key-1',
+        },
+        key: 'secret-key-value',
+      },
+    ],
+    authClients: [],
+  },
+};
+const interceptOpenMock = mock.fn();
+
+mock.module('@/utils/countryCodes.js', {
+  defaultExport: () => ({
+    data: [{ id: 'AU', name: 'Australia' }],
+    isLoading: false,
+  }),
+});
+
+const theme = createTheme({
+  customColors: {
+    grey2: '#9aa4b2',
+  },
+  components: {
+    MuiBackdrop: {
+      defaultProps: {
+        transitionDuration: 0,
+      },
+    },
+    MuiDialog: {
+      defaultProps: {
+        disableAutoFocus: true,
+        disableEnforceFocus: true,
+        disableRestoreFocus: true,
+        disableScrollLock: true,
+        transitionDuration: 0,
+      },
+    },
+    MuiModal: {
+      defaultProps: {
+        disableAutoFocus: true,
+        disableEnforceFocus: true,
+        disablePortal: true,
+        disableRestoreFocus: true,
+        disableScrollLock: true,
+      },
+    },
+  },
+});
+
+const buildToken = (payload) => {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
+  return `${encode({ alg: 'RS256', typ: 'JWT' })}.${encode(payload)}.signature`;
+};
+
+const MockOrganizationButton = ({ setInitialRecord }) => (
+  <button
+    type="button"
+    onClick={() =>
+      setInitialRecord({
+        profile: {
+          name: 'Acme Org',
+          website: 'https://acme.example',
+          physicalAddress: {
+            line1: '1 Harbour Street',
+          },
+          location: {
+            countryCode: 'AU',
+          },
+          logo: 'https://cdn.example.com/logo.png',
+          linkedInProfile: 'https://www.linkedin.com/company/acme-org',
+          contactEmail: 'support@acme.example',
+          technicalEmail: 'tech@acme.example',
+          description: 'A registrar test organization',
+          adminGivenName: 'Admin',
+          adminFamilyName: 'User',
+          signatoryGivenName: 'Sig',
+          signatoryFamilyName: 'User',
+          adminTitle: 'Administrator',
+          signatoryTitle: 'Director',
+          adminEmail: 'admin@acme.example',
+          signatoryEmail: 'signatory@acme.example',
+          registrationNumbers: [
+            {
+              authority: 'DunnAndBradstreet',
+              number: '123456789',
+            },
+          ],
+          commercialEntities: [],
+        },
+      })
+    }
+  >
+    Fill Mock Organization
+  </button>
+);
+
+const InterceptOnOrganizationCreationMock = ({ isInterceptOnCreateOpen = false, onNext }) => {
+  useEffect(() => {
+    if (isInterceptOnCreateOpen) {
+      interceptOpenMock();
+      onNext();
+    }
+  }, [isInterceptOnCreateOpen, onNext]);
+
+  return null;
+};
+
+MockOrganizationButton.propTypes = {
+  setInitialRecord: PropTypes.func.isRequired,
+};
+
+InterceptOnOrganizationCreationMock.propTypes = {
+  isInterceptOnCreateOpen: PropTypes.bool,
+  onNext: PropTypes.func.isRequired,
+};
+
+const findDialogByText = async (text) => {
+  const dialogText = await screen.findByText(text);
+  const dialog = dialogText.closest('[role="dialog"]');
+
+  expect(dialog).not.toBeNull();
+
+  return dialog;
+};
+
+const wait = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const createGetAccessTokenMock = () => {
+  let tokenCallCount = 0;
+
+  return mock.fn(() => {
+    tokenCallCount += 1;
+
+    if (tokenCallCount === 1) {
+      return Promise.resolve(
+        buildToken({
+          scope: 'write:organizations',
+        }),
+      );
+    }
+
+    return Promise.resolve(
+      buildToken({
+        scope: 'write:organizations',
+        'http://velocitynetwork.foundation/groupId': TEST_ORGANIZATION_ID,
+      }),
+    );
+  });
+};
+
+const createDataProvider = ({ assertCreate }) =>
+  testDataProvider({
+    getOne: (resource) => {
+      if (resource === 'users') {
+        return Promise.resolve({
+          data: TEST_USER,
+        });
+      }
+
+      throw new Error(`Unexpected getOne resource: ${resource}`);
+    },
+    getList: (resource) => {
+      if (resource === 'organizations' || resource === 'search-profiles') {
+        return Promise.resolve({ data: [], total: 0 });
+      }
+
+      throw new Error(`Unexpected getList resource: ${resource}`);
+    },
+    create: (resource, params) => {
+      if (resource === 'organizations') {
+        assertCreate(params);
+        return Promise.resolve({
+          data: {
+            ...ORGANIZATION_CREATE_RESPONSE.data,
+            serviceEndpoints: params.data.serviceEndpoints,
+          },
+        });
+      }
+
+      throw new Error(`Unexpected create resource: ${resource}`);
+    },
+  });
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        gcTime: Infinity,
+        retry: false,
+      },
+    },
+  });
+
+const ServicesListStub = () => <div>Services list</div>;
+
+const OrganizationCreateRoute = ({ OrganizationCreateComponent }) => {
+  return (
+    <ResourceContextProvider value="organizations">
+      <OrganizationCreateComponent
+        MockOrganization={MockOrganizationButton}
+        InterceptOnOrganizationCreation={InterceptOnOrganizationCreationMock}
+      />
+    </ResourceContextProvider>
+  );
+};
+
+const RoutedOrganizationCreateApp = ({ OrganizationCreateComponent }) => {
+  const { pathname } = useLocation();
+
+  if (pathname === '/services') {
+    return <ServicesListStub />;
+  }
+
+  if (pathname === '/organizations/create') {
+    return <OrganizationCreateRoute OrganizationCreateComponent={OrganizationCreateComponent} />;
+  }
+
+  return null;
+};
+
+OrganizationCreateRoute.propTypes = {
+  OrganizationCreateComponent: PropTypes.elementType.isRequired,
+};
+
+RoutedOrganizationCreateApp.propTypes = {
+  OrganizationCreateComponent: PropTypes.elementType.isRequired,
+};
+
+const renderOrganizationCreateApp = ({ OrganizationCreateComponent, assertCreate }) => {
+  let location;
+  const getAccessTokenMock = createGetAccessTokenMock();
+  const queryClient = createQueryClient();
+  const renderResult = render(
+    <TestMemoryRouter
+      initialEntries={['/organizations/create']}
+      locationCallback={(nextLocation) => {
+        location = nextLocation;
+      }}
+    >
+      <CoreAdminContext
+        dataProvider={createDataProvider({ assertCreate })}
+        queryClient={queryClient}
+        store={memoryStore()}
+      >
+        <ConfigContext.Provider value={{ chainName: 'Devnet' }}>
+          <AuthContext.Provider
+            value={{
+              isLoading: false,
+              isAuthenticated: true,
+              user: { sub: TEST_USER.id },
+              login: mock.fn(),
+              logout: mock.fn(),
+              getAccessToken: getAccessTokenMock,
+              getAccessTokenWithPopup: mock.fn(),
+            }}
+          >
+            <ThemeProvider theme={theme}>
+              <RoutedOrganizationCreateApp
+                OrganizationCreateComponent={OrganizationCreateComponent}
+              />
+            </ThemeProvider>
+          </AuthContext.Provider>
+        </ConfigContext.Provider>
+      </CoreAdminContext>
+    </TestMemoryRouter>,
+  );
+
+  return {
+    user: userEvent.setup(),
+    getPathname: () => location?.pathname,
+    cleanup: async () => {
+      renderResult.unmount();
+      queryClient.clear();
+      cleanup();
+      document.body.innerHTML = '';
+      await wait(0);
+    },
+  };
+};
+
+const fillOrganizationDetails = async (user) => {
+  await user.click(await screen.findByText('Fill Mock Organization'));
+  await waitFor(() => {
+    expect(screen.getByDisplayValue('Acme Org')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('https://acme.example')).toBeInTheDocument();
+  });
+};
+
+const openAddServiceFlow = async (user) => {
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Add Service' })).toBeEnabled());
+  await user.click(screen.getByRole('button', { name: 'Add Service' }));
+  await screen.findByText('Step 1/2');
+};
+
+const closeKeysFlowAndAssertRedirect = async ({ user, getPathname }) => {
+  const keysDialog = await findDialogByText(EXPECTED_KEYS_DIALOG_TITLE);
+  expect(within(keysDialog).getByText(EXPECTED_KEYS_DIALOG_TEXT)).toBeInTheDocument();
+
+  // This delay is intentional regression coverage: the old flow could tear down
+  // the success modal after navigation/history changes even though the user had
+  // not dismissed it yet.
+  await wait(2000);
+  const persistedKeysDialog = await findDialogByText(EXPECTED_KEYS_DIALOG_TITLE);
+  expect(within(persistedKeysDialog).getByText(EXPECTED_KEYS_DIALOG_TEXT)).toBeInTheDocument();
+
+  await user.click(within(persistedKeysDialog).getByLabelText('close'));
+
+  const warningDialog = await findDialogByText(EXPECTED_WARNING_TITLE);
+  expect(within(warningDialog).getByText(EXPECTED_WARNING_TEXT)).toBeInTheDocument();
+
+  await user.click(within(warningDialog).getByLabelText('close'));
+
+  await waitFor(() => {
+    expect(getPathname()).toEqual('/services');
+    expect(screen.getByText('Services list')).toBeInTheDocument();
+  });
+};
+
+describe('OrganizationCreate integration', () => {
+  let OrganizationCreate;
+
+  before(async () => {
+    OrganizationCreate = (await import('../OrganizationCreate.jsx')).default;
+  });
+
+  beforeEach(() => {
+    interceptOpenMock.mock.resetCalls();
+  });
+
+  it('redirects to the services list after creating an organization with an initial service and completing the keys flow', async () => {
+    const app = renderOrganizationCreateApp({
+      OrganizationCreateComponent: OrganizationCreate,
+      assertCreate: (params) => {
+        expect(params.data.serviceEndpoints).toHaveLength(1);
+        expect(params.data.serviceEndpoints[0].serviceEndpoint).toEqual('https://cao.example');
+      },
+    });
+
+    try {
+      await fillOrganizationDetails(app.user);
+      await openAddServiceFlow(app.user);
+
+      await app.user.click(screen.getByLabelText('Select type of service'));
+      await app.user.click(
+        screen.getByRole('option', { name: 'Credential Agent Operator', hidden: true }),
+      );
+      await app.user.click(screen.getByRole('button', { name: 'Next', hidden: true }));
+
+      await screen.findByText('Step 2/2');
+      expect(screen.queryByRole('button', { name: 'Back' })).toBeNull();
+      await app.user.type(
+        document.querySelector('[name="serviceEndpoint"]'),
+        'https://cao.example',
+      );
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Add', hidden: true })).toBeEnabled(),
+      );
+      await app.user.click(screen.getByRole('button', { name: 'Add', hidden: true }));
+
+      await waitFor(() => expect(interceptOpenMock.mock.calls.length).toBe(1));
+      await closeKeysFlowAndAssertRedirect(app);
+    } finally {
+      await app.cleanup();
+    }
+  });
+
+  it('redirects to the services list after skipping the initial service and completing the keys flow', async () => {
+    const app = renderOrganizationCreateApp({
+      OrganizationCreateComponent: OrganizationCreate,
+      assertCreate: (params) => {
+        expect(params.data.serviceEndpoints).toEqual([]);
+      },
+    });
+
+    try {
+      await fillOrganizationDetails(app.user);
+      await openAddServiceFlow(app.user);
+      await app.user.click(screen.getByRole('button', { name: 'Do Later', hidden: true }));
+
+      expect(interceptOpenMock.mock.calls.length).toBe(0);
+      await closeKeysFlowAndAssertRedirect(app);
+    } finally {
+      await app.cleanup();
+    }
+  });
+});

--- a/packages/components-organizations-registrar/src/pages/organizations/__tests__/OrganizationCreate.test.jsx
+++ b/packages/components-organizations-registrar/src/pages/organizations/__tests__/OrganizationCreate.test.jsx
@@ -2,7 +2,7 @@ import { before, describe, it, mock } from 'node:test';
 import { expect } from 'expect';
 import * as matchers from '@testing-library/jest-dom/matchers';
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import * as reactAdminActual from 'react-admin';
 import * as reactRouterActual from 'react-router';
@@ -18,18 +18,12 @@ const theme = createTheme({
   },
 });
 
-const createDeferred = () => {
-  let resolve;
-  const promise = new Promise((res) => {
-    resolve = res;
-  });
-  return { promise, resolve };
-};
-
 const buildToken = (payload) => {
   const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
   return `${encode({ alg: 'RS256', typ: 'JWT' })}.${encode(payload)}.signature`;
 };
+
+const EXPECTED_KEYS_DIALOG_TITLE = 'Your organization is now registered on Velocity Network™.';
 
 const navigateMock = mock.fn();
 const redirectMock = mock.fn();
@@ -60,6 +54,7 @@ mock.module('react-admin', {
     useGetOne: () => ({
       data: { givenName: 'New', familyName: 'User' },
       isLoading: false,
+      refetch: mock.fn(),
     }),
     useNotify: () => notifyMock,
     useGetList: () => ({
@@ -108,155 +103,36 @@ describe('OrganizationCreate', () => {
     OrganizationCreate = (await import('../OrganizationCreate.jsx')).default;
   });
 
-  it('waits for access token refresh before navigating after organization creation', async () => {
+  it('opens the keys flow immediately after organization creation without refreshing auth or organizations', async () => {
     createControllerOptions = undefined;
     navigateMock.mock.resetCalls();
     refetchMock.mock.resetCalls();
     getAccessTokenMock.mock.resetCalls();
     getAccessTokenWithPopupMock.mock.resetCalls();
 
-    const refreshDeferred = createDeferred();
-    let tokenCallCount = 0;
-    getAccessTokenMock.mock.mockImplementation(() => {
-      tokenCallCount += 1;
-      if (tokenCallCount === 1) {
-        return Promise.resolve(
-          buildToken({
-            scope: 'write:organizations',
-          }),
-        );
-      }
-      return refreshDeferred.promise;
-    });
+    getAccessTokenMock.mock.mockImplementation(() =>
+      Promise.resolve(
+        buildToken({
+          scope: 'write:organizations',
+        }),
+      ),
+    );
 
     renderOrganizationCreate(OrganizationCreate);
 
     await waitFor(() => expect(createControllerOptions).toBeDefined());
     await waitFor(() => expect(getAccessTokenMock.mock.calls.length).toEqual(1));
 
-    let onSuccessSettled = false;
-    const onSuccessPromise = createControllerOptions.mutationOptions.onSuccess({
+    createControllerOptions.mutationOptions.onSuccess({
       id: 'did:test:new-org',
       keys: [],
       authClients: [],
     });
-    onSuccessPromise.then(() => {
-      onSuccessSettled = true;
-    });
 
-    await Promise.resolve();
-
-    expect(getAccessTokenMock.mock.calls.length).toEqual(2);
-    expect(refetchMock.mock.calls).toEqual([]);
-    expect(navigateMock.mock.calls).toEqual([]);
-    expect(onSuccessSettled).toEqual(false);
-
-    refreshDeferred.resolve(
-      buildToken({
-        scope: 'write:organizations',
-        'http://velocitynetwork.foundation/groupId': 'did:test:new-org',
-      }),
-    );
-    await onSuccessPromise;
-
-    expect(refetchMock.mock.calls.length).toEqual(1);
-    expect(navigateMock.mock.calls.length).toEqual(1);
-    expect(navigateMock.mock.calls[0].arguments).toEqual([-1]);
-  });
-
-  it('falls back to popup refresh and still waits before navigating when silent refresh errors', async () => {
-    createControllerOptions = undefined;
-    navigateMock.mock.resetCalls();
-    refetchMock.mock.resetCalls();
-    getAccessTokenMock.mock.resetCalls();
-    getAccessTokenWithPopupMock.mock.resetCalls();
-
-    const popupDeferred = createDeferred();
-    let tokenCallCount = 0;
-    getAccessTokenMock.mock.mockImplementation(() => {
-      tokenCallCount += 1;
-      if (tokenCallCount === 1) {
-        return Promise.resolve(
-          buildToken({
-            scope: 'write:organizations',
-          }),
-        );
-      }
-      throw Object.assign(new Error('Consent required'), {
-        error: 'consent_required',
-      });
-    });
-    getAccessTokenWithPopupMock.mock.mockImplementation(() => popupDeferred.promise);
-
-    renderOrganizationCreate(OrganizationCreate);
-
-    await waitFor(() => expect(createControllerOptions).toBeDefined());
-    await waitFor(() => expect(getAccessTokenMock.mock.calls.length).toEqual(1));
-
-    const onSuccessPromise = createControllerOptions.mutationOptions.onSuccess({
-      id: 'did:test:new-org',
-      keys: [],
-      authClients: [],
-    });
-    onSuccessPromise.catch(() => {});
-
-    await Promise.resolve();
-
-    expect(getAccessTokenMock.mock.calls.length).toEqual(2);
-    expect(getAccessTokenWithPopupMock.mock.calls.length).toEqual(1);
-    expect(navigateMock.mock.calls).toEqual([]);
-
-    popupDeferred.resolve(
-      buildToken({
-        scope: 'write:organizations',
-        'http://velocitynetwork.foundation/groupId': 'did:test:new-org',
-      }),
-    );
-    await onSuccessPromise;
-
-    expect(refetchMock.mock.calls.length).toEqual(1);
-    expect(navigateMock.mock.calls.length).toEqual(1);
-    expect(navigateMock.mock.calls[0].arguments).toEqual([-1]);
-  });
-
-  it('continues navigation when refresh fails with a non-interaction error', async () => {
-    createControllerOptions = undefined;
-    navigateMock.mock.resetCalls();
-    refetchMock.mock.resetCalls();
-    getAccessTokenMock.mock.resetCalls();
-    getAccessTokenWithPopupMock.mock.resetCalls();
-
-    let tokenCallCount = 0;
-    const refreshError = new Error('network timeout');
-    getAccessTokenMock.mock.mockImplementation(() => {
-      tokenCallCount += 1;
-      if (tokenCallCount === 1) {
-        return Promise.resolve(
-          buildToken({
-            scope: 'write:organizations',
-          }),
-        );
-      }
-
-      return Promise.reject(refreshError);
-    });
-
-    renderOrganizationCreate(OrganizationCreate);
-
-    await waitFor(() => expect(createControllerOptions).toBeDefined());
-    await waitFor(() => expect(getAccessTokenMock.mock.calls.length).toEqual(1));
-
-    await expect(
-      createControllerOptions.mutationOptions.onSuccess({
-        id: 'did:test:new-org',
-        keys: [],
-        authClients: [],
-      }),
-    ).resolves.toBeUndefined();
-
+    expect(getAccessTokenMock.mock.calls.length).toEqual(1);
     expect(getAccessTokenWithPopupMock.mock.calls.length).toEqual(0);
-    expect(refetchMock.mock.calls.length).toEqual(1);
-    expect(navigateMock.mock.calls.length).toEqual(1);
-    expect(navigateMock.mock.calls[0].arguments).toEqual([-1]);
+    expect(refetchMock.mock.calls.length).toEqual(0);
+    expect(navigateMock.mock.calls).toEqual([]);
+    await waitFor(() => expect(screen.getByText(EXPECTED_KEYS_DIALOG_TITLE)).toBeInTheDocument());
   });
 });

--- a/packages/components-organizations-registrar/src/pages/services/ServiceCreateForm.jsx
+++ b/packages/components-organizations-registrar/src/pages/services/ServiceCreateForm.jsx
@@ -51,7 +51,7 @@ const ServiceCreateForm = ({ onServiceCreated, services, InterceptOnCreate }) =>
   );
 
   const [selectedStep, setSelectedStep] = useState(1);
-  const [selectedServiceType, setSelectedServiceType] = useState('');
+  const [selectedServiceType, setSelectedServiceType] = useState(null);
   const [authClient, setAuthClient] = useState(defaultAuthClient);
   const [createServiceInProgress, setCreateServiceInProgress] = useState(false);
 
@@ -68,7 +68,7 @@ const ServiceCreateForm = ({ onServiceCreated, services, InterceptOnCreate }) =>
   useEffect(() => {
     const reset = () => {
       setSelectedStep(1);
-      setSelectedServiceType('');
+      setSelectedServiceType(null);
       setAuthClient(defaultAuthClient);
     };
     if (openedStateRef.current === false && isModalOpened) {
@@ -170,8 +170,6 @@ const ServiceCreateForm = ({ onServiceCreated, services, InterceptOnCreate }) =>
         }}
         warningWording={{
           title: 'You must download a copy of your keys before exiting',
-          subtitle:
-            'They will not be available again and are critical for managing your organization data.',
         }}
       />
     </>

--- a/packages/components-organizations-registrar/src/pages/services/components/SecretKeysPopup/WarningSecretKeysPopup/index.jsx
+++ b/packages/components-organizations-registrar/src/pages/services/components/SecretKeysPopup/WarningSecretKeysPopup/index.jsx
@@ -24,16 +24,16 @@ import Loading from '@/components/Loading.jsx';
 
 const titleDefault =
   'Wait! Before you close this window, please make sure you have saved a copy of your keys';
-const subTitleDefault =
+const subtitleDefault =
   // eslint-disable-next-line max-len
-  'Your organization’s unique keys are critical for managing your organization’s data on Velocity Network™. This information will not be available once you close this window.';
+  'Your organization’s unique keys are critical for managing your organization’s data on Velocity Network™. They will not be available once you close this window.';
 const buttonLabelDefault = 'Download keys';
 
 const WarningSecretKeysPopup = ({
   isModalOpened,
   onClose,
   title = titleDefault,
-  subTitle = subTitleDefault,
+  subtitle = subtitleDefault,
   buttonLabel = buttonLabelDefault,
   isLoading = false,
   onClick,
@@ -52,7 +52,7 @@ const WarningSecretKeysPopup = ({
     >
       <InfoIcon color="warning" sx={styles.icon} />
       <Typography sx={styles.title}>{title}</Typography>
-      <Typography textAlign="center">{subTitle}</Typography>
+      <Typography textAlign="center">{subtitle}</Typography>
 
       <Box sx={styles.buttonBlock}>
         <Button
@@ -99,7 +99,7 @@ WarningSecretKeysPopup.propTypes = {
   isModalOpened: PropTypes.bool,
   onClose: PropTypes.func,
   title: PropTypes.string,
-  subTitle: PropTypes.string,
+  subtitle: PropTypes.string,
   buttonLabel: PropTypes.string,
   isLoading: PropTypes.bool,
   onClick: PropTypes.func,

--- a/packages/components-organizations-registrar/src/pages/services/components/SecretKeysPopup/index.jsx
+++ b/packages/components-organizations-registrar/src/pages/services/components/SecretKeysPopup/index.jsx
@@ -70,7 +70,7 @@ SecretKeysPopup.propTypes = {
   }).isRequired,
   warningWording: PropTypes.shape({
     title: PropTypes.string.isRequired,
-    subtitle: PropTypes.string.isRequired,
+    subtitle: PropTypes.string,
   }).isRequired,
 };
 

--- a/packages/components-organizations-registrar/src/pages/services/components/ServiceEndpointSelection/index.jsx
+++ b/packages/components-organizations-registrar/src/pages/services/components/ServiceEndpointSelection/index.jsx
@@ -14,13 +14,16 @@ import { getTitle, isAddButtonDisabled } from '../../utils/index.js';
 
 const selectedStep = 2;
 
+/* eslint-disable complexity */
 export const ServiceEndpointSelection = ({
   credentialAgentOperators,
   selectedServiceType,
   inProgress,
   onCreate,
   handleBack,
+  showBackButton,
 }) => {
+  const shouldShowBackButton = showBackButton ?? !!handleBack;
   const { isIssuingOrInspection, isCAO, isWallet, isWebWallet, isHolderWallet } =
     useIsIssuingInspection(selectedServiceType);
 
@@ -49,15 +52,17 @@ export const ServiceEndpointSelection = ({
           {isCAO && <CAOSelection inProgress={inProgress} />}
           <UserAgreement isWallet={isWallet} />
           <Box sx={styles.buttonBlock}>
-            <Button
-              variant="outlined"
-              sx={[styles.button, styles.backButton]}
-              onClick={handleBack}
-              startIcon={<KeyboardArrowLeftIcon />}
-              disabled={inProgress}
-            >
-              Back
-            </Button>
+            {shouldShowBackButton && (
+              <Button
+                variant="outlined"
+                sx={[styles.button, styles.backButton]}
+                onClick={handleBack}
+                startIcon={<KeyboardArrowLeftIcon />}
+                disabled={inProgress}
+              >
+                Back
+              </Button>
+            )}
             <FormDataConsumer>
               {({ formData }) => {
                 const isDisabled = isAddButtonDisabled(
@@ -87,6 +92,7 @@ export const ServiceEndpointSelection = ({
     </>
   );
 };
+/* eslint-enable complexity */
 
 const styles = {
   step: { color: (theme) => theme.palette.primary.main, pb: '20px', display: 'block' },
@@ -140,10 +146,20 @@ ServiceEndpointSelection.propTypes = {
       ),
     }),
   ).isRequired,
-  selectedServiceType: PropTypes.string.isRequired,
+  selectedServiceType: PropTypes.shape({
+    id: PropTypes.string,
+    title: PropTypes.string,
+  }).isRequired,
   inProgress: PropTypes.bool.isRequired,
   onCreate: PropTypes.func.isRequired,
-  handleBack: PropTypes.func.isRequired,
+  handleBack: PropTypes.func,
+  showBackButton: PropTypes.bool,
+};
+
+// eslint-disable-next-line better-mutation/no-mutation
+ServiceEndpointSelection.defaultProps = {
+  handleBack: null,
+  showBackButton: undefined,
 };
 
 export default ServiceEndpointSelection;

--- a/packages/components-organizations-registrar/src/pages/services/components/ServiceTypeSelection/index.jsx
+++ b/packages/components-organizations-registrar/src/pages/services/components/ServiceTypeSelection/index.jsx
@@ -10,6 +10,7 @@ import { getTitle } from '../../utils/index.js';
 
 const selectedStep = 1;
 
+/* eslint-disable complexity */
 export const ServiceTypeSelection = ({
   handleNext,
   isLoading,
@@ -17,6 +18,10 @@ export const ServiceTypeSelection = ({
   setSelectedServiceType,
   onDoLater,
 }) => {
+  const handleSelectedServiceTypeChange = (value) => {
+    setSelectedServiceType(value || null);
+  };
+
   return (
     <>
       <Typography variant="pm" sx={styles.step}>
@@ -30,11 +35,11 @@ export const ServiceTypeSelection = ({
         <CustomDropDown
           source="selectedServiceType"
           label="Select type of service"
-          value={selectedServiceType}
-          onChange={setSelectedServiceType}
+          value={selectedServiceType || ''}
+          onChange={handleSelectedServiceTypeChange}
           items={serviceTypes}
-          stringValue={(item) => item.title}
-          parse={(value) => value.id}
+          stringValue={(item) => item?.title || ''}
+          parse={(value) => value?.id || ''}
           disabled={false}
         />
         <Box sx={[styles.buttonBlock, !onDoLater && styles.rightButton]}>
@@ -63,6 +68,7 @@ export const ServiceTypeSelection = ({
     </>
   );
 };
+/* eslint-enable complexity */
 
 const styles = {
   buttonBlock: {
@@ -82,7 +88,10 @@ const styles = {
 ServiceTypeSelection.propTypes = {
   handleNext: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,
-  selectedServiceType: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.number]),
+  selectedServiceType: PropTypes.shape({
+    id: PropTypes.string,
+    title: PropTypes.string,
+  }),
   setSelectedServiceType: PropTypes.func.isRequired,
   onDoLater: PropTypes.func,
 };

--- a/packages/components-organizations-registrar/src/utils/auth/__tests__/useSignupRedirect.test.jsx
+++ b/packages/components-organizations-registrar/src/utils/auth/__tests__/useSignupRedirect.test.jsx
@@ -1,0 +1,78 @@
+import { afterEach, before, describe, it, mock } from 'node:test';
+import { expect } from 'expect';
+import React, { useState } from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import PropTypes from 'prop-types';
+
+mock.module('react-admin', {
+  namedExports: {
+    useStore: (_key, initialValue) => useState(initialValue),
+  },
+});
+
+describe('useSignupRedirect', () => {
+  let useSignupRedirect;
+
+  before(async () => {
+    useSignupRedirect = (await import('../useSignupRedirect.js')).default;
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  const TestComponent = ({ auth }) => {
+    useSignupRedirect({ auth });
+    return null;
+  };
+
+  TestComponent.propTypes = {
+    auth: PropTypes.shape({
+      isAuthenticated: PropTypes.bool.isRequired,
+      isLoading: PropTypes.bool.isRequired,
+      login: PropTypes.func.isRequired,
+      logout: PropTypes.func.isRequired,
+    }).isRequired,
+  };
+
+  it('starts the normal login redirect after auth resolves logged out', async () => {
+    const login = mock.fn(() => Promise.resolve());
+    const auth = {
+      isLoading: false,
+      isAuthenticated: false,
+      login,
+      logout: mock.fn(() => Promise.resolve()),
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/organizations']}>
+        <TestComponent auth={auth} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(login.mock.calls.length).toEqual(1));
+    expect(login.mock.calls[0].arguments).toEqual([{ appState: { returnTo: '/organizations' } }]);
+  });
+
+  it('does not start normal login while an invitation signup URL is pending', async () => {
+    const login = mock.fn(() => Promise.resolve());
+    const logout = mock.fn(() => new Promise(() => {}));
+    const auth = {
+      isLoading: false,
+      isAuthenticated: false,
+      login,
+      logout,
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/invitations/abc?signup_url=https%3A%2F%2Fauth.example']}>
+        <TestComponent auth={auth} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(logout.mock.calls.length).toEqual(1));
+    expect(login.mock.calls.length).toEqual(0);
+  });
+});

--- a/packages/components-organizations-registrar/src/utils/auth/useSignupRedirect.js
+++ b/packages/components-organizations-registrar/src/utils/auth/useSignupRedirect.js
@@ -17,15 +17,30 @@
 import { useLocation, useSearchParams } from 'react-router';
 import { useStore } from 'react-admin';
 import { useEffect } from 'react';
+import { initTrace } from '../tracing.js';
+
+const trace = initTrace('useSignupRedirect');
 
 const useSignupRedirect = ({ auth, options = {} }) => {
   const [searchParams] = useSearchParams();
   const signupUrlParam = searchParams.get('signup_url');
 
   const [signupUrl, setSignupUrl] = useStore('signupUrl', null);
+  const isSignupProcess = signupUrlParam != null || signupUrl != null;
 
   const redirectKey = options.redirectKey ?? 'afterSignupRedirectUrl';
   const location = useLocation();
+
+  useEffect(() => {
+    trace({
+      event: 'signup-redirect-state-changed',
+      hasSignupUrlParam: signupUrlParam != null,
+      hasStoredSignupUrl: signupUrl != null,
+      isLoading: auth.isLoading,
+      isAuthenticated: auth.isAuthenticated,
+      isSignupProcess,
+    });
+  }, [auth.isAuthenticated, auth.isLoading, isSignupProcess, signupUrl, signupUrlParam]);
 
   useEffect(() => {
     if (signupUrlParam !== signupUrl) {
@@ -38,26 +53,28 @@ const useSignupRedirect = ({ auth, options = {} }) => {
       return;
     }
 
+    trace({ event: 'signup-url-redirect-requested', pathname: location.pathname });
     localStorage.setItem(redirectKey, location.pathname);
 
     auth.logout().then(() => {
       window.location.replace(decodeURIComponent(signupUrl));
     });
-  }, [signupUrl, signupUrlParam, redirectKey, location, auth]);
+  }, [signupUrl, signupUrlParam, redirectKey, location.pathname, auth]);
 
   useEffect(() => {
-    if (signupUrl || auth.isLoading || auth.isAuthenticated) {
+    if (isSignupProcess || auth.isLoading || auth.isAuthenticated) {
       return;
     }
 
     const returnTo = localStorage.getItem(redirectKey) || location.pathname;
 
+    trace({ event: 'login-redirect-requested', returnTo });
     auth.login({ appState: { returnTo } }).then(() => {
       localStorage.removeItem(redirectKey);
     });
-  }, [signupUrl, auth.isLoading, auth.isAuthenticated, auth, location, redirectKey]);
+  }, [isSignupProcess, auth.isLoading, auth.isAuthenticated, auth, location.pathname, redirectKey]);
 
-  return { isSignupProcess: signupUrl != null };
+  return { isSignupProcess };
 };
 
 export default useSignupRedirect;

--- a/packages/components-organizations-registrar/src/utils/tracing.js
+++ b/packages/components-organizations-registrar/src/utils/tracing.js
@@ -1,0 +1,16 @@
+/* global __TRACING_ENABLED__ */
+
+export const initTrace = (scope) => {
+  const isEnabled =
+    (typeof __TRACING_ENABLED__ !== 'undefined' && __TRACING_ENABLED__) ||
+    import.meta.env?.DEV === true;
+
+  return (payload) => {
+    if (!isEnabled) {
+      return;
+    }
+
+    // eslint-disable-next-line no-console
+    console.debug(`[${scope}]`, payload);
+  };
+};

--- a/packages/components-organizations-registrar/vite.config.js
+++ b/packages/components-organizations-registrar/vite.config.js
@@ -21,8 +21,13 @@ import path from 'path';
 import react from '@vitejs/plugin-react-swc';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
 
+const isTracingEnabled = (mode) => mode === 'development' || process.env.TRACING_ENABLED === '1';
+
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  define: {
+    __TRACING_ENABLED__: JSON.stringify(isTracingEnabled(mode)),
+  },
   // Automatically externalizes deps based on package.json
   plugins: [libInjectCss(), externalizeDeps({}), react()],
   resolve: {
@@ -64,4 +69,4 @@ export default defineConfig({
       },
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary
- Forward-port release/1.1.x PR #587 into main.
- Centralize the registrar organization creation flow across direct creation, invitation, and add-service entry points.
- Add the organization creation regression coverage from the 1.1.2 release line.

## Context
This is the first PR in the 1.1.2 forward-port stack from release/1.1.x to main.

Original release PR: https://github.com/LFDT-Verii/core/pull/587
Cherry-picked from: 1f8a0b50a40359c67a28a421213031f5f0511571

## Validation
- NODE_OPTIONS=--experimental-specifier-resolution=node ../../node_modules/.bin/eslint --fix affected registrar files
- git diff --check
- Regression tests were run on the final stacked branch containing #587, #594, and #596: 6 passed