### PR TITLE
[codex] Forward-port #596 to main

### DIFF
--- a/packages/components-organizations-registrar/README.md
+++ b/packages/components-organizations-registrar/README.md
@@ -13,5 +13,19 @@ Style is maintained in eslint based on the monorepo root styles
 ## How to develop
 `> vite build:watch`
 
+## Auth contract
+Host applications provide authentication through `AuthContext`. The component
+library expects the host to provide the current auth state, token retrieval, and
+login/logout functions.
+
+`PrivateAppRoot` also reads `auth.isLogoutInProgress`. When this value is true,
+`PrivateAppRoot` enters its internal `resolvingLogout` state, renders the
+loading screen, and does not trigger the automatic login redirect. This prevents
+an explicit logout from racing against login and re-authenticating the user from
+an existing identity-provider session.
+
+Host apps should set `isLogoutInProgress` synchronously before starting provider
+logout. If omitted, it is treated as false.
+
 ## See how to use it
 [Sample Registrar App](../../samples/sample-registrar-app)

--- a/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
+++ b/packages/components-organizations-registrar/src/PrivateAppRoot.jsx
@@ -43,24 +43,31 @@ const AUTH_STATES = Object.freeze({
   RESOLVING: 'resolving',
   AUTHENTICATED: 'authenticated',
   REFRESHING_AUTHENTICATED: 'refreshingAuthenticated',
+  RESOLVING_LOGOUT: 'resolvingLogout',
   LOGGED_OUT: 'loggedOut',
 });
 
