### PR TITLE
[codex] Fix Mongo peer dependency resolution

### DIFF
--- a/packages/db-kms/package.json
+++ b/packages/db-kms/package.json
@@ -16,16 +16,19 @@
     "lint:fix": "eslint --fix ."
   },
   "dependencies": {
-    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@verii/crypto": "workspace:*",
     "@verii/jwt": "workspace:*",
     "@verii/spencer-mongo-extensions": "workspace:*",
     "fastify-plugin": "^5.1.0",
-    "lodash": "^4.18.0",
-    "mongodb": "^7.3.0"
+    "lodash": "^4.18.0"
+  },
+  "peerDependencies": {
+    "@spencejs/spence-mongo-repos": "^1.1.0",
+    "mongodb": "^7.0.0"
   },
   "devDependencies": {
     "@spencejs/spence-config": "1.1.0",
+    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@typescript-eslint/eslint-plugin": "8.59.2",
     "@typescript-eslint/parser": "8.59.2",
     "@verii/test-regexes": "workspace:*",

--- a/packages/endpoints-credential-types-registrar/package.json
+++ b/packages/endpoints-credential-types-registrar/package.json
@@ -22,7 +22,6 @@
     "@fastify/sensible": "^6.0.4",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.6",
-    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@verii/auth": "workspace:*",
     "@verii/aws-clients": "workspace:*",
     "@verii/common-fetchers": "workspace:*",
@@ -38,9 +37,14 @@
     "lodash": "^4.18.0",
     "nanoid": "^5.1.14"
   },
+  "peerDependencies": {
+    "@spencejs/spence-mongo-repos": "^1.1.0",
+    "mongodb": "^7.0.0"
+  },
   "devDependencies": {
     "@aws-sdk/client-s3": "3.1045.0",
     "@spencejs/spence-factories": "^1.1.0",
+    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@verii/crypto": "workspace:*",
     "@verii/sample-data": "workspace:*",
     "@verii/server-provider": "workspace:*",

--- a/packages/endpoints-event-processing/package.json
+++ b/packages/endpoints-event-processing/package.json
@@ -22,7 +22,6 @@
     "@fastify/sensible": "^6.0.4",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.6",
-    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@verii/auth": "workspace:*",
     "@verii/aws-clients": "workspace:*",
     "@verii/base-contract-io": "workspace:*",
@@ -43,8 +42,13 @@
     "fastify-plugin": "^5.1.0",
     "lodash": "^4.18.0"
   },
+  "peerDependencies": {
+    "@spencejs/spence-mongo-repos": "^1.1.0",
+    "mongodb": "^7.0.0"
+  },
   "devDependencies": {
     "@spencejs/spence-factories": "^1.1.0",
+    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@verii/common-functions": "workspace:*",
     "@verii/server-provider": "workspace:*",
     "@verii/tests-helpers": "workspace:*",

--- a/packages/endpoints-organizations-registrar/package.json
+++ b/packages/endpoints-organizations-registrar/package.json
@@ -24,7 +24,6 @@
     "@fastify/view": "^11.1.1",
     "@spencejs/spence-events": "^1.1.0",
     "@spencejs/spence-factories": "^1.1.0",
-    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@verii/auth": "workspace:*",
     "@verii/aws-clients": "workspace:*",
     "@verii/base-contract-io": "workspace:*",
@@ -59,13 +58,17 @@
     "handlebars": "^4.7.9",
     "http-errors": "^2.0.1",
     "lodash": "^4.18.0",
-    "mongodb": "^7.3.0",
     "nanoid": "^5.1.14",
     "sprintf-js": "1.1.3",
     "uuid": "~14.0.0"
   },
