### PR TITLE
[codex] Forward-port #594 to main

### DIFF
--- a/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
+++ b/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
@@ -16,6 +16,7 @@
 import React, { useEffect, useState } from 'react';
 // react admin
 import { Admin } from 'react-admin';
+import { useLocation } from 'react-router';
 
 import PropTypes from 'prop-types';
 
@@ -37,11 +38,40 @@ import theme from './theme/theme.js';
 
 const trace = initTrace('PrivateAppRoot');
 
+const AUTH_STATES = Object.freeze({
+  SIGNUP_REDIRECT: 'signupRedirect',
+  RESOLVING: 'resolving',
+  AUTHENTICATED: 'authenticated',
+  REFRESHING_AUTHENTICATED: 'refreshingAuthenticated',
+  LOGGED_OUT: 'loggedOut',
+});
+
+const getAuthState = ({ isSignupProcess, isAuthenticated, isLoading, hasAuthenticatedOnce }) => {
+  if (isSignupProcess) {
+    return AUTH_STATES.SIGNUP_REDIRECT;
+  }
+
+  if (isAuthenticated) {
+    return AUTH_STATES.AUTHENTICATED;
+  }
+
+  if (isLoading && hasAuthenticatedOnce) {
+    return AUTH_STATES.REFRESHING_AUTHENTICATED;
+  }
+
+  if (isLoading) {
+    return AUTH_STATES.RESOLVING;
+  }
+
+  return AUTH_STATES.LOGGED_OUT;
+};
+
 export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
   const auth = useAuth();
+  const { isAuthenticated, isLoading, login } = auth;
   const config = useConfig();
-  const hasResolvedAuth = auth.isAuthenticated || !auth.isLoading;
-  const [isAuthBootstrapped, setIsAuthBootstrapped] = useState(auth.isAuthenticated);
+  const location = useLocation();
+  const [hasAuthenticatedOnce, setHasAuthenticatedOnce] = useState(isAuthenticated);
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -53,6 +83,12 @@ export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
       }),
   );
   const { isSignupProcess } = useSignupRedirect({ auth });
+  const authState = getAuthState({
+    isSignupProcess,
+    isAuthenticated,
+    isLoading,
+    hasAuthenticatedOnce,
+  });
 
   useEffect(() => {
     trace({ event: 'mounted' });
@@ -61,31 +97,37 @@ export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
 
   useEffect(() => {
     trace({
-      event: 'auth-gate-state-changed',
-      isAuthenticated: auth.isAuthenticated,
-      isLoading: auth.isLoading,
-      hasResolvedAuth,
-      isAuthBootstrapped,
-      isSignupProcess,
+      event: 'auth-state-changed',
+      authState,
     });
-  }, [auth.isAuthenticated, auth.isLoading, hasResolvedAuth, isAuthBootstrapped, isSignupProcess]);
+  }, [authState]);
 
   useEffect(() => {
-    if (!isAuthBootstrapped && auth.isAuthenticated) {
+    if (!hasAuthenticatedOnce && isAuthenticated) {
       trace({
-        event: 'auth-bootstrapped',
-        isAuthenticated: auth.isAuthenticated,
-        isLoading: auth.isLoading,
+        event: 'auth-authenticated-once',
+        isAuthenticated,
+        isLoading,
       });
-      // This is a one-way latch: once authenticated auth has resolved for this mount,
-      // keep the app bootstrapped so later token refreshes cannot remount the root by
-      // flipping auth.isLoading back on.
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setIsAuthBootstrapped(true);
+      setHasAuthenticatedOnce(true);
     }
-  }, [auth.isAuthenticated, auth.isLoading, isAuthBootstrapped]);
+  }, [hasAuthenticatedOnce, isAuthenticated, isLoading]);
 