-const getAuthState = ({ isSignupProcess, isAuthenticated, isLoading, hasAuthenticatedOnce }) => {
+const getAuthState = ({
+  isSignupProcess,
+  isAuthenticated,
+  isLoading,
+  hasAuthenticatedOnce,
+  isLogoutInProgress,
+}) => {
   if (isSignupProcess) {
     return AUTH_STATES.SIGNUP_REDIRECT;
+  }
+
+  if (isLogoutInProgress) {
+    return AUTH_STATES.RESOLVING_LOGOUT;
   }
 
   if (isAuthenticated) {
     return AUTH_STATES.AUTHENTICATED;
   }
 
-  if (isLoading && hasAuthenticatedOnce) {
-    return AUTH_STATES.REFRESHING_AUTHENTICATED;
-  }
-
   if (isLoading) {
-    return AUTH_STATES.RESOLVING;
+    return hasAuthenticatedOnce ? AUTH_STATES.REFRESHING_AUTHENTICATED : AUTH_STATES.RESOLVING;
   }
 
   return AUTH_STATES.LOGGED_OUT;
@@ -68,7 +75,7 @@ const getAuthState = ({ isSignupProcess, isAuthenticated, isLoading, hasAuthenti
 
 export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
   const auth = useAuth();
-  const { isAuthenticated, isLoading, login } = auth;
+  const { isAuthenticated, isLoading, isLogoutInProgress = false, login } = auth;
   const config = useConfig();
   const location = useLocation();
   const [hasAuthenticatedOnce, setHasAuthenticatedOnce] = useState(isAuthenticated);
@@ -88,6 +95,7 @@ export const PrivateAppRoot = ({ extendedRemoteDataProvider, children }) => {
     isAuthenticated,
     isLoading,
     hasAuthenticatedOnce,
+    isLogoutInProgress,
   });
 
   useEffect(() => {

--- a/packages/components-organizations-registrar/src/components/AppBar/AppBarOrganization.jsx
+++ b/packages/components-organizations-registrar/src/components/AppBar/AppBarOrganization.jsx
@@ -33,7 +33,6 @@ import useSelectedOrganization from '../../state/selectedOrganizationState.js';
 import { useIsHideSidebar } from '../../utils/index.jsx';
 import useCountryCodes from '../../utils/countryCodes.js';
 import Loading from '../Loading.jsx';
-import { useAuth } from '../../utils/auth/AuthContext.js';
 
 // eslint-disable-next-line complexity
 const AppBarOrganization = () => {
@@ -41,7 +40,6 @@ const AppBarOrganization = () => {
   const isHidden = useIsHideSidebar();
   const redirect = useRedirect();
   const [did, setDid] = useSelectedOrganization();
-  const auth = useAuth();
   const logout = useLogout();
 
   const { data: allOrganizations, isLoading } = useGetList('organizations', undefined, {
@@ -94,7 +92,7 @@ const AppBarOrganization = () => {
 
   const handleLogoutClick = () => {
     setAnchorEl(null);
-    logout(auth, '/', false);
+    logout({ source: 'app-bar-organization' }, '/', false);
   };
 
   return (

--- a/packages/components-organizations-registrar/src/components/ConsentProvider.jsx
+++ b/packages/components-organizations-registrar/src/components/ConsentProvider.jsx
@@ -65,7 +65,11 @@ const ConsentProvider = ({ children }) => {
 
     const handleConsentError = (e) => {
       if (e.error && logoutErrors.includes(e.error)) {
-        logout({ logoutParams: { returnTo: window.location.origin } });
+        logout({
+          source: 'consent-error',
+          details: { error: e.error },
+          logoutParams: { returnTo: window.location.origin },
+        });
       }
     };
 
@@ -144,7 +148,7 @@ const ConsentProvider = ({ children }) => {
       <TermsOfUsePopup
         isOpen={isShouldAgreeWithNewVersion}
         onClose={() => {
-          logout();
+          logout({ source: 'terms-popup-close' });
         }}
         onProceed={onAgreeWithNewVersion}
         title={isNewUser ? 'Terms of use' : 'The terms of use were updated'}

--- a/packages/components-organizations-registrar/src/components/organizations/CreateOrganization.jsx
+++ b/packages/components-organizations-registrar/src/components/organizations/CreateOrganization.jsx
@@ -310,7 +310,11 @@ const CreateOrganization = ({
                     color="secondary"
                     size="large"
                     sx={sxStyles.cancelButton}
-                    onClick={() => (hasOrganisations ? navigate('/') : logout())}
+                    onClick={() =>
+                      hasOrganisations
+                        ? navigate('/')
+                        : logout({ source: 'create-organization-discard' })
+                    }
                   >
                     {hasOrganisations ? 'Cancel' : 'Log out & discard'}
                   </Button>

--- a/packages/components-organizations-registrar/src/index.jsx
+++ b/packages/components-organizations-registrar/src/index.jsx
@@ -19,6 +19,7 @@ export * from './PublicAppRoot.jsx';
 export * from './utils/auth/AuthContext.js';
 export * from './utils/auth/authScopes.js';
 export * from './utils/ConfigContext.js';
+export * from './utils/tracing.js';
 export * from './utils/chainNames.js';
 export * from './utils/serviceTypes.js';
 export * from './state/index.js';

--- a/packages/components-organizations-registrar/src/pages/invitations/CreateOrganisationFromInvitation.jsx
+++ b/packages/components-organizations-registrar/src/pages/invitations/CreateOrganisationFromInvitation.jsx
@@ -159,9 +159,9 @@ const CreateOrganizationFromInvitation = ({ InterceptOnOrganizationCreation }) =
         userEmail,
       });
       localStorage.setItem('createInvitationURL', window.location.pathname);
-      logout(auth, window.location.href, true);
+      logout({ source: 'invitation-email-mismatch' }, window.location.href, true);
     }
-  }, [userData, invitationData, logout, auth]);
+  }, [userData, invitationData, logout]);
 
   useEffect(() => {
     if (secretKeys) {

--- a/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
+++ b/packages/components-organizations-registrar/src/pages/organizations/OrganizationCreate.jsx
@@ -591,7 +591,11 @@ const OrganizationCreate = ({
                     color="secondary"
                     size="large"
                     sx={sx.cancelButton}
-                    onClick={() => (hasOrganisations ? navigate('/') : logout())}
+                    onClick={() =>
+                      hasOrganisations
+                        ? navigate('/')
+                        : logout({ source: 'organization-create-discard' })
+                    }
                   >
                     {hasOrganisations ? 'Cancel' : 'Log out & discard'}
                   </Button>

--- a/packages/components-organizations-registrar/src/utils/auth/__tests__/useSignupRedirect.test.jsx
+++ b/packages/components-organizations-registrar/src/utils/auth/__tests__/useSignupRedirect.test.jsx
@@ -53,6 +53,7 @@ describe('useSignupRedirect', () => {
     );
 
     await waitFor(() => expect(logout.mock.calls.length).toEqual(1));
+    expect(logout.mock.calls[0].arguments).toEqual([{ source: 'signup-redirect' }]);
     expect(login.mock.calls.length).toEqual(0);
   });
 });

--- a/packages/components-organizations-registrar/src/utils/auth/useSignupRedirect.js
+++ b/packages/components-organizations-registrar/src/utils/auth/useSignupRedirect.js
@@ -56,7 +56,7 @@ const useSignupRedirect = ({ auth }) => {
     trace({ event: 'signup-url-redirect-requested', pathname: location.pathname });
     localStorage.setItem(REDIRECT_KEY, location.pathname);
 
-    auth.logout().then(() => {
+    auth.logout({ source: 'signup-redirect' }).then(() => {
       window.location.replace(decodeURIComponent(signupUrl));
     });
   }, [signupUrl, signupUrlParam, location.pathname, auth]);


### PR DESCRIPTION
## Summary
- Forward-port release/1.1.x PR #596 into main.
- Pass explicit logout source metadata through registrar logout entry points.
- Add the resolvingLogout auth state and export tracing utilities needed by registrar consumers.

## Context
This is the third PR in the 1.1.2 forward-port stack from release/1.1.x to main.
Merge after #597 and #598.

Original release PR: https://github.com/LFDT-Verii/core/pull/596
Cherry-picked from: c95cefaa20de7e9a1bef31cd2238bd5c0cf6fdb2

## Validation
- NODE_OPTIONS=--experimental-specifier-resolution=node ../../node_modules/.bin/eslint --fix affected registrar files
- git diff --check
- node --enable-source-maps --import=global-jsdom/register --import=./setup-tests.js --test --test-concurrency=1 --experimental-test-module-mocks --test-reporter=spec --test-reporter-destination=stdout src/pages/organizations/__tests__/OrganizationCreate.test.jsx src/pages/organizations/__tests__/OrganizationCreate.integration.test.jsx src/utils/auth/__tests__/useSignupRedirect.test.jsx src/utils/__tests__/reactAdminAuthProvider.test.js

Test result: 6 passed