### PR TITLE
ci: allow dependency bots to trigger Claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          allowed_bots: 'renovate[bot]'
+          allowed_bots: 'dependabot[bot],renovate[bot]'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          allowed_bots: 'renovate[bot]'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary
- Allow Renovate and Dependabot PRs to trigger the Claude Code Review workflow via the Claude action bot allowlist

## Verification
- Reviewed recent Dependabot PR history; REST/search payloads report Dependabot PR authors as dependabot[bot]
- Checked anthropics/claude-code-action actor validation; allowed_bots normalizes dependabot[bot] and renovate[bot] by stripping the [bot] suffix before matching
- Not run locally; workflow configuration only