### PR TITLE
fix(release): create plans during release prep

### DIFF
--- a/.github/workflows/node-ci.workflow.yml
+++ b/.github/workflows/node-ci.workflow.yml
@@ -73,9 +73,6 @@ jobs:
       run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile --prefer-offline
-    - name: Check version plans
-      if: github.event_name == 'pull_request'
-      run: pnpm exec nx release plan:check --base=${{ github.event.pull_request.base.sha }} --head=HEAD
     - name: Save pnpm cache
       id: cache-pnpm-save
       uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/prepare-release.workflow.yml
+++ b/.github/workflows/prepare-release.workflow.yml
@@ -70,6 +70,8 @@ jobs:
           branch="codex/prepare-release-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           git switch -c "${branch}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
+      - name: Clear existing version plans
+        run: rm -f .nx/version-plans/*.md
       - name: Create version plan
         run: >-
           pnpm exec nx release plan "${RELEASE_BUMP}"

--- a/.github/workflows/prepare-release.workflow.yml
+++ b/.github/workflows/prepare-release.workflow.yml
@@ -11,6 +11,18 @@ on:
         type: string
         description: Comma-separated release groups to prepare
         default: platform,credentialagent,credentialinghub,sdk-nodejs
+      bump:
+        type: choice
+        description: Semver bump to prepare
+        default: minor
+        options:
+          - major
+          - minor
+          - patch
+      plan-message:
+        type: string
+        description: Version plan summary
+        default: Prepare release
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.base-branch }}
@@ -29,6 +41,8 @@ jobs:
     env:
       BASE_BRANCH: ${{ inputs.base-branch }}
       RELEASE_GROUPS: ${{ inputs.groups }}
+      RELEASE_BUMP: ${{ inputs.bump }}
+      VERSION_PLAN_MESSAGE: ${{ inputs.plan-message }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -45,13 +59,6 @@ jobs:
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Assert version plans exist
-        shell: bash
-        run: |
-          if ! find .nx/version-plans -maxdepth 1 -type f -name '*.md' | grep -q .; then
-            echo "No version plans found in .nx/version-plans."
-            exit 1
-          fi
       - name: Configure git author
         run: |
           git config user.name 'github-actions[bot]'
@@ -63,6 +70,12 @@ jobs:
           branch="codex/prepare-release-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           git switch -c "${branch}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
+      - name: Create version plan
+        run: >-
+          pnpm exec nx release plan "${RELEASE_BUMP}"
+          --groups "${RELEASE_GROUPS}"
+          --onlyTouched=false
+          --message "${VERSION_PLAN_MESSAGE}"
       - name: Version packages from plans
         run: >-
           pnpm exec nx release version
@@ -90,5 +103,5 @@ jobs:
           --draft
           --base "${BASE_BRANCH}"
           --head "${{ steps.branch.outputs.name }}"
-          --title "chore(release): prepare release"
-          --body "Prepared package versions from Nx version plans."
+          --title "chore(release): prepare ${RELEASE_BUMP} release"
+          --body "Prepared ${RELEASE_BUMP} release for ${RELEASE_GROUPS}. Add production release notes before merging."

--- a/.nx/version-plans/credentialinghub-next-minor.md
+++ b/.nx/version-plans/credentialinghub-next-minor.md
@@ -1,5 +1,0 @@
----
-credentialinghub: minor
----
-
-Prepare the next Credentialing Hub minor release after the `credentialinghub-v2.0.0` bootstrap.

--- a/.nx/version-plans/sdk-nodejs-2.10.0.md
+++ b/.nx/version-plans/sdk-nodejs-2.10.0.md
@@ -1,5 +1,0 @@
----
-sdk-nodejs: minor
----
-
-Prepare the Node.js wallet SDK v2.10.0 release.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pnpm lint
 - Package publishing is handled by Nx Release and GitHub Actions.
 - Release groups are configured in `nx.json`.
 - Next-minor prerelease builds publish automatically from `main` with the npm `prerelease` dist-tag.
-- Release PRs are prepared by `.github/workflows/prepare-release.workflow.yml` from `.nx/version-plans/*.md`.
+- Release PRs are prepared by `.github/workflows/prepare-release.workflow.yml` from selected groups and a semver bump.
 - Production release notes are checked in under `.github/releases/<group>-vX.Y.Z.md`.
 - Manual prerelease and production exact-version publishes run through `.github/workflows/publish-packages.workflow.yml`.
-- See [RELEASING.md](RELEASING.md) for release groups, version plans, and promotion policy.
+- See [RELEASING.md](RELEASING.md) for release groups, release bumps, and promotion policy.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,11 +73,12 @@ Run `.github/workflows/prepare-release.workflow.yml` manually with the release g
 The workflow:
 
 1. Checks out the selected base branch.
-2. Creates an Nx version plan from the selected groups, bump, and message.
-3. Uses Nx Release to consume that generated version plan.
-4. Updates package versions and dependency metadata.
-5. Removes consumed version plans.
-6. Opens a draft release PR.
+2. Clears any existing version-plan files from the checked-out branch.
+3. Creates an Nx version plan from the selected groups, bump, and message.
+4. Uses Nx Release to consume that generated version plan.
+5. Updates package versions and dependency metadata.
+6. Removes consumed version plans.
+7. Opens a draft release PR.
 
 The prepare workflow does not publish packages, create git tags, or create GitHub Releases.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,23 +42,17 @@ Package manifests are the source of truth for released versions.
 - Internal `@verii/*` dependencies use `workspace:*` in source manifests.
 - pnpm converts `workspace:*` dependencies to package versions while packing and publishing.
 
-## Version Plans
+## Release Bumps
 
-Feature PRs that touch releasable projects must include a version plan in `.nx/version-plans/*.md`.
+Feature PRs do not need to include version plans. The release manager chooses the release groups and semver bump when running `.github/workflows/prepare-release.workflow.yml`.
 
-Create a plan with:
-
-```bash
-pnpm exec nx release plan <major|minor|patch>
-```
-
-A single version plan can coordinate multiple groups. CI runs:
+The prepare workflow creates an Nx version plan internally for the selected groups, consumes it immediately, and opens a draft release PR with the resulting package versions. For local preview, run:
 
 ```bash
-pnpm exec nx release plan:check --base=<base-sha> --head=HEAD
+pnpm exec nx release plan <major|minor|patch> --groups <group> --onlyTouched=false --message "Prepare release" --dry-run
 ```
 
-Docs, tests, workflow files, package manifests, lockfiles, and release config files are ignored by the version-plan check. Manifest and lockfile changes are ignored so generated prepare-release PRs do not require a second version plan after consuming the original plans.
+A single prepare-release run can coordinate multiple groups by passing a comma-separated `groups` value.
 
 ## Prerelease Builds
 
@@ -74,15 +68,16 @@ The workflow:
 
 ## Preparing A Release
 
-Run `.github/workflows/prepare-release.workflow.yml` manually. For a normal minor release train, use `main` as `base-branch`; for patch trains, use the patch branch created from the released tag; for next-major release trains, use the dedicated major branch.
+Run `.github/workflows/prepare-release.workflow.yml` manually with the release groups, bump type, and version-plan message. For a normal minor release train, use `main` as `base-branch` and `minor` as `bump`; for patch trains, use the patch branch created from the released tag and `patch` as `bump`; for next-major release trains, use the dedicated major branch and `major` as `bump`.
 
 The workflow:
 
 1. Checks out the selected base branch.
-2. Uses Nx Release to consume `.nx/version-plans/*.md`.
-3. Updates package versions and dependency metadata.
-4. Removes consumed version plans.
-5. Opens a draft release PR.
+2. Creates an Nx version plan from the selected groups, bump, and message.
+3. Uses Nx Release to consume that generated version plan.
+4. Updates package versions and dependency metadata.
+5. Removes consumed version plans.
+6. Opens a draft release PR.
 
 The prepare workflow does not publish packages, create git tags, or create GitHub Releases.
 
@@ -111,12 +106,11 @@ For a train of fixes against already released code:
 
 1. Create a patch branch from the latest group tag you are patching, for example `git switch -c patch/platform-v1.2.1 platform-v1.2.0`.
 2. Cherry-pick or apply the fixes onto that branch.
-3. Add version plans for the affected release groups.
-4. Run `.github/workflows/prepare-release.workflow.yml` with `base-branch` set to the patch branch.
-5. Add release notes for the new group tag, for example `.github/releases/platform-v1.2.1.md`.
-6. Merge the release PR into the patch branch.
-7. Run production publishing for the affected groups.
-8. Forward-port the fix commits back to `main`.
+3. Run `.github/workflows/prepare-release.workflow.yml` with `base-branch` set to the patch branch and `bump` set to `patch`.
+4. Add release notes for the new group tag, for example `.github/releases/platform-v1.2.1.md`.
+5. Merge the release PR into the patch branch.
+6. Run production publishing for the affected groups.
+7. Forward-port the fix commits back to `main`.
 
 Patch branches do not publish prerelease versions. Keep releasing exact patch versions from the patch branch until the issue train is complete.
 


### PR DESCRIPTION
## Summary

Move version-plan creation into the manual prepare-release workflow so feature PRs do not need to carry `.nx/version-plans/*.md` files.

## Changes

- Add `bump` and `plan-message` inputs to `.github/workflows/prepare-release.workflow.yml`.
- Have prepare-release clear existing checked-in version-plan files, create an Nx version plan for the selected groups, then immediately consume it to open the release PR.
- Remove the PR-time `nx release plan:check` CI gate.
- Delete stale checked-in version plans from `main`.
- Update README and RELEASING docs to describe release-manager-driven bump selection.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec nx release --printConfig`
- `pnpm exec nx release plan minor --groups sdk-nodejs --onlyTouched=false --message "Prepare SDK release" --dry-run`
- `pnpm exec nx release version preminor --groups platform,credentialagent,credentialinghub,sdk-nodejs --preid pre.1234567890 --git-commit=false --git-tag=false --dry-run`
- `bash -lc 'rm -f .nx/version-plans/*.md && pnpm exec nx release plan minor --groups sdk-nodejs --onlyTouched=false --message "Prepare SDK release" && pnpm exec nx release version --groups sdk-nodejs --git-commit=false --git-tag=false --dry-run && rm -f .nx/version-plans/*.md'`
- `actionlint .github/workflows/publish-packages.workflow.yml .github/workflows/prepare-release.workflow.yml .github/workflows/node-ci.workflow.yml`
- `git diff --check`
