### PR TITLE
[codex] Move key conversion into crypto

### DIFF
--- a/packages/aws-clients/package.json
+++ b/packages/aws-clients/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "@verii/crypto": "workspace:*",
-    "@verii/jwt": "workspace:*",
     "eslint": "9.39.4",
     "eslint-config-airbnb-extended": "3.1.0",
     "eslint-config-prettier": "10.1.8",

--- a/packages/aws-clients/test/kms-client.test.js
+++ b/packages/aws-clients/test/kms-client.test.js
@@ -23,8 +23,8 @@ const {
   DeleteAliasCommand,
   DecryptCommand,
 } = require('@aws-sdk/client-kms');
-const { generateKeyPair } = require('@verii/crypto');
-const { hexFromJwk } = require('@verii/jwt');
+const { generateKeyPair, hexFromJwk } = require('@verii/crypto');
+
 const { initKmsClient } = require('../src/kms-client');
 
 describe('kms-client test suite', () => {

--- a/packages/blockchain-functions/package.json
+++ b/packages/blockchain-functions/package.json
@@ -17,12 +17,11 @@
   "author": "Itay Podhajcer",
   "license": "Apache-2.0",
   "dependencies": {
-    "@verii/jwt": "workspace:*",
+    "@verii/crypto": "workspace:*",
     "ethers": "^6.17.0",
     "lodash": "^4.18.1"
   },
   "devDependencies": {
-    "@verii/crypto": "workspace:*",
     "eslint": "9.39.4",
     "eslint-config-airbnb-extended": "3.1.0",
     "eslint-config-prettier": "10.1.8",

--- a/packages/blockchain-functions/src/ethers-wrappers.js
+++ b/packages/blockchain-functions/src/ethers-wrappers.js
@@ -1,6 +1,6 @@
 const { isString, isEmpty } = require('lodash/fp');
 const ethers = require('ethers');
-const { hexFromJwk } = require('@verii/jwt');
+const { hexFromJwk } = require('@verii/crypto');
 
 const toEthereumAddress = (key) => {
   if (isString(key)) {

--- a/packages/crypto/index.js
+++ b/packages/crypto/index.js
@@ -18,6 +18,7 @@ const { encrypt, decrypt } = require('./src/crypto');
 
 module.exports = {
   ...require('./src/crypto'),
+  ...require('./src/key-transformer'),
   ...require('./src/constants'),
   ...require('./src/call-with-kms-key'),
   encryptCollection: encrypt,

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -17,7 +17,6 @@
   "author": "Yuaheni Pozdnyakov",
   "license": "Apache-2.0",
   "dependencies": {
-    "@verii/test-regexes": "workspace:*",
     "argon2": "0.44.0",
     "bigint-crypto-utils": "3.3.0",
     "canonicalize": "^2.1.0",
@@ -27,6 +26,7 @@
     "random-number-csprng": "^1.0.2"
   },
   "devDependencies": {
+    "@verii/test-regexes": "workspace:*",
     "eslint": "9.39.4",
     "eslint-config-airbnb-extended": "3.1.0",
     "eslint-config-prettier": "10.1.8",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -17,7 +17,6 @@
   "author": "Yuaheni Pozdnyakov",
   "license": "Apache-2.0",
   "dependencies": {
-    "@trust/keyto": "~2.0.0-alpha1",
     "@verii/test-regexes": "workspace:*",
     "argon2": "0.44.0",
     "bigint-crypto-utils": "3.3.0",

--- a/packages/crypto/src/crypto.js
+++ b/packages/crypto/src/crypto.js
@@ -19,9 +19,9 @@ const crypto = require('crypto');
 const argon2 = require('argon2');
 const { flow, isString, omit } = require('lodash/fp');
 const randomNumber = require('random-number-csprng');
-const keyto = require('@trust/keyto');
 const { HEX_FORMAT } = require('@verii/test-regexes');
 const { KeyAlgorithms } = require('./constants');
+const { hexFromJwk, jwkFromSecp256k1Key } = require('./key-transformer');
 
 const secp256k1 = new EC('secp256k1');
 
@@ -83,8 +83,8 @@ const generateKeyPair = (options = {}) => {
 
   if (format === 'hex') {
     return {
-      privateKey: keyto.from(privateKey, 'jwk').toString('blk', 'private'),
-      publicKey: keyto.from(publicKey, 'jwk').toString('blk', 'public'),
+      privateKey: hexFromJwk(privateKey),
+      publicKey: hexFromJwk(publicKey, false),
     };
   }
 
@@ -128,9 +128,6 @@ const prepareSignedValue = (payload, options) => {
   return hashAndEncodeHex(`${hexOptions}${hexPayload}`);
 };
 
-const publicKeyHexToPem = (publicKey) =>
-  keyto.from(publicKey, 'blk').toString('pem', 'public_pkcs8');
-
 const sanitizeOptions = (options) => {
   const objOptions = !isString(options) ? options : JSON.parse(options);
   return omit(['jws'], objOptions);
@@ -154,29 +151,22 @@ const get2BytesHash = (value) => {
 };
 
 const signAndEncodeBase64 = (value, privateKey) => {
-  const privateKeyPem = keyto
-    .from(privateKey, 'blk')
-    .toString('pem', 'private_pkcs8');
-  return crypto
-    .createSign('SHA256')
-    .update(value)
-    .sign({
-      key: privateKeyPem,
-    })
-    .toString('base64');
+  const key = crypto.createPrivateKey({
+    key: omit(['use'], jwkFromSecp256k1Key(privateKey)),
+    format: 'jwk',
+  });
+  return crypto.createSign('SHA256').update(value).sign(key).toString('base64');
 };
 
 const verifyBase64Signature = (value, signature, publicKey) => {
+  const key = crypto.createPublicKey({
+    key: omit(['use'], jwkFromSecp256k1Key(publicKey, false)),
+    format: 'jwk',
+  });
   return crypto
     .createVerify('SHA256')
     .update(value)
-    .verify(
-      {
-        key: publicKeyHexToPem(publicKey),
-      },
-      signature,
-      'base64',
-    );
+    .verify(key, signature, 'base64');
 };
 
 const encryptBuffer = (buffer, secret) =>
@@ -258,7 +248,6 @@ module.exports = {
   generateRandomBytes,
   generateKeyPair,
   generatePositive256BitHexString,
-  publicKeyHexToPem,
   encrypt,
   decrypt,
   encryptBuffer,

--- a/packages/crypto/src/crypto.js
+++ b/packages/crypto/src/crypto.js
@@ -19,9 +19,12 @@ const crypto = require('crypto');
 const argon2 = require('argon2');
 const { flow, isString, omit } = require('lodash/fp');
 const randomNumber = require('random-number-csprng');
-const { HEX_FORMAT } = require('@verii/test-regexes');
 const { KeyAlgorithms } = require('./constants');
-const { hexFromJwk, jwkFromSecp256k1Key } = require('./key-transformer');
+const {
+  HEX_FORMAT,
+  hexFromJwk,
+  jwkFromSecp256k1Key,
+} = require('./key-transformer');
 
 const secp256k1 = new EC('secp256k1');
 

--- a/packages/crypto/src/key-transformer.js
+++ b/packages/crypto/src/key-transformer.js
@@ -1,0 +1,104 @@
+const { createECDH } = require('crypto');
+const { omit } = require('lodash/fp');
+
+const normalizeHex = (hex) => hex.replace(/^0x/i, '');
+
+const HEX_FORMAT = /^[0-9a-fA-F]+$/;
+
+const normalizeCoordinateHex = (hex, byteLength = 32) => {
+  const normalizedHex = normalizeHex(hex);
+  const paddedHex = normalizedHex.padStart(byteLength * 2, '0');
+  return paddedHex.slice(-byteLength * 2);
+};
+
+const detectHexKeyType = (key) => {
+  const normalizedKey = normalizeHex(key);
+  if (!HEX_FORMAT.test(normalizedKey)) {
+    return 'unknown';
+  }
+  if (normalizedKey.length === 64) {
+    return 'private';
+  }
+  if (
+    (normalizedKey.length === 130 && normalizedKey.startsWith('04')) ||
+    normalizedKey.length === 128
+  ) {
+    return 'public';
+  }
+  return 'unknown';
+};
+
+const base64UrlToHex = (value) =>
+  Buffer.from(value, 'base64url').toString('hex');
+
+const hexToBase64Url = (value) =>
+  Buffer.from(normalizeHex(value), 'hex').toString('base64url');
+
+const uncompressedPublicKeyToCoordinates = (publicKey) => {
+  const normalizedKey = normalizeHex(publicKey);
+  const coordinates = normalizedKey.startsWith('04')
+    ? normalizedKey.slice(2)
+    : normalizedKey;
+  const canonicalCoordinates = coordinates.slice(-128);
+  return {
+    x: canonicalCoordinates.slice(0, 64),
+    y: canonicalCoordinates.slice(64),
+  };
+};
+
+const publicJwkFromPublicHex = (publicKeyHex) => {
+  const { x, y } = uncompressedPublicKeyToCoordinates(publicKeyHex);
+  return {
+    kty: 'EC',
+    crv: 'secp256k1',
+    use: 'sig',
+    x: hexToBase64Url(x),
+    y: hexToBase64Url(y),
+  };
+};
+
+const publicHexFromPrivateHex = (privateKeyHex) => {
+  const ecdh = createECDH('secp256k1');
+  ecdh.setPrivateKey(Buffer.from(normalizeCoordinateHex(privateKeyHex), 'hex'));
+  return ecdh.getPublicKey('hex', 'uncompressed');
+};
+
+const jwkFromSecp256k1Key = (key, priv = true) => {
+  if (!priv) {
+    const keyType = detectHexKeyType(key);
+    if (keyType === 'public') {
+      return publicJwkFromPublicHex(key);
+    }
+    if (keyType === 'private') {
+      return publicJwkFromPublicHex(publicHexFromPrivateHex(key));
+    }
+    throw new Error(
+      'Expected secp256k1 private key (64 hex chars) or uncompressed public key (128/130 hex chars)',
+    );
+  }
+  const privateKeyHex = normalizeCoordinateHex(key);
+  return {
+    ...publicJwkFromPublicHex(publicHexFromPrivateHex(privateKeyHex)),
+    d: hexToBase64Url(privateKeyHex),
+  };
+};
+
+const hexFromJwk = (jwk, priv = true) => {
+  if (priv) {
+    return normalizeCoordinateHex(base64UrlToHex(jwk.d));
+  }
+  return `04${normalizeCoordinateHex(base64UrlToHex(jwk.x))}${normalizeCoordinateHex(base64UrlToHex(jwk.y))}`;
+};
+
+const publicKeyFromPrivateKey = (key) => {
+  if (key.x == null) {
+    return publicHexFromPrivateHex(key);
+  }
+  return omit(['d'], key);
+};
+
+module.exports = {
+  hexFromJwk,
+  jwkFromSecp256k1Key,
+  publicKeyFromPrivateKey,
+};

--- a/packages/crypto/src/key-transformer.js
+++ b/packages/crypto/src/key-transformer.js
@@ -85,6 +85,9 @@ const jwkFromSecp256k1Key = (key, priv = true) => {
 
 const hexFromJwk = (jwk, priv = true) => {
   if (priv) {
+    if (jwk?.d == null) {
+      throw new Error('Expected private JWK with d property');
+    }
     return normalizeCoordinateHex(base64UrlToHex(jwk.d));
   }
   return `04${normalizeCoordinateHex(base64UrlToHex(jwk.x))}${normalizeCoordinateHex(base64UrlToHex(jwk.y))}`;
@@ -98,6 +101,7 @@ const publicKeyFromPrivateKey = (key) => {
 };
 
 module.exports = {
+  HEX_FORMAT,
   hexFromJwk,
   jwkFromSecp256k1Key,
   publicKeyFromPrivateKey,

--- a/packages/crypto/test/crypto.test.js
+++ b/packages/crypto/test/crypto.test.js
@@ -16,12 +16,10 @@
 const { describe, it } = require('node:test');
 const { expect } = require('expect');
 
-const { padCharsStart } = require('lodash/fp');
 const crypto = require('crypto');
 const { HEX_FORMAT, URLSAFE_BASE64_FORMAT } = require('@verii/test-regexes');
 const {
   generateKeyPair,
-  publicKeyHexToPem,
   generateRandomNumber,
   generatePositive256BitHexString,
   signPayload,
@@ -43,6 +41,20 @@ const {
   calcSha384,
   generateJWAKeyPair,
 } = require('../src/crypto');
+const { jwkFromSecp256k1Key } = require('../src/key-transformer');
+
+const toNodePublicKey = (publicKeyHex) => {
+  const publicJwk = jwkFromSecp256k1Key(publicKeyHex, false);
+  return crypto.createPublicKey({
+    key: {
+      kty: publicJwk.kty,
+      crv: publicJwk.crv,
+      x: publicJwk.x,
+      y: publicJwk.y,
+    },
+    format: 'jwk',
+  });
+};
 
 describe('Crypto tests', () => {
   const { publicKey, privateKey } = {
@@ -102,8 +114,9 @@ describe('Crypto tests', () => {
         publicKey: expect.any(String),
         privateKey: expect.any(String),
       });
-      expect(padCharsStart('0', 64, keyPair.privateKey)).toHaveLength(64);
+      expect(keyPair.privateKey).toHaveLength(64);
       expect(keyPair.publicKey).toHaveLength(130);
+      expect(keyPair.publicKey).toEqual(expect.stringMatching(/^04/));
     });
 
     it('should be generate key pairs', () => {
@@ -216,14 +229,6 @@ describe('Crypto tests', () => {
       });
     });
   });
-  describe('pem / hex conversions', () => {
-    it('should generate pems for hex public keys', () => {
-      expect(publicKeyHexToPem(publicKey)).toEqual(
-        expect.stringContaining('BEGIN PUBLIC KEY'),
-      );
-    });
-  });
-
   it('Should return a random number with with 1 digit', async () => {
     const number = await generateRandomNumber(1);
     expect(number.toString()).toHaveLength(1);
@@ -277,7 +282,7 @@ describe('Crypto tests', () => {
         .createVerify('SHA256')
         .update(payload)
         .verify(
-          publicKeyHexToPem(publicKeyHex),
+          toNodePublicKey(publicKeyHex),
           Buffer.from(signature, 'base64'),
         );
 
@@ -296,7 +301,7 @@ describe('Crypto tests', () => {
         .createVerify('SHA256')
         .update(JSON.stringify({ message: 'TEST MESSAGE 2' }))
         .verify(
-          publicKeyHexToPem(publicKeyHex),
+          toNodePublicKey(publicKeyHex),
           Buffer.from(signature, 'base64'),
         );
       expect(isSignatureValid).toBe(false);

--- a/packages/crypto/test/key-transformer.test.js
+++ b/packages/crypto/test/key-transformer.test.js
@@ -1,0 +1,130 @@
+const { describe, it } = require('node:test');
+const { expect } = require('expect');
+const {
+  hexFromJwk,
+  jwkFromSecp256k1Key,
+  publicKeyFromPrivateKey,
+} = require('../src/key-transformer');
+
+// These fixtures have a leading 0x00 byte in the X coordinate. They verify we
+// preserve coordinate padding when converting between key representations.
+const PRIVATE_KEY_WITH_PADDING =
+  '52b1a0115ecef18c8e082711c84b9a19fda9128c24d206b7f718b39036d26cc1';
+const PUBLIC_KEY_WITH_PADDING =
+  '04007ea463cc5f7ac9e6eef4f1aa3484ca01d365f8f4f23fcd13569ed28a9c4b4ae43f3b3c1d5fae0f2f8fc67b551322a35c38d9a10a4b392adc580fd483d79187';
+const PRIVATE_JWK_WITH_PADDING = {
+  kty: 'EC',
+  crv: 'secp256k1',
+  x: 'AH6kY8xfesnm7vTxqjSEygHTZfj08j_NE1ae0oqcS0o',
+  y: '5D87PB1frg8vj8Z7VRMio1w42aEKSzkq3FgP1IPXkYc',
+  d: 'UrGgEV7O8YyOCCcRyEuaGf2pEowk0ga39xizkDbSbME',
+  use: 'sig',
+};
+const PUBLIC_JWK_WITH_PADDING = {
+  kty: 'EC',
+  crv: 'secp256k1',
+  x: 'AH6kY8xfesnm7vTxqjSEygHTZfj08j_NE1ae0oqcS0o',
+  y: '5D87PB1frg8vj8Z7VRMio1w42aEKSzkq3FgP1IPXkYc',
+  use: 'sig',
+};
+const PUBLIC_JWK_WITH_SHORT_X = {
+  ...PUBLIC_JWK_WITH_PADDING,
+  x: 'fqRjzF96yebu9PGqNITKAdNl-PTyP80TVp7SipxLSg',
+};
+const PRIVATE_JWK_WITH_SHORT_D = {
+  d: 'AQ',
+};
+
+const PRIVATE_KEY =
+  '1111111111111111111111111111111111111111111111111111111111111111';
+const PUBLIC_KEY =
+  '044f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa385b6b1b8ead809ca67454d9683fcf2ba03456d6fe2c4abe2b07f0fbdbb2f1c1';
+const PRIVATE_JWK = {
+  kty: 'EC',
+  crv: 'secp256k1',
+  x: 'TzVb3LfMCvco7zzOuWFdkGhLtbLKX4WasPC3BAdYcao',
+  y: 'OFtrG46tgJymdFTZaD_PK6A0Vtb-LEq-Kwfw-9uy8cE',
+  d: 'ERERERERERERERERERERERERERERERERERERERERERE',
+  use: 'sig',
+};
+const PUBLIC_JWK = {
+  kty: 'EC',
+  crv: 'secp256k1',
+  x: 'TzVb3LfMCvco7zzOuWFdkGhLtbLKX4WasPC3BAdYcao',
+  y: 'OFtrG46tgJymdFTZaD_PK6A0Vtb-LEq-Kwfw-9uy8cE',
+  use: 'sig',
+};
+
+describe('Key Transformer Tests', () => {
+  it('should generate jwk for hex public keys', () => {
+    expect(jwkFromSecp256k1Key(PUBLIC_KEY, false)).toEqual(PUBLIC_JWK);
+  });
+
+  it('should generate jwk for hex public keys without prefix', () => {
+    expect(jwkFromSecp256k1Key(PUBLIC_KEY.slice(2), false)).toEqual(PUBLIC_JWK);
+  });
+
+  it('should generate public jwk from private hex when requested', () => {
+    expect(jwkFromSecp256k1Key(PRIVATE_KEY, false)).toEqual(PUBLIC_JWK);
+  });
+
+  it('should throw for invalid keys when public jwk is requested', () => {
+    expect(() => jwkFromSecp256k1Key('not-a-key', false)).toThrow(
+      'Expected secp256k1 private key (64 hex chars) or uncompressed public key (128/130 hex chars)',
+    );
+  });
+
+  it('should throw for wrong-sized hex keys when public jwk is requested', () => {
+    expect(() => jwkFromSecp256k1Key('abcd', false)).toThrow(
+      'Expected secp256k1 private key (64 hex chars) or uncompressed public key (128/130 hex chars)',
+    );
+  });
+
+  it('should generate hex for jwk public keys', () => {
+    expect(hexFromJwk(PUBLIC_JWK, false)).toEqual(PUBLIC_KEY);
+  });
+
+  it('should generate jwk for hex private keys', () => {
+    expect(jwkFromSecp256k1Key(PRIVATE_KEY, true)).toEqual(PRIVATE_JWK);
+  });
+
+  it('should generate hex for jwk private keys', () => {
+    expect(hexFromJwk(PRIVATE_JWK, true)).toEqual(PRIVATE_KEY);
+  });
+
+  it('should preserve padding when generating hex for padded jwk private keys', () => {
+    expect(hexFromJwk(PRIVATE_JWK_WITH_PADDING, true)).toEqual(
+      PRIVATE_KEY_WITH_PADDING,
+    );
+  });
+
+  it('should preserve padding when generating hex for padded jwk public keys', () => {
+    expect(hexFromJwk(PUBLIC_JWK_WITH_PADDING, false)).toEqual(
+      PUBLIC_KEY_WITH_PADDING,
+    );
+  });
+
+  it('should add padding when generating hex for shortened jwk private keys', () => {
+    expect(hexFromJwk(PRIVATE_JWK_WITH_SHORT_D, true)).toEqual(
+      '0000000000000000000000000000000000000000000000000000000000000001',
+    );
+  });
+
+  it('should add coordinate padding when generating hex for shortened jwk public keys', () => {
+    expect(hexFromJwk(PUBLIC_JWK_WITH_SHORT_X, false)).toEqual(
+      PUBLIC_KEY_WITH_PADDING,
+    );
+  });
+
+  it('should preserve padding for derived hex public keys', () => {
+    expect(publicKeyFromPrivateKey(PRIVATE_KEY_WITH_PADDING)).toEqual(
+      PUBLIC_KEY_WITH_PADDING,
+    );
+  });
+
+  it('should return public jwk for passed private jwk', () => {
+    expect(publicKeyFromPrivateKey(PRIVATE_JWK_WITH_PADDING)).toEqual(
+      PUBLIC_JWK_WITH_PADDING,
+    );
+  });
+});

--- a/packages/crypto/test/key-transformer.test.js
+++ b/packages/crypto/test/key-transformer.test.js
@@ -92,6 +92,12 @@ describe('Key Transformer Tests', () => {
     expect(hexFromJwk(PRIVATE_JWK, true)).toEqual(PRIVATE_KEY);
   });
 
+  it('should throw when private hex is requested for public jwk', () => {
+    expect(() => hexFromJwk(PUBLIC_JWK, true)).toThrow(
+      'Expected private JWK with d property',
+    );
+  });
+
   it('should preserve padding when generating hex for padded jwk private keys', () => {
     expect(hexFromJwk(PRIVATE_JWK_WITH_PADDING, true)).toEqual(
       PRIVATE_KEY_WITH_PADDING,

--- a/packages/crypto/test/vnf-signature.test.js
+++ b/packages/crypto/test/vnf-signature.test.js
@@ -23,11 +23,21 @@ const {
   buildVnfSignature,
   verifyVnfSignature,
 } = require('../src/vnf-signature');
-const {
-  publicKeyHexToPem,
-  signAndEncodeBase64,
-  generateKeyPair,
-} = require('../src/crypto');
+const { signAndEncodeBase64, generateKeyPair } = require('../src/crypto');
+const { jwkFromSecp256k1Key } = require('../src/key-transformer');
+
+const toNodePublicKey = (publicKeyHex) => {
+  const publicJwk = jwkFromSecp256k1Key(publicKeyHex, false);
+  return crypto.createPublicKey({
+    key: {
+      kty: publicJwk.kty,
+      crv: publicJwk.crv,
+      x: publicJwk.x,
+      y: publicJwk.y,
+    },
+    format: 'jwk',
+  });
+};
 
 describe('vnf signature library', () => {
   const { privateKey, publicKey } = generateKeyPair();
@@ -56,7 +66,7 @@ describe('vnf signature library', () => {
         .createVerify('SHA256')
         .update(`${timestampValue}.${canonicalize(payload)}`)
         .verify(
-          publicKeyHexToPem(publicKey),
+          toNodePublicKey(publicKey),
           Buffer.from(vnfSignatureValue, 'base64'),
         );
       expect(isSignatureValid).toBe(true);

--- a/packages/db-kms/src/db-kms.js
+++ b/packages/db-kms/src/db-kms.js
@@ -21,8 +21,13 @@
  * @import { Context, Id, KMS, KeySpec, KmsKey, KmsSecret, ImportableKey, ImportableSecret } from "../../types/types"
  */
 
-const { generateJWAKeyPair, encrypt, decrypt } = require('@verii/crypto');
-const { jwtSign, jwtVerify, hexFromJwk } = require('@verii/jwt');
+const {
+  generateJWAKeyPair,
+  encrypt,
+  decrypt,
+  hexFromJwk,
+} = require('@verii/crypto');
+const { jwtSign, jwtVerify } = require('@verii/jwt');
 const { isEmpty, omit } = require('lodash/fp');
 const kmsRepo = require('./repo');
 const { defaultRepoOptions } = require('./default-repo-options');

--- a/packages/did-doc/src/common.js
+++ b/packages/did-doc/src/common.js
@@ -17,8 +17,12 @@
 const newError = require('http-errors');
 const { default: bs58 } = require('bs58');
 const { find, isNil, reduce } = require('lodash/fp');
-const { signPayload, generateKeyPair } = require('@verii/crypto');
-const { hexFromJwk, jwkFromSecp256k1Key } = require('@verii/jwt');
+const {
+  signPayload,
+  generateKeyPair,
+  hexFromJwk,
+  jwkFromSecp256k1Key,
+} = require('@verii/crypto');
 
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 

--- a/packages/did-doc/test/common.test.js
+++ b/packages/did-doc/test/common.test.js
@@ -20,8 +20,12 @@ const { expect } = require('expect');
 const { default: bs58 } = require('bs58');
 const { last } = require('lodash/fp');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
-const { generateKeyPair, signPayload } = require('@verii/crypto');
-const { jwkFromSecp256k1Key } = require('@verii/jwt');
+const {
+  generateKeyPair,
+  signPayload,
+  jwkFromSecp256k1Key,
+} = require('@verii/crypto');
+
 const { rootPrivateKey } = require('@verii/sample-data');
 const {
   verificationKeyType,

--- a/packages/endpoints-organizations-registrar/src/controllers/organizations/_did/controller.js
+++ b/packages/endpoints-organizations-registrar/src/controllers/organizations/_did/controller.js
@@ -23,7 +23,8 @@ const {
   VerifiableCredentialTypes,
   VerifiableCredentialFormats,
 } = require('@verii/verii-verification');
-const { decodeCredentialJwt, jwkFromSecp256k1Key } = require('@verii/jwt');
+const { jwkFromSecp256k1Key } = require('@verii/crypto');
+const { decodeCredentialJwt } = require('@verii/jwt');
 const { publish } = require('@spencejs/spence-events');
 const {
   verifyUserOrganizationReadAuthorized,

--- a/packages/endpoints-organizations-registrar/src/controllers/resolve-kid/controller.js
+++ b/packages/endpoints-organizations-registrar/src/controllers/resolve-kid/controller.js
@@ -3,7 +3,7 @@ const { default: bs58 } = require('bs58');
 const newError = require('http-errors');
 
 const { extractVerificationKey } = require('@verii/did-doc');
-const { jwkFromSecp256k1Key } = require('@verii/jwt');
+const { jwkFromSecp256k1Key } = require('@verii/crypto');
 const { resolveDid } = require('../resolve-did/resolve-did');
 const publicKeyFormats = require('./public-key-formats');
 

--- a/packages/endpoints-organizations-registrar/src/controllers/resolve-kid/controller.js
+++ b/packages/endpoints-organizations-registrar/src/controllers/resolve-kid/controller.js
@@ -3,14 +3,12 @@ const { default: bs58 } = require('bs58');
 const newError = require('http-errors');
 
 const { extractVerificationKey } = require('@verii/did-doc');
-const { publicKeyHexToPem } = require('@verii/crypto');
 const { jwkFromSecp256k1Key } = require('@verii/jwt');
 const { resolveDid } = require('../resolve-did/resolve-did');
 const publicKeyFormats = require('./public-key-formats');
 
 const resolversController = async (fastify) => {
   const publicKeyEncoders = {
-    [publicKeyFormats.PEM]: (publicKey) => publicKeyHexToPem(publicKey),
     [publicKeyFormats.BASE58]: (publicKey) =>
       bs58.encode(Buffer.from(publicKey, 'hex')),
     [publicKeyFormats.HEX]: (publicKey) => publicKey,
@@ -37,12 +35,11 @@ const resolversController = async (fastify) => {
             format: {
               type: 'string',
               enum: [
-                publicKeyFormats.PEM,
                 publicKeyFormats.BASE58,
                 publicKeyFormats.HEX,
                 publicKeyFormats.JWK,
               ],
-              default: publicKeyFormats.PEM,
+              default: publicKeyFormats.HEX,
             },
           },
         },

--- a/packages/endpoints-organizations-registrar/src/controllers/resolve-kid/public-key-formats.js
+++ b/packages/endpoints-organizations-registrar/src/controllers/resolve-kid/public-key-formats.js
@@ -1,5 +1,4 @@
 const PublicKeyFormats = Object.freeze({
-  PEM: 'pem',
   BASE58: 'base58',
   HEX: 'hex',
   JWK: 'jwk',

--- a/packages/endpoints-organizations-registrar/src/entities/organization-keys/domains/jwk-to-hex-key-transformer.js
+++ b/packages/endpoints-organizations-registrar/src/entities/organization-keys/domains/jwk-to-hex-key-transformer.js
@@ -1,5 +1,5 @@
 const { isEmpty } = require('lodash/fp');
-const { hexFromJwk } = require('@verii/jwt');
+const { hexFromJwk } = require('@verii/crypto');
 
 const jwkToHexKeyTransformer = (key) => ({
   ...key,

--- a/packages/endpoints-organizations-registrar/src/entities/organization-keys/domains/map-key-response.js
+++ b/packages/endpoints-organizations-registrar/src/entities/organization-keys/domains/map-key-response.js
@@ -1,4 +1,4 @@
-const { hexFromJwk } = require('@verii/jwt');
+const { hexFromJwk } = require('@verii/crypto');
 const { omit, isEmpty } = require('lodash/fp');
 
 /* eslint-disable better-mutation/no-mutation */

--- a/packages/endpoints-organizations-registrar/src/entities/organization-keys/orchestrators/delete-key.js
+++ b/packages/endpoints-organizations-registrar/src/entities/organization-keys/orchestrators/delete-key.js
@@ -18,8 +18,8 @@ const { toRelativeServiceId, removeKeyFromDidDoc } = require('@verii/did-doc');
 const { ObjectId } = require('mongodb');
 const newError = require('http-errors');
 const { includes } = require('lodash/fp');
-const { KeyPurposes } = require('@verii/crypto');
-const { hexFromJwk } = require('@verii/jwt');
+const { KeyPurposes, hexFromJwk } = require('@verii/crypto');
+
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 const {
   initPermissionsContract,

--- a/packages/endpoints-organizations-registrar/src/entities/organizations/factories/organizations-factory.js
+++ b/packages/endpoints-organizations-registrar/src/entities/organizations/factories/organizations-factory.js
@@ -19,11 +19,12 @@ const { compact, filter, flow, map } = require('lodash/fp');
 const { register } = require('@spencejs/spence-factories');
 const { createDidDoc, toRelativeServiceId } = require('@verii/did-doc');
 const { categorizeServices } = require('@verii/organizations-registry');
-const { hexFromJwk } = require('@verii/jwt');
+
 const {
   KeyPurposes,
   generateKeyPair,
   KeyAlgorithms,
+  hexFromJwk,
 } = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 

--- a/packages/endpoints-organizations-registrar/src/helpers/init-permissions-contract.js
+++ b/packages/endpoints-organizations-registrar/src/helpers/init-permissions-contract.js
@@ -15,9 +15,9 @@
  *
  */
 const { initPermissions } = require('@verii/contract-permissions');
-const { hexFromJwk } = require('@verii/jwt');
+
 const { ObjectId } = require('mongodb');
-const { KeyPurposes } = require('@verii/crypto');
+const { KeyPurposes, hexFromJwk } = require('@verii/crypto');
 
 const initPermissionsContract = async (organization, context) => {
   const { repos } = context;

--- a/packages/endpoints-organizations-registrar/test/helpers/map-response-key-to-db.js
+++ b/packages/endpoints-organizations-registrar/test/helpers/map-response-key-to-db.js
@@ -1,4 +1,4 @@
-const { jwkFromSecp256k1Key } = require('@verii/jwt');
+const { jwkFromSecp256k1Key } = require('@verii/crypto');
 const { omit } = require('lodash/fp');
 const { ObjectId } = require('mongodb');
 const { expect } = require('expect');

--- a/packages/endpoints-organizations-registrar/test/organization-keys-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/organization-keys-controller.test.js
@@ -112,8 +112,8 @@ const {
   KeyPurposes,
   generateKeyPair,
   KeyAlgorithms,
+  hexFromJwk,
 } = require('@verii/crypto');
-const { hexFromJwk } = require('@verii/jwt');
 
 const {
   generateOrganizationKeyMatcher,

--- a/packages/endpoints-organizations-registrar/test/organizations-full-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/organizations-full-controller.test.js
@@ -159,8 +159,9 @@ const {
   KeyPurposes,
   generateKeyPair,
   decryptCollection,
+  hexFromJwk,
 } = require('@verii/crypto');
-const { decodeCredentialJwt, hexFromJwk } = require('@verii/jwt');
+const { decodeCredentialJwt } = require('@verii/jwt');
 const { mapWithIndex, runSequentially } = require('@verii/common-functions');
 const { toRelativeKeyId } = require('@verii/did-doc');
 const {

--- a/packages/endpoints-organizations-registrar/test/resolve-kid-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/resolve-kid-controller.test.js
@@ -21,11 +21,7 @@ const { expect } = require('expect');
 const nock = require('./helpers/nock');
 const { mongoDb } = require('@spencejs/spence-mongo-repos');
 const { extractVerificationKey } = require('@verii/did-doc');
-const {
-  publicKeyHexToPem,
-  KeyPurposes,
-  generateKeyPair,
-} = require('@verii/crypto');
+const { KeyPurposes, generateKeyPair } = require('@verii/crypto');
 const { jwkFromSecp256k1Key, hexFromJwk } = require('@verii/jwt');
 const { errorResponseMatcher } = require('@verii/tests-helpers');
 const { default: bs58 } = require('bs58');
@@ -106,7 +102,7 @@ describe('Public Key Resolution', () => {
       url: `/api/v0.6/resolve-kid/${encodeURIComponent(kid)}`,
     });
 
-    expect(response.body).toEqual(publicKeyHexToPem(publicKeyHex0));
+    expect(response.body).toEqual(publicKeyHex0);
   });
 
   it('[Deprecated] Should resolve kid public key for "did:velocity" did with base58 publicKey as jwk', async () => {
@@ -140,7 +136,7 @@ describe('Public Key Resolution', () => {
     );
   });
 
-  it('Should return public key in default (PEM) format when query param not passed', async () => {
+  it('Should return public key in default HEX format when query param not passed', async () => {
     const organization = await persistOrganization({
       keys: DEFAULT_KEYS,
     });
@@ -155,25 +151,7 @@ describe('Public Key Resolution', () => {
       url: `/api/v0.6/resolve-kid/${encodeURIComponent(kid)}`,
     });
 
-    expect(response.body).toEqual(publicKeyHexToPem(publicKeyHex0));
-  });
-
-  it("Should return public key in PEM format when query param set to 'pem'", async () => {
-    const organization = await persistOrganization({
-      keys: DEFAULT_KEYS,
-    });
-    const { didDoc } = organization;
-    const did = didDoc.id;
-    const kidFragment = '#vc-signing-key-1';
-    const kid = `${did}${kidFragment}`;
-    const publicKeyHex0 = extractVerificationKey(didDoc, kid);
-
-    const response = await fastify.inject({
-      method: 'GET',
-      url: `/api/v0.6/resolve-kid/${encodeURIComponent(kid)}?format=pem`,
-    });
-
-    expect(response.body).toEqual(publicKeyHexToPem(publicKeyHex0));
+    expect(response.body).toEqual(publicKeyHex0);
   });
 
   it("Should return public key in HEX format when query param set to 'hex'", async () => {
@@ -324,32 +302,7 @@ describe('Public Key Resolution', () => {
       expect(response.statusCode).toEqual(200);
       expect(nockData.isDone()).toBeTruthy();
 
-      expect(response.body).toBe(
-        publicKeyHexToPem(hexFromJwk(keyPair.publicKey, false)),
-      );
-    });
-
-    it("Should return public key in PEM format when query param set to 'pem'", async () => {
-      const nockData = nock('https://example.com')
-        .get('/.well-known/did.json')
-        .reply(200, expectedDidWebDoc);
-
-      await persistOrganization({
-        didDocId: expectedDidWebDoc.id,
-      });
-      const kid = expectedDidWebDoc.verificationMethod[0].id;
-
-      const response = await fastify.inject({
-        method: 'GET',
-        url: `/api/v0.6/resolve-kid/${encodeURIComponent(kid)}?format=pem`,
-      });
-
-      expect(response.statusCode).toEqual(200);
-      expect(nockData.isDone()).toBeTruthy();
-
-      expect(response.body).toBe(
-        publicKeyHexToPem(hexFromJwk(keyPair.publicKey, false)),
-      );
+      expect(response.body).toBe(hexFromJwk(keyPair.publicKey, false));
     });
 
     it("Should return public key in HEX format when query param set to 'hex'", async () => {
@@ -434,7 +387,7 @@ describe('Public Key Resolution', () => {
         url: `/api/v0.6/resolve-kid/${encodeURIComponent(kid)}`,
       });
 
-      expect(response.body).toEqual(publicKeyHexToPem(publicKeyHex0));
+      expect(response.body).toEqual(publicKeyHex0);
     });
   });
 });

--- a/packages/endpoints-organizations-registrar/test/resolve-kid-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/resolve-kid-controller.test.js
@@ -21,8 +21,13 @@ const { expect } = require('expect');
 const nock = require('./helpers/nock');
 const { mongoDb } = require('@spencejs/spence-mongo-repos');
 const { extractVerificationKey } = require('@verii/did-doc');
-const { KeyPurposes, generateKeyPair } = require('@verii/crypto');
-const { jwkFromSecp256k1Key, hexFromJwk } = require('@verii/jwt');
+const {
+  KeyPurposes,
+  generateKeyPair,
+  jwkFromSecp256k1Key,
+  hexFromJwk,
+} = require('@verii/crypto');
+
 const { errorResponseMatcher } = require('@verii/tests-helpers');
 const { default: bs58 } = require('bs58');
 const initOrganizationFactory = require('../src/entities/organizations/factories/organizations-factory');

--- a/packages/jwt/src/key-transformer.js
+++ b/packages/jwt/src/key-transformer.js
@@ -1,106 +1,9 @@
-const { createECDH, createPrivateKey, createPublicKey } = require('crypto');
-const { base64url } = require('jose');
-const { isEmpty, startsWith, omit } = require('lodash/fp');
-
-const isPem = startsWith('-----BEGIN');
-
-const normalizeHex = (hex) => hex.replace(/^0x/i, '');
-
-const HEX_FORMAT = /^[0-9a-fA-F]+$/;
-
-const normalizeCoordinateHex = (hex, byteLength = 32) => {
-  const normalizedHex = normalizeHex(hex);
-  const paddedHex = normalizedHex.padStart(byteLength * 2, '0');
-  return paddedHex.slice(-byteLength * 2);
-};
-
-const detectHexKeyType = (key) => {
-  const normalizedKey = normalizeHex(key);
-  if (!HEX_FORMAT.test(normalizedKey)) {
-    return 'unknown';
-  }
-  if (normalizedKey.length === 64) {
-    return 'private';
-  }
-  if (
-    (normalizedKey.length === 130 && normalizedKey.startsWith('04')) ||
-    normalizedKey.length === 128
-  ) {
-    return 'public';
-  }
-  return 'unknown';
-};
-
-const base64UrlToHex = (value) => {
-  return Buffer.from(base64url.decode(value)).toString('hex');
-};
-
-const hexToBase64Url = (value) => {
-  return base64url.encode(Buffer.from(normalizeHex(value), 'hex'));
-};
-
-const uncompressedPublicKeyToCoordinates = (publicKey) => {
-  const normalizedKey = normalizeHex(publicKey);
-  const coordinates = normalizedKey.startsWith('04')
-    ? normalizedKey.slice(2)
-    : normalizedKey;
-  const canonicalCoordinates = coordinates.slice(-128);
-  return {
-    x: canonicalCoordinates.slice(0, 64),
-    y: canonicalCoordinates.slice(64),
-  };
-};
-
-const publicJwkFromPublicHex = (publicKeyHex) => {
-  const { x, y } = uncompressedPublicKeyToCoordinates(publicKeyHex);
-  return {
-    kty: 'EC',
-    crv: 'secp256k1',
-    use: 'sig',
-    x: hexToBase64Url(x),
-    y: hexToBase64Url(y),
-  };
-};
-
-const publicHexFromPrivateHex = (privateKeyHex) => {
-  const ecdh = createECDH('secp256k1');
-  ecdh.setPrivateKey(Buffer.from(normalizeCoordinateHex(privateKeyHex), 'hex'));
-  return ecdh.getPublicKey('hex', 'uncompressed');
-};
-
-const jwkFromPem = (pem, priv) => {
-  const keyObject = priv ? createPrivateKey(pem) : createPublicKey(pem);
-  const exportedJwk = keyObject.export({ format: 'jwk' });
-  return priv ? exportedJwk : omit(['d'], exportedJwk);
-};
-
-const jwkFromSecp256k1Key = (key, priv = true) => {
-  if (isPem(key)) {
-    const rawJwk = jwkFromPem(key, priv);
-    return {
-      ...rawJwk,
-      kty: 'EC',
-      use: 'sig',
-    };
-  }
-  if (!priv) {
-    const keyType = detectHexKeyType(key);
-    if (keyType === 'public') {
-      return publicJwkFromPublicHex(key);
-    }
-    if (keyType === 'private') {
-      return publicJwkFromPublicHex(publicHexFromPrivateHex(key));
-    }
-    throw new Error(
-      'Expected secp256k1 private key (64 hex chars) or uncompressed public key (128/130 hex chars)',
-    );
-  }
-  const privateKeyHex = normalizeCoordinateHex(key);
-  return {
-    ...publicJwkFromPublicHex(publicHexFromPrivateHex(privateKeyHex)),
-    d: hexToBase64Url(privateKeyHex),
-  };
-};
+const { isEmpty, omit } = require('lodash/fp');
+const {
+  hexFromJwk,
+  jwkFromSecp256k1Key,
+  publicKeyFromPrivateKey,
+} = require('@verii/crypto');
 
 const jwkFromStringified = (key, priv = true) => {
   const parsed = JSON.parse(key, (k, v) => {
@@ -115,17 +18,6 @@ const jwkFromStringified = (key, priv = true) => {
 
 const stringifyJwk = (jwk, priv = true) => {
   return JSON.stringify(priv ? jwk : omit(['d'], jwk));
-};
-
-const hexFromJwk = (jwk, priv = true) => {
-  if (priv) {
-    return normalizeCoordinateHex(base64UrlToHex(jwk.d));
-  }
-  return `04${normalizeCoordinateHex(base64UrlToHex(jwk.x))}${normalizeCoordinateHex(base64UrlToHex(jwk.y))}`;
-};
-
-const publicKeyFromPrivateKey = (key) => {
-  return key.x == null ? publicHexFromPrivateHex(key) : omit(['d'], key);
 };
 
 const transformKey = (property, key, isPrivate = true) =>

--- a/packages/jwt/test/core.test.js
+++ b/packages/jwt/test/core.test.js
@@ -373,22 +373,6 @@ describe('JWT Tests', () => {
       });
     });
 
-    it('should generate jwks from a pem', () => {
-      const key1 =
-        '-----BEGIN PUBLIC KEY-----\n' +
-        'MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEu7yLD8KSz7SvTO0HBDdudY0VL2iEEEx2\n' +
-        'eTEqkg9aRQFbcBzedDgN+MNxGzHHl5PLLP7/zXcNanhJf4jcD9Xguw==\n' +
-        '-----END PUBLIC KEY-----';
-      const jwk = jwkFromSecp256k1Key(key1, false);
-      expect(jwk).toEqual({
-        kty: 'EC',
-        crv: 'secp256k1',
-        use: 'sig',
-        x: expect.any(String),
-        y: expect.any(String),
-      });
-    });
-
     it('should generate jwks for private keys from private key only', () => {
       const secp256kKeyPair1 = generateKeyPair();
       const publicJwk = jwkFromSecp256k1Key(secp256kKeyPair1.publicKey, false);

--- a/packages/jwt/test/key-transformer.test.js
+++ b/packages/jwt/test/key-transformer.test.js
@@ -1,12 +1,9 @@
 const { describe, it } = require('node:test');
 const { expect } = require('expect');
 const {
-  hexFromJwk,
   transformKey,
   hexToJwkKeyTransformer,
-  jwkFromSecp256k1Key,
   jwkFromStringified,
-  publicKeyFromPrivateKey,
   stringifyJwk,
 } = require('../src/key-transformer');
 
@@ -30,13 +27,6 @@ const PUBLIC_JWK_WITH_PADDING = {
   x: 'AH6kY8xfesnm7vTxqjSEygHTZfj08j_NE1ae0oqcS0o',
   y: '5D87PB1frg8vj8Z7VRMio1w42aEKSzkq3FgP1IPXkYc',
   use: 'sig',
-};
-const PUBLIC_JWK_WITH_SHORT_X = {
-  ...PUBLIC_JWK_WITH_PADDING,
-  x: 'fqRjzF96yebu9PGqNITKAdNl-PTyP80TVp7SipxLSg',
-};
-const PRIVATE_JWK_WITH_SHORT_D = {
-  d: 'AQ',
 };
 
 const PRIVATE_KEY =
@@ -105,90 +95,6 @@ describe('Key Transformer Tests', () => {
       const transformedKey = hexToJwkKeyTransformer(hexKey);
 
       expect(transformedKey).toEqual(jwkKey);
-    });
-  });
-
-  describe('jwk / hex conversions', () => {
-    it('should generate jwk for hex public keys', () => {
-      const publicJwk = jwkFromSecp256k1Key(PUBLIC_KEY, false);
-
-      expect(publicJwk).toEqual(PUBLIC_JWK);
-    });
-
-    it('should generate jwk for hex public keys without prefix', () => {
-      const publicJwk = jwkFromSecp256k1Key(PUBLIC_KEY.slice(2), false);
-
-      expect(publicJwk).toEqual(PUBLIC_JWK);
-    });
-
-    it('should generate public jwk from private hex when requested', () => {
-      const publicJwk = jwkFromSecp256k1Key(PRIVATE_KEY, false);
-
-      expect(publicJwk).toEqual(PUBLIC_JWK);
-    });
-
-    it('should throw for invalid keys when public jwk is requested', () => {
-      expect(() => jwkFromSecp256k1Key('not-a-key', false)).toThrow(
-        'Expected secp256k1 private key (64 hex chars) or uncompressed public key (128/130 hex chars)',
-      );
-    });
-
-    it('should throw for wrong-sized hex keys when public jwk is requested', () => {
-      expect(() => jwkFromSecp256k1Key('abcd', false)).toThrow(
-        'Expected secp256k1 private key (64 hex chars) or uncompressed public key (128/130 hex chars)',
-      );
-    });
-
-    it('should generate hex for jwk public keys', () => {
-      expect(hexFromJwk(PUBLIC_JWK, false)).toEqual(PUBLIC_KEY);
-    });
-
-    it('should generate jwk for hex private keys', () => {
-      const privateJwk = jwkFromSecp256k1Key(PRIVATE_KEY, true);
-
-      expect(privateJwk).toEqual(PRIVATE_JWK);
-    });
-
-    it('should generate hex for jwk private keys', () => {
-      expect(hexFromJwk(PRIVATE_JWK, true)).toEqual(PRIVATE_KEY);
-    });
-
-    it('should preserve padding when generating hex for padded jwk private keys', () => {
-      expect(hexFromJwk(PRIVATE_JWK_WITH_PADDING, true)).toEqual(
-        PRIVATE_KEY_WITH_PADDING,
-      );
-    });
-
-    it('should preserve padding when generating hex for padded jwk public keys', () => {
-      expect(hexFromJwk(PUBLIC_JWK_WITH_PADDING, false)).toEqual(
-        PUBLIC_KEY_WITH_PADDING,
-      );
-    });
-
-    it('should add padding when generating hex for shortened jwk private keys', () => {
-      expect(hexFromJwk(PRIVATE_JWK_WITH_SHORT_D, true)).toEqual(
-        '0000000000000000000000000000000000000000000000000000000000000001',
-      );
-    });
-
-    it('should add coordinate padding when generating hex for shortened jwk public keys', () => {
-      expect(hexFromJwk(PUBLIC_JWK_WITH_SHORT_X, false)).toEqual(
-        PUBLIC_KEY_WITH_PADDING,
-      );
-    });
-  });
-
-  describe('public key from private key', () => {
-    it('should preserve padding for derived hex public keys', () => {
-      expect(publicKeyFromPrivateKey(PRIVATE_KEY_WITH_PADDING)).toEqual(
-        PUBLIC_KEY_WITH_PADDING,
-      );
-    });
-
-    it('should return public jwk for passed private jwk', () => {
-      expect(publicKeyFromPrivateKey(PRIVATE_JWK_WITH_PADDING)).toEqual(
-        PUBLIC_JWK_WITH_PADDING,
-      );
     });
   });
 

--- a/packages/jwt/test/key-transformer.test.js
+++ b/packages/jwt/test/key-transformer.test.js
@@ -31,6 +31,13 @@ const PUBLIC_JWK_WITH_PADDING = {
   y: '5D87PB1frg8vj8Z7VRMio1w42aEKSzkq3FgP1IPXkYc',
   use: 'sig',
 };
+const PUBLIC_JWK_WITH_SHORT_X = {
+  ...PUBLIC_JWK_WITH_PADDING,
+  x: 'fqRjzF96yebu9PGqNITKAdNl-PTyP80TVp7SipxLSg',
+};
+const PRIVATE_JWK_WITH_SHORT_D = {
+  d: 'AQ',
+};
 
 const PRIVATE_KEY =
   '1111111111111111111111111111111111111111111111111111111111111111';
@@ -51,18 +58,6 @@ const PUBLIC_JWK = {
   y: 'OFtrG46tgJymdFTZaD_PK6A0Vtb-LEq-Kwfw-9uy8cE',
   use: 'sig',
 };
-
-const PRIVATE_PEM = `-----BEGIN PRIVATE KEY-----
-MIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQgUrGgEV7O8YyOCCcRyEua
-Gf2pEowk0ga39xizkDbSbMGhRANCAAQAfqRjzF96yebu9PGqNITKAdNl+PTyP80T
-Vp7SipxLSuQ/OzwdX64PL4/Ge1UTIqNcONmhCks5KtxYD9SD15GH
------END PRIVATE KEY-----
-`;
-const PUBLIC_PEM = `-----BEGIN PUBLIC KEY-----
-MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAH6kY8xfesnm7vTxqjSEygHTZfj08j/N
-E1ae0oqcS0rkPzs8HV+uDy+PxntVEyKjXDjZoQpLOSrcWA/Ug9eRhw==
------END PUBLIC KEY-----
-`;
 
 describe('Key Transformer Tests', () => {
   describe('Transform key', () => {
@@ -169,6 +164,18 @@ describe('Key Transformer Tests', () => {
         PUBLIC_KEY_WITH_PADDING,
       );
     });
+
+    it('should add padding when generating hex for shortened jwk private keys', () => {
+      expect(hexFromJwk(PRIVATE_JWK_WITH_SHORT_D, true)).toEqual(
+        '0000000000000000000000000000000000000000000000000000000000000001',
+      );
+    });
+
+    it('should add coordinate padding when generating hex for shortened jwk public keys', () => {
+      expect(hexFromJwk(PUBLIC_JWK_WITH_SHORT_X, false)).toEqual(
+        PUBLIC_KEY_WITH_PADDING,
+      );
+    });
   });
 
   describe('public key from private key', () => {
@@ -208,20 +215,6 @@ describe('Key Transformer Tests', () => {
       const stringifiedPrivateJwk = stringifyJwk(PRIVATE_JWK, true);
 
       expect(JSON.parse(stringifiedPrivateJwk)).toEqual(PRIVATE_JWK);
-    });
-  });
-
-  describe('pem conversion', () => {
-    it('should generate a public jwk from a public pem', () => {
-      const publicJwk = jwkFromSecp256k1Key(PUBLIC_PEM, false);
-
-      expect(publicJwk).toEqual(PUBLIC_JWK_WITH_PADDING);
-    });
-
-    it('should generate a private jwk from a private pem', () => {
-      const privateJwk = jwkFromSecp256k1Key(PRIVATE_PEM, true);
-
-      expect(privateJwk).toEqual(PRIVATE_JWK_WITH_PADDING);
     });
   });
 });

--- a/packages/metadata-registration/package.json
+++ b/packages/metadata-registration/package.json
@@ -22,7 +22,6 @@
     "@verii/common-functions": "workspace:*",
     "@verii/cose-key": "workspace:*",
     "@verii/crypto": "workspace:*",
-    "@verii/jwt": "workspace:*",
     "@verii/contract-permissions": "workspace:*",
     "eth-url-parser": "^1.0.4",
     "lodash": "^4.18.1"

--- a/packages/metadata-registration/src/code-jwk.js
+++ b/packages/metadata-registration/src/code-jwk.js
@@ -15,13 +15,14 @@
  *
  */
 
-const { hexFromJwk, jwkFromSecp256k1Key } = require('@verii/jwt');
 const {
   get2BytesHash,
   encrypt,
   encryptBuffer,
   decrypt,
   decryptBuffer,
+  hexFromJwk,
+  jwkFromSecp256k1Key,
 } = require('@verii/crypto');
 const { CoseKey, fromJwk, toJwk } = require('@verii/cose-key');
 const { ALG_TYPE } = require('./constants');

--- a/packages/metadata-registration/test/code-jwk.test.js
+++ b/packages/metadata-registration/test/code-jwk.test.js
@@ -22,8 +22,10 @@ const {
   encrypt,
   encryptBuffer,
   decrypt,
+  hexFromJwk,
+  jwkFromSecp256k1Key,
 } = require('@verii/crypto');
-const { hexFromJwk, jwkFromSecp256k1Key } = require('@verii/jwt');
+
 const { encodeJwk, decodeJwk } = require('../src/code-jwk');
 const { ALG_TYPE } = require('../src/constants');
 

--- a/packages/tests-helpers/src/generate-key-pair-in-hex-and-jwk.js
+++ b/packages/tests-helpers/src/generate-key-pair-in-hex-and-jwk.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-const { generateKeyPair } = require('@verii/crypto');
-const { jwkFromSecp256k1Key } = require('@verii/jwt');
+const { generateKeyPair, jwkFromSecp256k1Key } = require('@verii/crypto');
 
 const generateKeyPairInHexAndJwk = () => {
   const { publicKey, privateKey } = generateKeyPair();

--- a/packages/verii-issuing/src/adapters/get-revocation-registry.js
+++ b/packages/verii-issuing/src/adapters/get-revocation-registry.js
@@ -17,9 +17,8 @@
 
 /** @import { Issuer, Context } from "../../types/types" */
 
-const { hexFromJwk } = require('@verii/jwt');
 const { initRevocationRegistry } = require('@verii/metadata-registration');
-const { initCallWithKmsKey } = require('@verii/crypto');
+const { initCallWithKmsKey, hexFromJwk } = require('@verii/crypto');
 
 /**
  * Get revocation registry

--- a/packages/verii-issuing/src/adapters/init-credential-metadata-contract.js
+++ b/packages/verii-issuing/src/adapters/init-credential-metadata-contract.js
@@ -16,8 +16,12 @@
  */
 
 const { initMetadataRegistry } = require('@verii/metadata-registration');
-const { jsonLdToUnsignedVcJwtContent, hexFromJwk } = require('@verii/jwt');
-const { KeyAlgorithms, initCallWithKmsKey } = require('@verii/crypto');
+const { jsonLdToUnsignedVcJwtContent } = require('@verii/jwt');
+const {
+  KeyAlgorithms,
+  initCallWithKmsKey,
+  hexFromJwk,
+} = require('@verii/crypto');
 const { buildIssuerVcUrl } = require('./build-issuer-vc-url');
 
 /** @import { Issuer, CredentialMetadata, Context } from "../../types/types" */

--- a/packages/verii-issuing/src/adapters/mongo-allocation-list-queries.js
+++ b/packages/verii-issuing/src/adapters/mongo-allocation-list-queries.js
@@ -17,7 +17,7 @@
 /** @import { Issuer, AllocationListEntry, AllocationListQueries, Context } from "../../types/types" */
 
 const { toEthereumAddress } = require('@verii/blockchain-functions');
-const { hexFromJwk } = require('@verii/jwt');
+const { hexFromJwk } = require('@verii/crypto');
 /**
  * Returns the queries needed for allocating to DLT Lists
  * @param {unknown} db the db connection

--- a/packages/verii-issuing/test/e2e-issuing.test.js
+++ b/packages/verii-issuing/test/e2e-issuing.test.js
@@ -35,7 +35,8 @@ const {
 } = require('@verii/metadata-registration/test/helpers/deploy-contracts');
 
 const { nanoid } = require('nanoid');
-const { hexFromJwk, jwtSign, jwtDecode } = require('@verii/jwt');
+const { hexFromJwk } = require('@verii/crypto');
+const { jwtSign, jwtDecode } = require('@verii/jwt');
 const { MongoClient } = require('mongodb');
 const { map } = require('lodash/fp');
 const { collectionClient } = require('./helpers/collection-client');

--- a/packages/verii-issuing/test/helpers/entity-factory.js
+++ b/packages/verii-issuing/test/helpers/entity-factory.js
@@ -16,9 +16,9 @@
  */
 
 const { nanoid } = require('nanoid');
-const { generateKeyPair } = require('@verii/crypto');
+const { generateKeyPair, hexFromJwk } = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
-const { hexFromJwk } = require('@verii/jwt');
+
 const { createExampleDid } = require('./create-example-did');
 
 const entityFactory = ({ service = [], key = [], ...values } = {}) => {

--- a/packages/verii-issuing/test/list-allocator.test.js
+++ b/packages/verii-issuing/test/list-allocator.test.js
@@ -22,9 +22,9 @@ const { mongoify } = require('@verii/tests-helpers');
 const { first, omit } = require('lodash/fp');
 const { ObjectId, MongoClient } = require('mongodb');
 const { nanoid } = require('nanoid');
-const { generateJWAKeyPair } = require('@verii/crypto');
+const { generateJWAKeyPair, hexFromJwk } = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
-const { hexFromJwk } = require('@verii/jwt');
+
 const {
   mongoAllocationListQueries,
 } = require('../src/adapters/mongo-allocation-list-queries');

--- a/packages/verii-verification/package.json
+++ b/packages/verii-verification/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@verii/common-fetchers": "workspace:*",
     "@verii/common-functions": "workspace:*",
+    "@verii/crypto": "workspace:*",
     "@verii/did-doc": "workspace:*",
     "@verii/http-client": "workspace:*",
     "@verii/jwt": "workspace:*",
@@ -28,7 +29,6 @@
     "lodash": "^4.18.1"
   },
   "devDependencies": {
-    "@verii/crypto": "workspace:*",
     "@verii/sample-data": "workspace:*",
     "@verii/test-regexes": "workspace:*",
     "@verii/tests-helpers": "workspace:*",

--- a/packages/verii-verification/src/verify-credentials.js
+++ b/packages/verii-verification/src/verify-credentials.js
@@ -31,7 +31,8 @@ const {
   toLower,
   uniq,
 } = require('lodash/fp');
-const { buildDecodedCredential, jwtDecode, hexFromJwk } = require('@verii/jwt');
+const { hexFromJwk } = require('@verii/crypto');
+const { buildDecodedCredential, jwtDecode } = require('@verii/jwt');
 const {
   initMetadataRegistry,
   initVerificationCoupon,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -746,9 +746,6 @@ importers:
 
   packages/crypto:
     dependencies:
-      '@trust/keyto':
-        specifier: ~2.0.0-alpha1
-        version: 2.0.0-alpha1
       '@verii/test-regexes':
         specifier: workspace:*
         version: link:../test-regexes
@@ -7130,9 +7127,6 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@trust/keyto@2.0.0-alpha1':
-    resolution: {integrity: sha512-VmlOa+nOaDzhEUfprnVp7RxFQyuEwA4fJ5+smnsud5WM01gU16yQnO/ejZnDVMGXuq/sUwTa5pCej4JhkKA5Sg==}
-
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -7696,10 +7690,6 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  base64url@3.0.1:
-    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
-    engines: {node: '>=6.0.0'}
 
   baseline-browser-mapping@2.10.0:
     resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
@@ -15895,12 +15885,6 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@trust/keyto@2.0.0-alpha1':
-    dependencies:
-      asn1.js: 5.4.1
-      base64url: 3.0.1
-      elliptic: 6.6.1
-
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -16515,8 +16499,6 @@ snapshots:
   base64-js@0.0.8: {}
 
   base64-js@1.5.1: {}
-
-  base64url@3.0.1: {}
 
   baseline-browser-mapping@2.10.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,9 +334,9 @@ importers:
 
   packages/blockchain-functions:
     dependencies:
-      '@verii/jwt':
+      '@verii/crypto':
         specifier: workspace:*
-        version: link:../jwt
+        version: link:../crypto
       ethers:
         specifier: ^6.17.0
         version: 6.17.0
@@ -344,9 +344,6 @@ importers:
         specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
-      '@verii/crypto':
-        specifier: workspace:*
-        version: link:../crypto
       eslint:
         specifier: 9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -2473,6 +2470,9 @@ importers:
       '@verii/common-functions':
         specifier: workspace:*
         version: link:../common-functions
+      '@verii/crypto':
+        specifier: workspace:*
+        version: link:../crypto
       '@verii/did-doc':
         specifier: workspace:*
         version: link:../did-doc
@@ -2495,9 +2495,6 @@ importers:
         specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
-      '@verii/crypto':
-        specifier: workspace:*
-        version: link:../crypto
       '@verii/sample-data':
         specifier: workspace:*
         version: link:../sample-data

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,9 +258,6 @@ importers:
       '@verii/crypto':
         specifier: workspace:*
         version: link:../crypto
-      '@verii/jwt':
-        specifier: workspace:*
-        version: link:../jwt
       eslint:
         specifier: 9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -743,9 +740,6 @@ importers:
 
   packages/crypto:
     dependencies:
-      '@verii/test-regexes':
-        specifier: workspace:*
-        version: link:../test-regexes
       argon2:
         specifier: 0.44.0
         version: 0.44.0
@@ -768,6 +762,9 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
     devDependencies:
+      '@verii/test-regexes':
+        specifier: workspace:*
+        version: link:../test-regexes
       eslint:
         specifier: 9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -1889,9 +1886,6 @@ importers:
       '@verii/crypto':
         specifier: workspace:*
         version: link:../crypto
-      '@verii/jwt':
-        specifier: workspace:*
-        version: link:../jwt
       eth-url-parser:
         specifier: ^1.0.4
         version: 1.0.4

--- a/servers/credentialagent/src/entities/keys/domains/is-matching-private-key-kid.js
+++ b/servers/credentialagent/src/entities/keys/domains/is-matching-private-key-kid.js
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-const {
-  generateDocJwt,
-  jwtVerify,
-  jwkFromSecp256k1Key,
-} = require('@verii/jwt');
+const { jwkFromSecp256k1Key } = require('@verii/crypto');
+const { generateDocJwt, jwtVerify } = require('@verii/jwt');
 const { extractVerificationKey } = require('@verii/did-doc');
 
 const isMatchingPrivateKeyKid = async (doc, key, kid) => {

--- a/servers/credentialagent/src/entities/keys/orchestrators/validate-did-doc-keys.js
+++ b/servers/credentialagent/src/entities/keys/orchestrators/validate-did-doc-keys.js
@@ -1,6 +1,6 @@
 const { each, map, omit, isEmpty, isString, some } = require('lodash/fp');
 const newError = require('http-errors');
-const { jwkFromSecp256k1Key } = require('@verii/jwt');
+const { jwkFromSecp256k1Key } = require('@verii/crypto');
 const { extractVerificationMethod } = require('@verii/did-doc');
 const { validateKey, isMatchingPrivateKeyKid } = require('../domains');
 

--- a/servers/credentialagent/src/entities/offers/orchestrators/create-verifiable-credentials.js
+++ b/servers/credentialagent/src/entities/offers/orchestrators/create-verifiable-credentials.js
@@ -16,9 +16,9 @@
 
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 const { mapWithIndex } = require('@verii/common-functions');
-const { KeyPurposes, calcSha384 } = require('@verii/crypto');
+const { KeyPurposes, calcSha384, hexFromJwk } = require('@verii/crypto');
 const { toDidUrl } = require('@verii/did-doc');
-const { hexFromJwk, jwtDecode } = require('@verii/jwt');
+const { jwtDecode } = require('@verii/jwt');
 const {
   issueVeriiCredentials,
   mongoAllocationListQueries,

--- a/servers/credentialagent/src/entities/tenants/orchestrators/add-primary-address-to-tenant.js
+++ b/servers/credentialagent/src/entities/tenants/orchestrators/add-primary-address-to-tenant.js
@@ -15,9 +15,8 @@
  */
 
 const { initPermissions } = require('@verii/contract-permissions');
-const { KeyPurposes, decrypt } = require('@verii/crypto');
+const { KeyPurposes, decrypt, hexFromJwk } = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
-const { hexFromJwk } = require('@verii/jwt');
 
 const addPrimaryAddressToTenant = async ({ _id }, context) => {
   const { repos, config, rpcProvider } = context;

--- a/servers/credentialagent/test/holder/e2e-issuing-controller.test.js
+++ b/servers/credentialagent/test/holder/e2e-issuing-controller.test.js
@@ -23,7 +23,7 @@ const {
   mongoFactoryWrapper,
   mongoCloseWrapper,
 } = require('@verii/tests-helpers');
-const { generateKeyPair } = require('@verii/crypto');
+const { generateKeyPair, hexFromJwk } = require('@verii/crypto');
 
 const {
   deployPermissionContract,
@@ -36,7 +36,7 @@ const {
 } = require('@verii/metadata-registration/test/helpers/deploy-contracts');
 const { initPermissions } = require('@verii/contract-permissions');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
-const { hexFromJwk, jwtDecode } = require('@verii/jwt');
+const { jwtDecode } = require('@verii/jwt');
 const { ObjectId } = require('mongodb');
 const nock = require('../helpers/nock');
 const { KeyPurposes } = require('@verii/crypto');

--- a/servers/credentialagent/test/holder/helpers/generate-presentation.js
+++ b/servers/credentialagent/test/holder/helpers/generate-presentation.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const { generateKeyPair } = require('@verii/crypto');
+const { generateKeyPair, jwkFromSecp256k1Key } = require('@verii/crypto');
 const { mapWithIndex } = require('@verii/common-functions');
 const {
   castArray,
@@ -31,7 +31,6 @@ const {
 } = require('lodash/fp');
 const { nanoid } = require('nanoid/non-secure');
 const {
-  jwkFromSecp256k1Key,
   generateDocJwt,
   generateCredentialJwt,
   generatePresentationJwt,

--- a/servers/credentialagent/test/holder/issuing-controller.test.js
+++ b/servers/credentialagent/test/holder/issuing-controller.test.js
@@ -49,7 +49,7 @@ const { mongoDb } = require('@spencejs/spence-mongo-repos');
 const { getUnixTime, subYears, subDays } = require('date-fns/fp');
 const { nanoid } = require('nanoid');
 const { mapWithIndex, wait } = require('@verii/common-functions');
-const { jwtDecode, jwtSign, hexFromJwk, jwkThumbprint } = require('@verii/jwt');
+const { jwtDecode, jwtSign, jwkThumbprint } = require('@verii/jwt');
 const {
   VeriiProtocolVersions,
   VelocityRevocationListType,
@@ -83,7 +83,7 @@ const {
   jsonify,
   errorResponseMatcher,
 } = require('@verii/tests-helpers');
-const { KeyPurposes, generateKeyPair } = require('@verii/crypto');
+const { KeyPurposes, generateKeyPair, hexFromJwk } = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 const { hashOffer } = require('@verii/verii-issuing');
 const buildFastify = require('./helpers/credentialagent-holder-build-fastify');

--- a/servers/credentialagent/test/operator/credentials-revoke.test.js
+++ b/servers/credentialagent/test/operator/credentials-revoke.test.js
@@ -34,10 +34,10 @@ const { mongoDb } = require('@spencejs/spence-mongo-repos');
 
 const nock = require('../helpers/nock');
 const { mongoify, errorResponseMatcher } = require('@verii/tests-helpers');
-const { generateKeyPair, KeyPurposes } = require('@verii/crypto');
+const { generateKeyPair, KeyPurposes, hexFromJwk } = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 const { ObjectId } = require('mongodb');
-const { hexFromJwk } = require('@verii/jwt');
+
 const buildFastify = require('./helpers/credentialagent-operator-build-fastify');
 const {
   initOfferFactory,

--- a/servers/credentialagent/test/operator/helpers/create-test-org-doc.js
+++ b/servers/credentialagent/test/operator/helpers/create-test-org-doc.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-const { generateKeyPair } = require('@verii/crypto');
-const { jwkFromSecp256k1Key } = require('@verii/jwt');
+const { generateKeyPair, jwkFromSecp256k1Key } = require('@verii/crypto');
+
 const { nanoid } = require('nanoid/non-secure');
 
 const createOrgDoc = async () => {

--- a/servers/credentialagent/test/operator/keys-controller-v0.8.test.js
+++ b/servers/credentialagent/test/operator/keys-controller-v0.8.test.js
@@ -25,10 +25,16 @@ const {
   OBJECT_ID_FORMAT,
 } = require('@verii/test-regexes');
 const { errorResponseMatcher, mongoify } = require('@verii/tests-helpers');
-const { hexFromJwk, jwkFromSecp256k1Key } = require('@verii/jwt');
+
 const { rootPrivateKey } = require('@verii/sample-data');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
-const { KeyPurposes, KeyEncodings, generateKeyPair } = require('@verii/crypto');
+const {
+  KeyPurposes,
+  KeyEncodings,
+  generateKeyPair,
+  hexFromJwk,
+  jwkFromSecp256k1Key,
+} = require('@verii/crypto');
 const {
   deployTestPermissionsContract,
 } = require('@verii/contract-permissions/test/helpers/deploy-test-permissions-contract');

--- a/servers/credentialagent/test/operator/tenants-controller-v0.8.test.js
+++ b/servers/credentialagent/test/operator/tenants-controller-v0.8.test.js
@@ -27,12 +27,18 @@ const {
 const { errorResponseMatcher } = require('@verii/tests-helpers');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 const { rootPrivateKey } = require('@verii/sample-data');
-const { KeyPurposes, generateKeyPair, decrypt } = require('@verii/crypto');
+const {
+  KeyPurposes,
+  generateKeyPair,
+  decrypt,
+  hexFromJwk,
+  publicKeyFromPrivateKey,
+  jwkFromSecp256k1Key,
+} = require('@verii/crypto');
 const {
   deployTestPermissionsContract,
 } = require('@verii/contract-permissions/test/helpers/deploy-test-permissions-contract');
-const { hexFromJwk, publicKeyFromPrivateKey } = require('@verii/jwt');
-const { jwkFromSecp256k1Key } = require('@verii/jwt');
+
 const buildFastify = require('./helpers/credentialagent-operator-build-fastify');
 const { createOrgDoc } = require('./helpers/create-test-org-doc');
 const {

--- a/servers/credentialinghub/src/entities/keys/adapters/load-primary-account.js
+++ b/servers/credentialinghub/src/entities/keys/adapters/load-primary-account.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-const { hexFromJwk } = require('@verii/jwt');
+const { hexFromJwk } = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 const { initPermissions } = require('@verii/contract-permissions');
 

--- a/servers/credentialinghub/src/entities/keys/domain/normalize-tenant-key.js
+++ b/servers/credentialinghub/src/entities/keys/domain/normalize-tenant-key.js
@@ -16,8 +16,12 @@
  */
 const { omit } = require('lodash/fp');
 const { ObjectId } = require('mongodb');
-const { publicKeyFromPrivateKey, jwkFromSecp256k1Key } = require('@verii/jwt');
-const { KeyEncodings } = require('@verii/crypto');
+
+const {
+  KeyEncodings,
+  publicKeyFromPrivateKey,
+  jwkFromSecp256k1Key,
+} = require('@verii/crypto');
 
 const normalizeTenantKey = (key) => {
   const privateJwk = key.jwk != null ? key.jwk : jwkFromSecp256k1Key(key.key);

--- a/servers/credentialinghub/src/entities/keys/factories/key-factory.js
+++ b/servers/credentialinghub/src/entities/keys/factories/key-factory.js
@@ -20,9 +20,10 @@ const {
   KeyAlgorithms,
   KeyEncodings,
   generateKeyPair,
+  publicKeyFromPrivateKey,
 } = require('@verii/crypto');
 const { ObjectId } = require('mongodb');
-const { publicKeyFromPrivateKey } = require('@verii/jwt');
+
 const { kmsRepo, defaultRepoOptions } = require('@verii/db-kms');
 const { initTenantFactory } = require('../../tenants/factories');
 const { kmsRepoOptions } = require('../plugins');

--- a/servers/credentialinghub/test/openid4vc/openid4vci-credential.test.js
+++ b/servers/credentialinghub/test/openid4vc/openid4vci-credential.test.js
@@ -34,7 +34,7 @@ mock.module('@verii/metadata-registration', {
     }),
   },
 });
-const { generateKeyPair, encrypt } = require('@verii/crypto');
+const { generateKeyPair, encrypt, hexFromJwk } = require('@verii/crypto');
 const { getDidUriFromJwk } = require('@verii/did-doc');
 const { ObjectId } = require('mongodb');
 const { applyOverrides } = require('@verii/common-functions');
@@ -45,7 +45,7 @@ const {
 
 mock.module('@verii/http-client', { namedExports: mockHttpClientModule });
 
-const { jwtSign, hexFromJwk, tamperJwt, jwtDecode } = require('@verii/jwt');
+const { jwtSign, tamperJwt, jwtDecode } = require('@verii/jwt');
 const { NANO_ID_FORMAT, DID_FORMAT } = require('@verii/test-regexes');
 const { mongoify } = require('@verii/tests-helpers');
 const { mongoDb } = require('@spencejs/spence-mongo-repos');

--- a/servers/credentialinghub/test/openid4vc/openid4vci-nonce.test.js
+++ b/servers/credentialinghub/test/openid4vc/openid4vci-nonce.test.js
@@ -23,8 +23,8 @@ const { mockHttpClientModule } = require('../helpers/mock-http-client');
 mock.module('@verii/http-client', { namedExports: mockHttpClientModule });
 
 const { mongoDb } = require('@spencejs/spence-mongo-repos');
-const { decrypt } = require('@verii/crypto');
-const { hexFromJwk } = require('@verii/jwt');
+const { decrypt, hexFromJwk } = require('@verii/crypto');
+
 const { initKeyFactory } = require('../../src/entities/keys');
 const { initTenantFactory } = require('../../src/entities/tenants');
 const createTestFastify = require('../helpers/create-test-fastify');

--- a/servers/credentialinghub/test/operator/tenants-controller.test.js
+++ b/servers/credentialinghub/test/operator/tenants-controller.test.js
@@ -41,9 +41,14 @@ const {
   OBJECT_ID_FORMAT,
 } = require('@verii/test-regexes');
 const { errorResponseMatcher, mongoify } = require('@verii/tests-helpers');
-const { generateKeyPair, KeyPurposes, KeyEncodings } = require('@verii/crypto');
+const {
+  generateKeyPair,
+  KeyPurposes,
+  KeyEncodings,
+  publicKeyFromPrivateKey,
+} = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
-const { publicKeyFromPrivateKey } = require('@verii/jwt');
+
 const { applyOverrides } = require('@verii/common-functions');
 const createTestFastify = require('../helpers/create-test-fastify');
 const { buildIssuerDidDoc } = require('../helpers/build-issuer-did-doc');

--- a/tools/verifgen/src/verifgen-presentation.js
+++ b/tools/verifgen/src/verifgen-presentation.js
@@ -1,13 +1,9 @@
 const { program } = require('commander');
 const { map, isEmpty } = require('lodash/fp');
 const { nanoid } = require('nanoid');
-const {
-  generatePresentationJwt,
-  toJwk,
-  publicKeyFromPrivateKey,
-} = require('@verii/jwt');
+const { generatePresentationJwt, toJwk } = require('@verii/jwt');
 const { mapWithIndex } = require('@verii/common-functions');
-const { generateKeyPair } = require('@verii/crypto');
+const { generateKeyPair, publicKeyFromPrivateKey } = require('@verii/crypto');
 const { getDidUriFromJwk } = require('@verii/did-doc');
 const { VeriiProtocolVersions } = require('@verii/vc-checks');
 

--- a/tools/verifgen/src/verifgen-proof/generate-proof.js
+++ b/tools/verifgen/src/verifgen-proof/generate-proof.js
@@ -1,5 +1,6 @@
 const { isEmpty } = require('lodash/fp');
-const { jwtSign, publicKeyFromPrivateKey, toJwk } = require('@verii/jwt');
+const { publicKeyFromPrivateKey } = require('@verii/crypto');
+const { jwtSign, toJwk } = require('@verii/jwt');
 const { getDidUriFromJwk } = require('@verii/did-doc');
 const common = require('../common');
 

--- a/tools/verifgen/test/proof.test.js
+++ b/tools/verifgen/test/proof.test.js
@@ -5,8 +5,8 @@ const fs = require('fs').promises;
 const os = require('os');
 const path = require('path');
 
-const { generateKeyPair } = require('@verii/crypto');
-const { jwtVerify, jwkFromSecp256k1Key } = require('@verii/jwt');
+const { generateKeyPair, jwkFromSecp256k1Key } = require('@verii/crypto');
+const { jwtVerify } = require('@verii/jwt');
 const { getDidUriFromJwk } = require('@verii/did-doc');
 const { generateProof } = require('../src/verifgen-proof/generate-proof');
 


### PR DESCRIPTION
## Summary

- Move secp256k1 JWK/hex conversion helpers into `@verii/crypto` and export them from the crypto package.
- Switch conversion and signature key-object construction away from `@trust/keyto`/PEM and onto native Node crypto APIs.
- Keep `@verii/jwt` key-transformer helpers as compatibility wrappers over `@verii/crypto`.
- Remove PEM handling from the registrar `resolve-kid` public-key format path; default output is now `hex`, with `hex`, `base58`, and `jwk` supported.
- Add fixed-vector coverage for leading-zero and shortened base64url JWK coordinate/private-key padding cases.

## Validation

- `corepack $(node -p "require('./package.json').packageManager") --filter @verii/crypto test`
- `corepack $(node -p "require('./package.json').packageManager") --filter @verii/jwt test`
- `corepack $(node -p "require('./package.json').packageManager") --filter @verii/endpoints-organizations-registrar exec cross-env NODE_ENV=test node --test --test-concurrency=1 --experimental-test-module-mocks --test-reporter=spec --test-reporter-destination=stdout test/resolve-kid-controller.test.js`
- `eslint --fix` on affected JS files
- `git diff --check`