### PR TITLE
[codex] Fix Renovate RE2 matcher

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,10 +45,10 @@
       "matchDatasources": [
         "npm"
       ],
-      "matchCurrentValue": "/^(?![~^]?[1-9]\\d*\\.\\d+\\.\\d+$).+/",
+      "matchCurrentValue": "/(^[~^]?0\\.)|(^[~^]?[1-9]\\d*(\\.\\d+)?$)|(^[~^]?[1-9]\\d*\\.\\d+\\.\\d+[-+])|(^[^~^0-9])|([xX*<>=])|( - )|(\\|\\|)/",
       "rangeStrategy": "pin",
       "automerge": false,
-      "description": "Pre-1.0, prerelease, and other non-plain-stable npm values may break outside major-version semver guarantees, so pin them exactly and require review."
+      "description": "Pre-1.0, prerelease, and other non-plain-stable npm values may break outside major-version semver guarantees, so pin them exactly and require review using an RE2-compatible matcher."
     },
     {
       "matchPackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -45,10 +45,10 @@
       "matchDatasources": [
         "npm"
       ],
-      "matchCurrentValue": "/(^[~^]?0\\.)|(^[~^]?[1-9]\\d*(\\.\\d+)?$)|(^[~^]?[1-9]\\d*\\.\\d+\\.\\d+[-+])|(^[^~^0-9])|([xX*<>=])|( - )|(\\|\\|)/",
+      "matchCurrentValue": "!/^[~^]?[1-9]\\d*\\.\\d+\\.\\d+$/",
       "rangeStrategy": "pin",
       "automerge": false,
-      "description": "Pre-1.0, prerelease, and other non-plain-stable npm values may break outside major-version semver guarantees, so pin them exactly and require review using an RE2-compatible matcher."
+      "description": "Pre-1.0, prerelease, and other non-plain-stable npm values may break outside major-version semver guarantees, so pin them exactly and require review."
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Summary
- replace Renovate's unsupported negative-lookahead `matchCurrentValue` regex with Renovate's documented negated pattern syntax
- keep the policy behavior: stable npm v1+ `x.y.z`, `^x.y.z`, and `~x.y.z` values stay range-based; pre-1.0, prerelease, shorthand, comparator, range, wildcard, tag, and protocol values are pinned and require review

## Root cause
Hosted Renovate/Mend rejects lookahead syntax because Renovate uses the RE2 regex engine for user-provided patterns. Renovate opened #683 and stopped creating PRs for the repo.

## Research
Renovate documents `!/…/` as the special negated regex syntax for `matchCurrentValue`, and its string pattern docs say valid regex patterns may start with `/` or `!/`. This lets us express “not stable v1+ semver” directly without using regex lookahead.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('renovate.json', 'utf8')); console.log('renovate.json parses')"`
- `corepack $(node -p "require('./package.json').packageManager") dlx --package renovate renovate-config-validator --strict renovate.json`
- negated stable matcher sanity check
- `LOG_LEVEL=info corepack $(node -p "require('./package.json').packageManager") dlx --package renovate renovate --dry-run=lookup --platform=local`
- `git diff --check`

Closes #683
