### PR TITLE
fix(security): override fast-jwt to 6.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "stop": "docker compose down -v"
   },
   "// mocha-serialize-javascript-override-note": "Temporary: remove this mocha>serialize-javascript override once the Hardhat dependency path no longer resolves serialize-javascript 6.x (Dependabot alert #148 / GHSA-5c6j-r48x-rmvq).",
+  "// fast-jwt-override-note": "Temporary: force patched fast-jwt for known production importers (@fastify/jwt and undici-oidc-interceptor@0.9.0) for GHSA-gmvf-9v4p-v8jc. Remove once both importers transitively resolve fast-jwt >=6.2.4 without overrides.",
   "// lodash-override-note": "Temporary: remove these package-specific lodash overrides once eslint-plugin-better-mutation, ra-data-local-storage, and ra-ui-materialui stop pinning lodash 4.17.x.",
   "pnpm": {
     "overrides": {
@@ -43,7 +44,9 @@
       "auth0>uuid": "^14.0.0",
       "eslint-plugin-better-mutation>lodash": "^4.18.0",
       "ra-data-local-storage>lodash": "^4.18.0",
-      "ra-ui-materialui>lodash": "^4.18.0"
+      "ra-ui-materialui>lodash": "^4.18.0",
+      "@fastify/jwt@*>fast-jwt": "6.2.4",
+      "undici-oidc-interceptor@0.9.0>fast-jwt": "6.2.4"
     },
     "onlyBuiltDependencies": [
       "@sentry/profiling-node",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,8 @@ overrides:
   eslint-plugin-better-mutation>lodash: ^4.18.0
   ra-data-local-storage>lodash: ^4.18.0
   ra-ui-materialui>lodash: ^4.18.0
+  '@fastify/jwt@*>fast-jwt': 6.2.4
+  undici-oidc-interceptor@0.9.0>fast-jwt: 6.2.4
 
 importers:
 
@@ -8175,8 +8177,8 @@ packages:
   fast-json-stringify@6.3.0:
     resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
 
-  fast-jwt@6.2.2:
-    resolution: {integrity: sha512-lzy+8JVyBOvwxjydFRBKLFVe1elRArL37pHRX1zHPt4T7FP7kNIpqauE1lOjZlD79DBzzRzQmp+28wbsY13weA==}
+  fast-jwt@6.2.4:
+    resolution: {integrity: sha512-IoQa53wI6TbARU2yelb0L44ggFQnP2qVcwswCSYHbCAWuwpr70icDb3QjG0v01I8Tt01rVGDkN/rRvpk0lKFTA==}
     engines: {node: '>=20'}
 
   fast-levenshtein@2.0.6:
@@ -12515,7 +12517,7 @@ snapshots:
     dependencies:
       '@fastify/error': 4.2.0
       '@lukeed/ms': 2.0.2
-      fast-jwt: 6.2.2
+      fast-jwt: 6.2.4
       fastify-plugin: 5.1.0
       steed: 1.1.3
 
@@ -16513,7 +16515,7 @@ snapshots:
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
-  fast-jwt@6.2.2:
+  fast-jwt@6.2.4:
     dependencies:
       '@lukeed/ms': 2.0.2
       asn1.js: 5.4.1
@@ -19360,7 +19362,7 @@ snapshots:
   undici-oidc-interceptor@0.9.0:
     dependencies:
       async-cache-dedupe: 3.4.0
-      fast-jwt: 6.2.2
+      fast-jwt: 6.2.4
       undici: 7.25.0
 
   undici-types@6.19.8: {}


### PR DESCRIPTION
## Summary
- replace global `fast-jwt` pin with importer-scoped overrides:
  - `@fastify/jwt@*>fast-jwt: 6.2.4`
  - `undici-oidc-interceptor@0.9.0>fast-jwt: 6.2.4`
- refresh `pnpm-lock.yaml` so the scoped selectors appear in lockfile `overrides`
- keep `fast-xml-builder` unchanged (handled separately via Renovate/AWS SDK upgrade path)

## Why
This mitigates Dependabot alert GHSA-gmvf-9v4p-v8jc while being explicit about the exact production importer chains that pull `fast-jwt`.

## Validation
- `corepack pnpm@10.33.4 install --lockfile-only --no-frozen-lockfile`
- lockfile confirms `fast-jwt@6.2.4` for both scoped importer paths