-  if (!isAuthBootstrapped || isSignupProcess) {
+  useEffect(() => {
+    if (authState !== AUTH_STATES.LOGGED_OUT) {
+      return;
+    }
+
+    const returnTo = localStorage.getItem('afterSignupRedirectUrl') || location.pathname;
+
+    trace({ event: 'login-redirect-requested', returnTo });
+    login({ appState: { returnTo } }).then(() => {
+      localStorage.removeItem('afterSignupRedirectUrl');
+    });
+  }, [authState, location.pathname, login]);
+
+  if (![AUTH_STATES.AUTHENTICATED, AUTH_STATES.REFRESHING_AUTHENTICATED].includes(authState)) {
     return <Loading sx={{ pt: '60px' }} />;
   }
 

--- a/packages/components-organizations-registrar/src/components/organizations/CreateOrganization.jsx
+++ b/packages/components-organizations-registrar/src/components/organizations/CreateOrganization.jsx
@@ -312,7 +312,7 @@ const CreateOrganization = ({
                     sx={sxStyles.cancelButton}
                     onClick={() => (hasOrganisations ? navigate('/') : logout())}
                   >
-                    Cancel
+                    {hasOrganisations ? 'Cancel' : 'Log out & discard'}
                   </Button>
                   <OrganizationSubmitButton
                     title={buttonTitle}

--- a/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
+++ b/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
@@ -593,7 +593,7 @@ const OrganizationCreate = ({
                     sx={sx.cancelButton}
                     onClick={() => (hasOrganisations ? navigate('/') : logout())}
                   >
-                    Cancel
+                    {hasOrganisations ? 'Cancel' : 'Log out & discard'}
                   </Button>
                   <OrganizationSubmitButton />
                 </Box>

--- a/packages/components-organizations-registrar/src/utils/__tests__/reactAdminAuthProvider.test.js
+++ b/packages/components-organizations-registrar/src/utils/__tests__/reactAdminAuthProvider.test.js
@@ -1,0 +1,36 @@
+import { describe, it, mock } from 'node:test';
+import { expect } from 'expect';
+
+import initReactAdminAuthProvider from '../reactAdminAuthProvider.js';
+
+describe('initReactAdminAuthProvider', () => {
+  it('returns the Auth0 user identity', () => {
+    const authProvider = initReactAdminAuthProvider({
+      logout: mock.fn(),
+      user: {
+        sub: 'auth0|user-id',
+        name: 'Auth User',
+        picture: 'https://example.com/avatar.png',
+      },
+    });
+
+    expect(authProvider.getIdentity()).toEqual({
+      id: 'auth0|user-id',
+      fullName: 'Auth User',
+      avatar: 'https://example.com/avatar.png',
+    });
+  });
+
+  it('does not throw when Auth0 clears the user during logout', () => {
+    const authProvider = initReactAdminAuthProvider({
+      logout: mock.fn(),
+      user: undefined,
+    });
+
+    expect(authProvider.getIdentity()).toEqual({
+      id: '',
+      fullName: undefined,
+      avatar: undefined,
+    });
+  });
+});

--- a/packages/components-organizations-registrar/src/utils/auth/__tests__/useSignupRedirect.test.jsx
+++ b/packages/components-organizations-registrar/src/utils/auth/__tests__/useSignupRedirect.test.jsx
@@ -32,29 +32,9 @@ describe('useSignupRedirect', () => {
     auth: PropTypes.shape({
       isAuthenticated: PropTypes.bool.isRequired,
       isLoading: PropTypes.bool.isRequired,
-      login: PropTypes.func.isRequired,
       logout: PropTypes.func.isRequired,
     }).isRequired,
   };
-
-  it('starts the normal login redirect after auth resolves logged out', async () => {
-    const login = mock.fn(() => Promise.resolve());
-    const auth = {
-      isLoading: false,
-      isAuthenticated: false,
-      login,
-      logout: mock.fn(() => Promise.resolve()),
-    };
-
-    render(
-      <MemoryRouter initialEntries={['/organizations']}>
-        <TestComponent auth={auth} />
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => expect(login.mock.calls.length).toEqual(1));
-    expect(login.mock.calls[0].arguments).toEqual([{ appState: { returnTo: '/organizations' } }]);
-  });
 
   it('does not start normal login while an invitation signup URL is pending', async () => {
     const login = mock.fn(() => Promise.resolve());

--- a/packages/components-organizations-registrar/src/utils/auth/useSignupRedirect.js
+++ b/packages/components-organizations-registrar/src/utils/auth/useSignupRedirect.js
@@ -20,15 +20,15 @@ import { useEffect } from 'react';
 import { initTrace } from '../tracing.js';
 
 const trace = initTrace('useSignupRedirect');
+const REDIRECT_KEY = 'afterSignupRedirectUrl';
 
-const useSignupRedirect = ({ auth, options = {} }) => {
+const useSignupRedirect = ({ auth }) => {
   const [searchParams] = useSearchParams();
   const signupUrlParam = searchParams.get('signup_url');
 
   const [signupUrl, setSignupUrl] = useStore('signupUrl', null);
   const isSignupProcess = signupUrlParam != null || signupUrl != null;
 
-  const redirectKey = options.redirectKey ?? 'afterSignupRedirectUrl';
   const location = useLocation();
 
   useEffect(() => {
@@ -54,25 +54,12 @@ const useSignupRedirect = ({ auth, options = {} }) => {
     }
 
     trace({ event: 'signup-url-redirect-requested', pathname: location.pathname });
-    localStorage.setItem(redirectKey, location.pathname);
+    localStorage.setItem(REDIRECT_KEY, location.pathname);
 
     auth.logout().then(() => {
       window.location.replace(decodeURIComponent(signupUrl));
     });
-  }, [signupUrl, signupUrlParam, redirectKey, location.pathname, auth]);
-
-  useEffect(() => {
-    if (isSignupProcess || auth.isLoading || auth.isAuthenticated) {
-      return;
-    }
-
-    const returnTo = localStorage.getItem(redirectKey) || location.pathname;
-
-    trace({ event: 'login-redirect-requested', returnTo });
-    auth.login({ appState: { returnTo } }).then(() => {
-      localStorage.removeItem(redirectKey);
-    });
-  }, [isSignupProcess, auth.isLoading, auth.isAuthenticated, auth, location.pathname, redirectKey]);
+  }, [signupUrl, signupUrlParam, location.pathname, auth]);
 
   return { isSignupProcess };
 };

--- a/packages/components-organizations-registrar/src/utils/reactAdminAuthProvider.js
+++ b/packages/components-organizations-registrar/src/utils/reactAdminAuthProvider.js
@@ -35,7 +35,11 @@ const initReactAdminAuthProvider = (auth) => ({
   getPermissions: async () => {},
   // called when getting the user details. Ignore calls
   getIdentity: () => {
-    return { id: auth.user.sub, fullName: auth.user.name, avatar: auth.user.picture };
+    return {
+      id: auth.user?.sub ?? '',
+      fullName: auth.user?.name,
+      avatar: auth.user?.picture,
+    };
   },
 });
 


### PR DESCRIPTION
## Summary
- Forward-port release/1.1.x PR #594 into main.
- Tolerate Auth0 clearing user data during registrar logout.
- Centralize normal logged-out redirects in PrivateAppRoot and keep signup redirect handling focused on invitation signup redirects.
- Include the registrar auth provider regression coverage, plus the eslint autofix for the new test file on main.

## Context
This is the second PR in the 1.1.2 forward-port stack from release/1.1.x to main.
Merge after #597.

Original release PR: https://github.com/LFDT-Verii/core/pull/594
Cherry-picked from: 60fdccbebbd1e8b3e611c97b08596e1acd9960d5

## Validation
- NODE_OPTIONS=--experimental-specifier-resolution=node ../../node_modules/.bin/eslint --fix affected registrar files
- git diff --check
- Regression tests were run on the final stacked branch containing #587, #594, and #596: 6 passed