### PR TITLE
fix(release): detect staged release prep changes

### DIFF
--- a/.github/workflows/prepare-release.workflow.yml
+++ b/.github/workflows/prepare-release.workflow.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Commit release preparation
         shell: bash
         run: |
-          if git diff --quiet; then
+          if git diff --quiet && git diff --cached --quiet; then
             echo "No release preparation changes were generated."
             exit 1
           fi

--- a/.github/workflows/prepare-release.workflow.yml
+++ b/.github/workflows/prepare-release.workflow.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Commit release preparation
         shell: bash
         run: |
-          if git diff --quiet && git diff --cached --quiet; then
+          if git diff --cached --quiet; then
             echo "No release preparation changes were generated."
             exit 1
           fi


### PR DESCRIPTION
## Summary

Fix `prepare-release` failing after Nx successfully stages generated release changes.

## Root Cause

`nx release version --git-commit=false --git-tag=false` stages the generated package and lockfile changes. The workflow checked only unstaged changes with `git diff --quiet`, so it incorrectly exited with `No release preparation changes were generated.`

## Changes

- Check the staged diff before deciding that no release-prep changes were generated.

## Validation

- `git diff --check`
- YAML parse of `.github/workflows/prepare-release.workflow.yml`
- `actionlint .github/workflows/prepare-release.workflow.yml`
- Local staged-only git simulation confirms `git diff --cached --quiet` detects staged changes.