+  "peerDependencies": {
+    "@spencejs/spence-mongo-repos": "^1.1.0",
+    "mongodb": "^7.0.0"
+  },
   "devDependencies": {
     "@aws-sdk/client-ses": "3.1045.0",
+    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@verii/common-functions": "workspace:*",
     "@verii/error-aggregation": "workspace:*",
     "@verii/sample-data": "workspace:*",
@@ -83,6 +86,7 @@
     "ethers": "^6.17.0",
     "expect": "30.4.1",
     "globals": "17.6.0",
+    "mongodb": "^7.3.0",
     "nock": "15.0.0-beta.11",
     "prettier": "3.8.3"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@spencejs/spence-events": "^1.1.0",
-    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@verii/common-functions": "workspace:*",
     "@verii/common-schemas": "workspace:*",
     "@verii/fastify-plugins": "workspace:*",
@@ -29,14 +28,17 @@
     "nanoid": "^5.1.14"
   },
   "peerDependencies": {
+    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@fastify/helmet": ">=11.1.1",
     "@fastify/sensible": ">=5.6.0",
     "@fastify/swagger": ">=8.15.0",
     "@fastify/swagger-ui": ">=4.2.0",
     "fastify": ">=4.29.0",
-    "fastify-plugin": ">=4.5.1"
+    "fastify-plugin": ">=4.5.1",
+    "mongodb": "^7.0.0"
   },
   "devDependencies": {
+    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@verii/config": "workspace:*",
     "@verii/http-client": "workspace:*",
     "@verii/tests-helpers": "workspace:*",
@@ -52,6 +54,7 @@
     "fastify": "^5.8.5",
     "globals": "17.6.0",
     "h2url": "0.2.0",
+    "mongodb": "^7.3.0",
     "prettier": "3.8.3"
   },
   "nx": {

--- a/packages/spencer-mongo-extensions/package.json
+++ b/packages/spencer-mongo-extensions/package.json
@@ -19,8 +19,10 @@
   "dependencies": {
     "@verii/crypto": "workspace:*",
     "http-errors": "^2.0.1",
-    "lodash": "^4.18.1",
-    "mongodb": "^7.3.0"
+    "lodash": "^4.18.1"
+  },
+  "peerDependencies": {
+    "mongodb": "^7.0.0"
   },
   "devDependencies": {
     "@spencejs/spence-config": "1.1.0",
@@ -35,6 +37,7 @@
     "eslint-watch": "8.0.0",
     "expect": "30.4.1",
     "globals": "17.6.0",
+    "mongodb": "^7.3.0",
     "nanoid": "^5.1.14",
     "prettier": "3.8.3"
   },

--- a/packages/tests-helpers/package.json
+++ b/packages/tests-helpers/package.json
@@ -17,7 +17,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/client-s3": "3.1045.0",
-    "@spencejs/spence-mongo-repos": "^1.1.0",
     "@verii/common-functions": "workspace:*",
     "@verii/crypto": "workspace:*",
     "@verii/jwt": "workspace:*",
@@ -26,10 +25,14 @@
     "env-var": "^7.5.0",
     "expect": "30.4.1",
     "lodash": "^4.18.1",
-    "mongodb": "^7.3.0",
     "nanoid": "^5.1.14"
   },
