### PR TITLE
[codex] remove stale pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "stop": "docker compose down -v"
   },
   "// mocha-serialize-javascript-override-note": "Temporary: remove this mocha>serialize-javascript override once the Hardhat dependency path no longer resolves serialize-javascript 6.x (Dependabot alert #148 / GHSA-5c6j-r48x-rmvq).",
+  "// auth0-uuid-override-note": "Temporary: remove this auth0>uuid override once auth0 no longer resolves uuid 9.x through its auth0-legacy dependency path.",
   "// lodash-override-note": "Temporary: remove this eslint-plugin-better-mutation>lodash override once eslint-plugin-better-mutation stops pinning lodash 4.17.x.",
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -36,17 +36,12 @@
     "stop": "docker compose down -v"
   },
   "// mocha-serialize-javascript-override-note": "Temporary: remove this mocha>serialize-javascript override once the Hardhat dependency path no longer resolves serialize-javascript 6.x (Dependabot alert #148 / GHSA-5c6j-r48x-rmvq).",
-  "// fast-jwt-override-note": "Temporary: force patched fast-jwt for known production importers (@fastify/jwt and undici-oidc-interceptor@0.9.0) for GHSA-gmvf-9v4p-v8jc. Remove once both importers transitively resolve fast-jwt >=6.2.4 without overrides.",
-  "// lodash-override-note": "Temporary: remove these package-specific lodash overrides once eslint-plugin-better-mutation, ra-data-local-storage, and ra-ui-materialui stop pinning lodash 4.17.x.",
+  "// lodash-override-note": "Temporary: remove this eslint-plugin-better-mutation>lodash override once eslint-plugin-better-mutation stops pinning lodash 4.17.x.",
   "pnpm": {
     "overrides": {
       "mocha>serialize-javascript": "7.0.5",
       "auth0>uuid": "^14.0.0",
-      "eslint-plugin-better-mutation>lodash": "^4.18.0",
-      "ra-data-local-storage>lodash": "^4.18.0",
-      "ra-ui-materialui>lodash": "^4.18.0",
-      "@fastify/jwt@*>fast-jwt": "6.2.4",
-      "undici-oidc-interceptor@0.9.0>fast-jwt": "6.2.4"
+      "eslint-plugin-better-mutation>lodash": "^4.18.0"
     },
     "onlyBuiltDependencies": [
       "@sentry/profiling-node",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,10 +8,6 @@ overrides:
   mocha>serialize-javascript: 7.0.5
   auth0>uuid: ^14.0.0
   eslint-plugin-better-mutation>lodash: ^4.18.0
-  ra-data-local-storage>lodash: ^4.18.0
-  ra-ui-materialui>lodash: ^4.18.0
-  '@fastify/jwt@*>fast-jwt': 6.2.4
-  undici-oidc-interceptor@0.9.0>fast-jwt: 6.2.4
 
 importers:
 


### PR DESCRIPTION
## Summary
- remove stale pnpm overrides for React Admin lodash and fast-jwt importers
- update the package.json override note so it only documents the remaining lodash override
- refresh the lockfile override block with pnpm 10.33.4

## Validation
- corepack $(node -p "require('./package.json').packageManager") install --lockfile-only --ignore-scripts
- git diff --check HEAD~1..HEAD