### PR TITLE
[codex] align pnpm instructions with package.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,6 @@
 - After modifying `.js` or `.ts` files, run `eslint --fix` on the affected files.
 
 ## pnpm workspace rules
-- Use the package manager declared in the root `package.json` `packageManager` field for all dependency commands, e.g. `corepack $(node -p "require('./package.json').packageManager")`.
+- Use the pnpm for all dependency commands, e.g. `corepack $(node -p "require('./package.json').packageManager")`.
 - After rebasing onto `origin/main` and no conflicts you can run:
   - `corepack $(node -p "require('./package.json').packageManager") install --lockfile-only --no-frozen-lockfile`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,6 @@
 - After modifying `.js` or `.ts` files, run `eslint --fix` on the affected files.
 
 ## pnpm workspace rules
-- Use the pnpm for all dependency commands, e.g. `corepack $(node -p "require('./package.json').packageManager")`.
+- Use `corepack $(node -p "require('./package.json').packageManager")` for all dependency commands
 - After rebasing onto `origin/main` and no conflicts you can run:
   - `corepack $(node -p "require('./package.json').packageManager") install --lockfile-only --no-frozen-lockfile`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,6 @@
 - After modifying `.js` or `.ts` files, run `eslint --fix` on the affected files.
 
 ## pnpm workspace rules
-- Use `corepack pnpm@10.30.2` for all dependency commands.
+- Use the package manager declared in the root `package.json` `packageManager` field for all dependency commands, e.g. `corepack $(node -p "require('./package.json').packageManager")`.
 - After rebasing onto `origin/main` and no conflicts you can run:
-  - `corepack pnpm@10.30.2 install --lockfile-only --no-frozen-lockfile`
+  - `corepack $(node -p "require('./package.json').packageManager") install --lockfile-only --no-frozen-lockfile`


### PR DESCRIPTION
## Summary

- Update AGENTS.md pnpm workspace instructions to read the package manager from the root package.json packageManager field.
- Replace the hardcoded pnpm 10.30.2 examples with a corepack command that follows the repo-declared pnpm version.

## Why

The repo now declares pnpm@10.33.4 in package.json, while AGENTS.md still instructed agents to use pnpm@10.30.2. Reading packageManager keeps future dependency commands aligned with the repository without another docs update for every pnpm bump.

## Validation

- Docs-only change; no code tests required.