+  "peerDependencies": {
+    "@spencejs/spence-mongo-repos": "^1.1.0",
+    "mongodb": "^7.0.0"
+  },
   "devDependencies": {
+    "@spencejs/spence-mongo-repos": "^1.1.0",
     "eslint": "9.39.4",
     "eslint-config-airbnb-extended": "3.1.0",
     "eslint-config-prettier": "10.1.8",
@@ -39,6 +42,7 @@
     "eslint-plugin-prettier": "5.5.5",
     "eslint-watch": "8.0.0",
     "globals": "17.6.0",
+    "mongodb": "^7.3.0",
     "prettier": "3.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,9 +853,6 @@ importers:
 
   packages/db-kms:
     dependencies:
-      '@spencejs/spence-mongo-repos':
-        specifier: ^1.1.0
-        version: 1.1.0(mongodb@7.3.0)
       '@verii/crypto':
         specifier: workspace:*
         version: link:../crypto
@@ -871,13 +868,13 @@ importers:
       lodash:
         specifier: ^4.18.0
         version: 4.18.1
-      mongodb:
-        specifier: ^7.3.0
-        version: 7.3.0
     devDependencies:
       '@spencejs/spence-config':
         specifier: 1.1.0
         version: 1.1.0
+      '@spencejs/spence-mongo-repos':
+        specifier: ^1.1.0
+        version: 1.1.0(mongodb@7.3.0)
       '@typescript-eslint/eslint-plugin':
         specifier: 8.59.2
         version: 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -926,6 +923,9 @@ importers:
       globals:
         specifier: 17.6.0
         version: 17.6.0
+      mongodb:
+        specifier: ^7.3.0
+        version: 7.3.0
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -1009,9 +1009,6 @@ importers:
       '@fastify/swagger-ui':
         specifier: ^5.2.6
         version: 5.2.6
-      '@spencejs/spence-mongo-repos':
-        specifier: ^1.1.0
-        version: 1.1.0(mongodb@7.3.0)
       '@verii/auth':
         specifier: workspace:*
         version: link:../auth
@@ -1061,6 +1058,9 @@ importers:
       '@spencejs/spence-factories':
         specifier: ^1.1.0
         version: 1.1.0
+      '@spencejs/spence-mongo-repos':
+        specifier: ^1.1.0
+        version: 1.1.0(mongodb@7.3.0)
       '@verii/crypto':
         specifier: workspace:*
         version: link:../crypto
@@ -1139,9 +1139,6 @@ importers:
       '@fastify/swagger-ui':
         specifier: ^5.2.6
         version: 5.2.6
-      '@spencejs/spence-mongo-repos':
-        specifier: ^1.1.0
-        version: 1.1.0(mongodb@7.3.0)
       '@verii/auth':
         specifier: workspace:*
         version: link:../auth
@@ -1203,6 +1200,9 @@ importers:
       '@spencejs/spence-factories':
         specifier: ^1.1.0
         version: 1.1.0
+      '@spencejs/spence-mongo-repos':
+        specifier: ^1.1.0
+        version: 1.1.0(mongodb@7.3.0)
       '@verii/common-functions':
         specifier: workspace:*
         version: link:../common-functions
@@ -1278,9 +1278,6 @@ importers:
       '@spencejs/spence-factories':
         specifier: ^1.1.0
         version: 1.1.0
-      '@spencejs/spence-mongo-repos':
-        specifier: ^1.1.0
-        version: 1.1.0(mongodb@7.3.0)
       '@verii/auth':
         specifier: workspace:*
         version: link:../auth
@@ -1383,9 +1380,6 @@ importers:
       lodash:
         specifier: ^4.18.0
         version: 4.18.1
-      mongodb:
-        specifier: ^7.3.0
-        version: 7.3.0
       nanoid:
         specifier: ^5.1.14
         version: 5.1.15
@@ -1399,6 +1393,9 @@ importers:
       '@aws-sdk/client-ses':
         specifier: 3.1045.0
         version: 3.1045.0
+      '@spencejs/spence-mongo-repos':
+        specifier: ^1.1.0
+        version: 1.1.0(mongodb@7.3.0)
       '@verii/error-aggregation':
         specifier: workspace:*
         version: link:../error-aggregation
@@ -1447,6 +1444,9 @@ importers:
       globals:
         specifier: 17.6.0
         version: 17.6.0
+      mongodb:
+        specifier: ^7.3.0
+        version: 7.3.0
       nock:
         specifier: 15.0.0-beta.11
         version: 15.0.0-beta.11
@@ -2008,9 +2008,6 @@ importers:
       '@spencejs/spence-events':
         specifier: ^1.1.0
         version: 1.1.0
-      '@spencejs/spence-mongo-repos':
-        specifier: ^1.1.0
-        version: 1.1.0(mongodb@7.3.0)
       '@verii/common-functions':
         specifier: workspace:*
         version: link:../common-functions
@@ -2042,6 +2039,9 @@ importers:
         specifier: ^5.1.14
         version: 5.1.15
     devDependencies:
+      '@spencejs/spence-mongo-repos':
+        specifier: ^1.1.0
+        version: 1.1.0(mongodb@7.3.0)
       '@verii/config':
         specifier: workspace:*
         version: link:../config
@@ -2087,6 +2087,9 @@ importers:
       h2url:
         specifier: 0.2.0
         version: 0.2.0
+      mongodb:
+        specifier: ^7.3.0
+        version: 7.3.0
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -2102,9 +2105,6 @@ importers:
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
-      mongodb:
-        specifier: ^7.3.0
-        version: 7.3.0
     devDependencies:
       '@spencejs/spence-config':
         specifier: 1.1.0
@@ -2142,6 +2142,9 @@ importers:
       globals:
         specifier: 17.6.0
         version: 17.6.0
+      mongodb:
+        specifier: ^7.3.0
+        version: 7.3.0
       nanoid:
         specifier: ^5.1.14
         version: 5.1.15
@@ -2187,9 +2190,6 @@ importers:
       '@aws-sdk/client-s3':
         specifier: 3.1045.0
         version: 3.1045.0
-      '@spencejs/spence-mongo-repos':
-        specifier: ^1.1.0
-        version: 1.1.0(mongodb@7.3.0)
       '@verii/common-functions':
         specifier: workspace:*
         version: link:../common-functions
@@ -2214,13 +2214,13 @@ importers:
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
-      mongodb:
-        specifier: ^7.3.0
-        version: 7.3.0
       nanoid:
         specifier: ^5.1.14
         version: 5.1.15
     devDependencies:
+      '@spencejs/spence-mongo-repos':
+        specifier: ^1.1.0
+        version: 1.1.0(mongodb@7.3.0)
       eslint:
         specifier: 9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -2248,6 +2248,9 @@ importers:
       globals:
         specifier: 17.6.0
         version: 17.6.0
+      mongodb:
+        specifier: ^7.3.0
+        version: 7.3.0
       prettier:
         specifier: 3.8.3
         version: 3.8.3


### PR DESCRIPTION
## Summary

- move `@spencejs/spence-mongo-repos` from runtime dependencies to peer dependencies for Mongo-backed `packages/*`
- move `mongodb` to peer dependencies for affected packages, keeping dev dependencies for local tests/imports
- keep app/server workspaces as direct consumers so they satisfy the new peer contracts

## Root Cause

`@spencejs/spence-mongo-repos` keeps Mongo connection/repo state at module scope. When Verii packages publish their own `mongodb` runtime dependency, pnpm can install multiple peer-resolved physical instances of `@spencejs/spence-mongo-repos`, splitting that singleton state inside one app.

## Validation

- `corepack $(node -p "require('./package.json').packageManager") install --lockfile-only --no-frozen-lockfile`
- `git diff --check`
- manifest scan confirming no `packages/*` runtime `mongodb` dependencies remain
- manifest scan confirming no `packages/*` runtime `@spencejs/spence-mongo-repos` dependencies remain