### PR TITLE
[codex] Tighten Renovate pinning policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,18 +26,29 @@
       "matchDatasources": [
         "npm"
       ],
-      "matchCurrentValue": "/^\\^[1-9]\\d*\\.\\d+\\.\\d+$/",
+      "matchCurrentValue": "/^[~^]?[1-9]\\d*\\.\\d+\\.\\d+$/",
       "rangeStrategy": "bump",
-      "description": "Keep stable npm caret ranges current in package manifests so shared pnpm lockfile refreshes don't split into lockfile-only PRs."
+      "description": "Keep stable npm v1+ semver dependencies current in package manifests so shared pnpm lockfile refreshes don't split into lockfile-only PRs."
     },
     {
       "matchDatasources": [
         "npm"
       ],
-      "matchCurrentValue": "/^[~^]?0\\./",
+      "matchUpdateTypes": [
+        "pin"
+      ],
+      "matchCurrentValue": "/^[~^]?[1-9]\\d*\\.\\d+\\.\\d+$/",
+      "enabled": false,
+      "description": "Stable npm v1+ packages should remain range-based instead of being pinned by config:best-practices."
+    },
+    {
+      "matchDatasources": [
+        "npm"
+      ],
+      "matchCurrentValue": "/^(?![~^]?[1-9]\\d*\\.\\d+\\.\\d+$).+/",
       "rangeStrategy": "pin",
       "automerge": false,
-      "description": "Pre-1.0 npm packages may break in minor or patch releases, so pin them exactly and require review."
+      "description": "Pre-1.0, prerelease, and other non-plain-stable npm values may break outside major-version semver guarantees, so pin them exactly and require review."
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Summary
- broaden stable npm v1+ matching so caret, tilde, and exact stable semver values share the same bump policy
- disable inherited Renovate pin PRs for stable npm v1+ dependencies
- pin and require review for pre-1.0, prerelease, and other non-plain-stable npm values

## Validation
- node JSON parse for renovate.json
- corepack pnpm@10.30.2 dlx --package renovate renovate-config-validator renovate.json
- git diff --check