### PR TITLE
[codex] Add sdk-nodejs v2.10.0 version plan

### DIFF
--- a/.nx/version-plans/sdk-nodejs-2.10.0.md
+++ b/.nx/version-plans/sdk-nodejs-2.10.0.md
@@ -1,0 +1,5 @@
+---
+sdk-nodejs: minor
+---
+
+Prepare the Node.js wallet SDK v2.10.0 release.


### PR DESCRIPTION
## Summary

Adds the missing Nx version plan for the Node.js wallet SDK v2.10.0 release.

The previous release-note PR (#715) has already merged, so this follow-up keeps the diff scoped to the `sdk-nodejs` minor version plan only.

## Validation

- `corepack $(node -p "require('./package.json').packageManager") exec nx release plan:check --base=origin/main --head=HEAD`
- `bash .github/scripts/validate-release-notes.sh .github/releases/sdk-nodejs-v2.10.0.md`