### PR TITLE
[codex] Tighten wallet SDK taxonomy compatibility mapping

### DIFF
--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/CredentialManifestRepositoryImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/CredentialManifestRepositoryImpl.ts
@@ -8,7 +8,9 @@ import { HttpMethod } from '../infrastructure/network/HttpMethod';
 import {
     toClientRequestFetchError,
     ErrorTaxonomy,
+    invalidLink,
 } from '../../utils/ErrorTaxonomy';
+import VelocityDeepLinkValidator from '../../utils/VelocityDeepLinkValidator';
 
 export default class CredentialManifestRepositoryImpl implements CredentialManifestRepository {
     constructor(private readonly networkService: NetworkService) {}
@@ -18,8 +20,11 @@ export default class CredentialManifestRepositoryImpl implements CredentialManif
     ): Promise<string> {
         const { endpoint } = credentialManifestDescriptor;
         if (!endpoint) {
-            throw new VCLError({
+            throw invalidLink({
                 message: 'credentialManifestDescriptor.endpoint = null',
+                sourceErrorCode:
+                    VelocityDeepLinkValidator.SourceInvalidOrMissingRequestEndpoint,
+                requestKind: ErrorTaxonomy.RequestKindIssuing,
             });
         }
 

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/PresentationRequestRepositoryImpl.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/data/repositories/PresentationRequestRepositoryImpl.ts
@@ -8,7 +8,9 @@ import { HttpMethod } from '../infrastructure/network/HttpMethod';
 import {
     toClientRequestFetchError,
     ErrorTaxonomy,
+    invalidLink,
 } from '../../utils/ErrorTaxonomy';
+import VelocityDeepLinkValidator from '../../utils/VelocityDeepLinkValidator';
 
 export default class PresentationRequestRepositoryImpl implements PresentationRequestRepository {
     constructor(private readonly networkService: NetworkService) {}
@@ -18,8 +20,11 @@ export default class PresentationRequestRepositoryImpl implements PresentationRe
     ): Promise<string> {
         const { endpoint } = presentationRequestDescriptor;
         if (!endpoint) {
-            throw new VCLError({
+            throw invalidLink({
                 message: 'presentationRequestDescriptor.endpoint = null',
+                sourceErrorCode:
+                    VelocityDeepLinkValidator.SourceInvalidOrMissingRequestEndpoint,
+                requestKind: ErrorTaxonomy.RequestKindPresentation,
             });
         }
 

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/utils/ErrorTaxonomyCompatibilityMapper.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/utils/ErrorTaxonomyCompatibilityMapper.ts
@@ -43,13 +43,7 @@ export default class ErrorTaxonomyCompatibilityMapper {
         const endpointNullMessage = legacyEndpointNullMessage(requestKind);
         switch (error.sourceErrorCode) {
             case VelocityDeepLinkValidator.SourceInvalidOrMissingDid:
-                return error.requestUri
-                    ? this.legacyCopy(error, mismatchErrorCode(requestKind))
-                    : this.legacyCopy(
-                          error,
-                          VCLErrorCode.SdkError,
-                          legacyMissingDidMessage,
-                      );
+                return this.mapInvalidOrMissingDid(error, requestKind);
             case VelocityDeepLinkValidator.SourceInvalidOrMissingRequestUri:
             case VelocityDeepLinkValidator.SourceInvalidOrMissingRequestEndpoint:
                 return this.mapInvalidRequestUri(error, endpointNullMessage);
@@ -68,6 +62,19 @@ export default class ErrorTaxonomyCompatibilityMapper {
             default:
                 return this.legacyCopy(error, VCLErrorCode.SdkError);
         }
+    }
+
+    private mapInvalidOrMissingDid(
+        error: VCLError,
+        requestKind: RequestKind,
+    ): VCLError {
+        return error.requestUri
+            ? this.legacyCopy(error, mismatchErrorCode(requestKind))
+            : this.legacyCopy(
+                  error,
+                  VCLErrorCode.SdkError,
+                  legacyMissingDidMessage,
+              );
     }
 
     private mapInvalidRequestUri(

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/utils/ErrorTaxonomyCompatibilityMapper.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/utils/ErrorTaxonomyCompatibilityMapper.ts
@@ -32,7 +32,7 @@ export default class ErrorTaxonomyCompatibilityMapper {
             default:
                 return isTaxonomyError(error)
                     ? this.mapTaxonomyError(error)
-                    : this.mapNetworkStatus(error);
+                    : error;
         }
     }
 
@@ -96,28 +96,23 @@ export default class ErrorTaxonomyCompatibilityMapper {
     }
 
     private mapTaxonomyError(error: VCLError): VCLError {
-        const networkStatusError = this.mapNetworkStatus(error);
-        const { sourceErrorCode } = networkStatusError;
-        if (isLegacyPlainTextRequestRejection(networkStatusError)) {
+        const { sourceErrorCode } = error;
+        if (isLegacyPlainTextRequestRejection(error)) {
             return this.legacyCopy(
-                networkStatusError,
+                error,
                 VCLErrorCode.SdkError,
-                `Request failed with status code ${networkStatusError.statusCode}`,
+                `Request failed with status code ${error.statusCode}`,
             );
         }
         if (
             !sourceErrorCode ||
-            sourceErrorCode === networkStatusError.errorCode ||
+            sourceErrorCode === error.errorCode ||
             sourceErrorCode ===
                 ProfileServiceTypeVerifier.SourceWrongServiceType
         ) {
-            return this.legacyCopy(networkStatusError, VCLErrorCode.SdkError);
+            return this.legacyCopy(error, VCLErrorCode.SdkError);
         }
-        return this.legacyCopy(networkStatusError, sourceErrorCode);
-    }
-
-    private mapNetworkStatus(error: VCLError): VCLError {
-        return error;
+        return this.legacyCopy(error, sourceErrorCode);
     }
 
     private legacyCopy(

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/utils/ErrorTaxonomyCompatibilityMapper.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/utils/ErrorTaxonomyCompatibilityMapper.ts
@@ -59,12 +59,14 @@ export default class ErrorTaxonomyCompatibilityMapper {
                     VCLErrorCode.SdkError,
                     legacyMissingDidMessage,
                 );
-            default:
+            case VelocityDeepLinkValidator.SourceUnsupportedVelocityLink:
                 return this.legacyCopy(
                     error,
                     VCLErrorCode.SdkError,
                     endpointNullMessage,
                 );
+            default:
+                return this.legacyCopy(error, VCLErrorCode.SdkError);
         }
     }
 
@@ -115,10 +117,7 @@ export default class ErrorTaxonomyCompatibilityMapper {
     }
 
     private mapNetworkStatus(error: VCLError): VCLError {
-        const payloadStatusCode = payloadStatus(error.payload);
-        return payloadStatusCode == null
-            ? error
-            : copyError(error, { statusCode: payloadStatusCode });
+        return error;
     }
 
     private legacyCopy(
@@ -144,16 +143,6 @@ const mismatchErrorCode = (requestKind: RequestKind) =>
     requestKind === ErrorTaxonomy.RequestKindPresentation
         ? VCLErrorCode.MismatchedPresentationRequestInspectorDid
         : VCLErrorCode.MismatchedRequestIssuerDid;
-
-const payloadStatus = (payload: string | null | undefined) => {
-    try {
-        const parsed = payload ? JSON.parse(payload) : null;
-        const value = parsed?.[VCLError.KeyStatusCode];
-        return typeof value === 'number' ? value : null;
-    } catch {
-        return null;
-    }
-};
 
 const optionalStatusCode = (overrides: { statusCode?: number | null }) =>
     Object.prototype.hasOwnProperty.call(overrides, 'statusCode')

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/utils/VelocityDeepLinkValidator.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/utils/VelocityDeepLinkValidator.ts
@@ -34,7 +34,7 @@ export default class VelocityDeepLinkValidator {
         requestKind: RequestKind;
     }): VCLError | null {
         const parsedUrl = parseUrl(deepLink.value);
-        if (!parsedUrl) {
+        if (!hasParseableVelocityPayload(parsedUrl)) {
             return invalidLink({
                 message: 'Payload is not a parseable URL',
                 sourceErrorCode:
@@ -43,21 +43,7 @@ export default class VelocityDeepLinkValidator {
                 requestKind,
             });
         }
-        if (!parsedUrl.hostname) {
-            return invalidLink({
-                message: 'Payload is not a parseable URL',
-                sourceErrorCode:
-                    VelocityDeepLinkValidator.SourceUnparseablePayload,
-                requestUri: deepLink.requestUri,
-                requestKind,
-            });
-        }
-        if (
-            !VelocityDeepLinkValidator.AllowedVelocitySchemes.has(
-                parsedUrl.protocol,
-            ) ||
-            parsedUrl.hostname !== expectedPath
-        ) {
+        if (isUnsupportedVelocityLink(parsedUrl, expectedPath)) {
             return invalidLink({
                 message: `Unsupported Velocity link: ${deepLink.value}`,
                 sourceErrorCode:
@@ -127,6 +113,16 @@ const hasValidDidParts = (did: string) => {
     const method = didParts.slice(0, methodEndIndex);
     return /^[a-z0-9]+$/.test(method);
 };
+
+const hasParseableVelocityPayload = (parsedUrl: URL | null): parsedUrl is URL =>
+    parsedUrl != null && Boolean(parsedUrl.hostname);
+
+const isUnsupportedVelocityLink = (
+    parsedUrl: URL,
+    expectedPath: string,
+): boolean =>
+    !VelocityDeepLinkValidator.AllowedVelocitySchemes.has(parsedUrl.protocol) ||
+    parsedUrl.hostname !== expectedPath;
 
 const parseUrl = (value: string) => {
     try {

--- a/packages/vnf-wallet-sdk-nodejs/src/impl/utils/VelocityDeepLinkValidator.ts
+++ b/packages/vnf-wallet-sdk-nodejs/src/impl/utils/VelocityDeepLinkValidator.ts
@@ -43,6 +43,15 @@ export default class VelocityDeepLinkValidator {
                 requestKind,
             });
         }
+        if (!parsedUrl.hostname) {
+            return invalidLink({
+                message: 'Payload is not a parseable URL',
+                sourceErrorCode:
+                    VelocityDeepLinkValidator.SourceUnparseablePayload,
+                requestUri: deepLink.requestUri,
+                requestKind,
+            });
+        }
         if (
             !VelocityDeepLinkValidator.AllowedVelocitySchemes.has(
                 parsedUrl.protocol,

--- a/packages/vnf-wallet-sdk-nodejs/test/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaseline.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaseline.test.ts
@@ -6,7 +6,9 @@ import {
     VCLEnvironment,
     VCLError,
     VCLErrorCode,
+    VCLCredentialManifestDescriptor,
     VCLCredentialManifestDescriptorByDeepLink,
+    VCLCredentialManifestDescriptorByService,
     VCLDeepLink,
     VCLCryptoServicesDescriptor,
     VCLIssuingType,
@@ -15,6 +17,7 @@ import {
     VCLJwtVerifyService,
     VCLPresentationRequestDescriptor,
     VCLPublicJwk,
+    VCLService,
     VCLStatusCode,
     VCLToken,
     VCLXVnfProtocolVersion,
@@ -36,11 +39,6 @@ import {
 } from '../../src/impl/data/verifiers';
 import Request from '../../src/impl/data/infrastructure/network/Request';
 import { ProfileServiceTypeVerifier } from '../../src/impl/utils/ProfileServiceTypeVerifier';
-import ErrorTaxonomyCompatibilityMapper from '../../src/impl/utils/ErrorTaxonomyCompatibilityMapper';
-import {
-    ErrorTaxonomy,
-    invalidLink,
-} from '../../src/impl/utils/ErrorTaxonomy';
 import { JwtSignServiceMock } from '../infrastructure/resources/jwt/JwtSignServiceMock';
 import { KeyServiceMock } from '../infrastructure/resources/key/KeyServiceMock';
 import { DeepLinkMocks } from '../infrastructure/resources/valid/DeepLinkMocks';
@@ -149,14 +147,10 @@ describe('Error taxonomy backward compatibility baseline', () => {
         }
     });
 
-    test('missing direct request did preserves legacy did message', () => {
-        const error = new ErrorTaxonomyCompatibilityMapper().map({
-            error: invalidLink({
-                message: 'did was not found in credentialManifestDescriptor',
-                requestKind: ErrorTaxonomy.RequestKindIssuing,
-            }),
-            requestKind: ErrorTaxonomy.RequestKindIssuing,
-        });
+    test('missing direct request did preserves legacy did message', async () => {
+        const error = await getCredentialManifestDescriptorError(
+            credentialManifestDescriptorByService({ did: '' }),
+        );
 
         expect(error.errorCode).toEqual(VCLErrorCode.SdkError);
         expect(error.message).toContain('did was not found');
@@ -565,6 +559,43 @@ const credentialManifestDescriptor = (deepLink: VCLDeepLink) =>
         null,
         DidJwkMocks.DidJwk,
     );
+
+const credentialManifestDescriptorByService = ({
+    endpoint = DeepLinkMocks.CredentialManifestRequestDecodedUriStr,
+    did = DeepLinkMocks.IssuerDid,
+}: {
+    endpoint?: string | null;
+    did?: string;
+} = {}) =>
+    new VCLCredentialManifestDescriptorByService(
+        new VCLService({
+            id: `${DeepLinkMocks.IssuerDid}#credential-agent-issuer-1`,
+            type: 'VelocityCredentialAgentIssuer_v1.0',
+            serviceEndpoint: endpoint,
+            credentialTypes: ['PastEmploymentPosition'],
+        }),
+        VCLIssuingType.Career,
+        null,
+        null,
+        DidJwkMocks.DidJwk,
+        did,
+    );
+
+const getCredentialManifestDescriptorError = async (
+    descriptor: VCLCredentialManifestDescriptor,
+    jwtVerificationError?: VCLError,
+): Promise<VCLError> => {
+    const vcl = initializedVcl(jwtVerificationError);
+
+    try {
+        await vcl.getCredentialManifest(descriptor);
+    } catch (error) {
+        expect(error).toBeInstanceOf(VCLError);
+        return error as VCLError;
+    }
+
+    throw new Error('Expected getCredentialManifest to reject with VCLError');
+};
 
 const presentationDescriptor = (deepLink: VCLDeepLink) =>
     new VCLPresentationRequestDescriptor(deepLink, null, DidJwkMocks.DidJwk);

--- a/packages/vnf-wallet-sdk-nodejs/test/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaseline.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaseline.test.ts
@@ -36,6 +36,11 @@ import {
 } from '../../src/impl/data/verifiers';
 import Request from '../../src/impl/data/infrastructure/network/Request';
 import { ProfileServiceTypeVerifier } from '../../src/impl/utils/ProfileServiceTypeVerifier';
+import ErrorTaxonomyCompatibilityMapper from '../../src/impl/utils/ErrorTaxonomyCompatibilityMapper';
+import {
+    ErrorTaxonomy,
+    invalidLink,
+} from '../../src/impl/utils/ErrorTaxonomy';
 import { JwtSignServiceMock } from '../infrastructure/resources/jwt/JwtSignServiceMock';
 import { KeyServiceMock } from '../infrastructure/resources/key/KeyServiceMock';
 import { DeepLinkMocks } from '../infrastructure/resources/valid/DeepLinkMocks';
@@ -144,6 +149,19 @@ describe('Error taxonomy backward compatibility baseline', () => {
         }
     });
 
+    test('missing direct request did preserves legacy did message', () => {
+        const error = new ErrorTaxonomyCompatibilityMapper().map({
+            error: invalidLink({
+                message: 'did was not found in credentialManifestDescriptor',
+                requestKind: ErrorTaxonomy.RequestKindIssuing,
+            }),
+            requestKind: ErrorTaxonomy.RequestKindIssuing,
+        });
+
+        expect(error.errorCode).toEqual(VCLErrorCode.SdkError);
+        expect(error.message).toContain('did was not found');
+    });
+
     test('malformed and disallowed request_uri values reach transport as raw endpoint text', async () => {
         for (const entryPoint of entryPoints) {
             const malformedRequestUriDeepLink = new VCLDeepLink(
@@ -202,7 +220,7 @@ describe('Error taxonomy backward compatibility baseline', () => {
                 expect(error.errorCode).toEqual(ErrorMocks.ErrorCode);
                 expect(error.requestId).toEqual(ErrorMocks.RequestId);
                 expect(error.message).toEqual(ErrorMocks.Message);
-                expect(error.statusCode).toEqual(ErrorMocks.StatusCode);
+                expect(error.statusCode).toEqual(statusCode);
             }
         }
     });
@@ -256,7 +274,7 @@ describe('Error taxonomy backward compatibility baseline', () => {
             expect(error.errorCode).toEqual(VCLErrorCode.SdkError);
             expect(error.requestId).toEqual(ErrorMocks.RequestId);
             expect(error.message).toEqual(ErrorMocks.Message);
-            expect(error.statusCode).toEqual(ErrorMocks.StatusCode);
+            expect(error.statusCode).toEqual(422);
         }
     });
 

--- a/packages/vnf-wallet-sdk-nodejs/test/backwardscompatibility/ErrorTaxonomyContract.test.ts
+++ b/packages/vnf-wallet-sdk-nodejs/test/backwardscompatibility/ErrorTaxonomyContract.test.ts
@@ -145,6 +145,26 @@ describe('Error taxonomy contract', () => {
         }
     });
 
+    test('opaque velocity uris return unparseable invalid link', async () => {
+        for (const entryPoint of entryPoints) {
+            const deepLink = new VCLDeepLink(
+                `velocity-network:${entryPoint.schemePath}?request_uri=${entryPoint.encodedRequestUri}&${entryPoint.didParam}=did:example:entity`,
+            );
+            const error = await getEntryPointError(entryPoint, deepLink);
+
+            assertDiagnostics(
+                expectedDiagnostics(entryPoint, {
+                    errorCode: VCLErrorCode.InvalidLink,
+                    sourceErrorCode:
+                        VelocityDeepLinkValidator.SourceUnparseablePayload,
+                    validationPhase: 'link_validation',
+                    requestUri: deepLink.requestUri,
+                }),
+                error,
+            );
+        }
+    });
+
     test('unsupported scheme with known query params returns null endpoint sdk_error', async () => {
         for (const entryPoint of entryPoints) {
             const deepLink = new VCLDeepLink(
@@ -322,6 +342,32 @@ describe('Error taxonomy contract', () => {
             }),
             error,
         );
+    });
+
+    test('repository null endpoint fallbacks return invalid link diagnostics', async () => {
+        for (const { entryPoint, getError } of [
+            {
+                entryPoint: issuingEntryPoint(),
+                getError: getCredentialManifestRepositoryNullEndpointError,
+            },
+            {
+                entryPoint: presentationEntryPoint(),
+                getError: getPresentationRequestRepositoryNullEndpointError,
+            },
+        ]) {
+            const error = await getError();
+
+            assertDiagnostics(
+                expectedDiagnostics(entryPoint, {
+                    errorCode: VCLErrorCode.InvalidLink,
+                    sourceErrorCode:
+                        VelocityDeepLinkValidator.SourceInvalidOrMissingRequestEndpoint,
+                    validationPhase: 'link_validation',
+                }),
+                error,
+            );
+            expect(error.message).toContain('endpoint = null');
+        }
     });
 
     test('missing presentation request deep link returns invalid link', async () => {
@@ -1088,6 +1134,59 @@ const getPresentationRequestDescriptorError = async (
 
     throw new Error('Expected getPresentationRequest to reject with VCLError');
 };
+
+const getCredentialManifestRepositoryNullEndpointError =
+    async (): Promise<VCLError> => {
+        try {
+            await new CredentialManifestRepositoryImpl(
+                unusedNetworkService(),
+            ).getCredentialManifest(
+                credentialManifestDescriptor(
+                    new VCLDeepLink(
+                        `velocity-network://issue?issuerDid=${issuingEntryPoint().did}`,
+                    ),
+                ),
+            );
+        } catch (error) {
+            expect(error).toBeInstanceOf(VCLError);
+            return error as VCLError;
+        }
+
+        throw new Error(
+            'Expected getCredentialManifest repository to reject with VCLError',
+        );
+    };
+
+const getPresentationRequestRepositoryNullEndpointError =
+    async (): Promise<VCLError> => {
+        try {
+            await new PresentationRequestRepositoryImpl(
+                unusedNetworkService(),
+            ).getPresentationRequest(
+                presentationDescriptor(
+                    new VCLDeepLink(
+                        `velocity-network://inspect?inspectorDid=${presentationEntryPoint().did}`,
+                    ),
+                ),
+            );
+        } catch (error) {
+            expect(error).toBeInstanceOf(VCLError);
+            return error as VCLError;
+        }
+
+        throw new Error(
+            'Expected getPresentationRequest repository to reject with VCLError',
+        );
+    };
+
+const unusedNetworkService = () => ({
+    sendRequest: async () => {
+        throw new Error('Network should not be called for null endpoint');
+    },
+    sendRequestRaw: async () => {
+        throw new Error('Network should not be called for null endpoint');
+    },
+});
 
 const getCredentialManifestByService = async (
     descriptor: VCLCredentialManifestDescriptor,


### PR DESCRIPTION
## Summary
- preserve legacy invalid-link messages when taxonomy source codes are absent
- keep normalized HTTP status codes in compatibility mode
- classify opaque Velocity deep links as unparseable
- return taxonomy invalid_link diagnostics from repository null-endpoint fallbacks

## Validation
- pnpm --filter @verii/vnf-nodejs-wallet-sdk exec cross-env NODE_ENV=test node --enable-source-maps --import=tsx --test --test-reporter=spec --test-reporter-destination=stdout test/backwardscompatibility/ErrorTaxonomyContract.test.ts test/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaseline.test.ts
- pnpm --filter @verii/vnf-nodejs-wallet-sdk run build