### PR TITLE
[codex] support jwk contract private keys

### DIFF
--- a/packages/base-contract-io/package.json
+++ b/packages/base-contract-io/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@verii/blockchain-functions": "workspace:*",
     "@verii/common-functions": "workspace:*",
+    "@verii/crypto": "workspace:*",
     "@verii/http-client": "workspace:*",
     "date-fns": "^4.4.0",
     "fastify-plugin": "^5.1.0",
@@ -26,9 +27,8 @@
     "lodash": "^4.18.1"
   },
   "devDependencies": {
-    "@verii/tests-helpers": "workspace:*",
     "@spencejs/spence-config": "1.1.0",
-    "@verii/crypto": "workspace:*",
+    "@verii/tests-helpers": "workspace:*",
     "expect": "30.4.1"
   },
   "nx": {

--- a/packages/base-contract-io/src/contract-with-transacting-client.js
+++ b/packages/base-contract-io/src/contract-with-transacting-client.js
@@ -1,13 +1,20 @@
 const { Wallet } = require('ethers');
-const { signArguments } = require('@verii/blockchain-functions');
+const {
+  generateAccount,
+  signArguments,
+} = require('@verii/blockchain-functions');
 const { initContractClient } = require('./contract');
+const { toEthersPrivateKey } = require('./private-key');
 
 const initContractWithTransactingClient = async (
   { privateKey, contractAddress, rpcProvider, contractAbi },
   context,
 ) => {
-  const transactingWallet = Wallet.createRandom();
-  const operatorWallet = new Wallet(privateKey, rpcProvider);
+  const transactingWallet = generateAccount();
+  const operatorWallet = new Wallet(
+    toEthersPrivateKey(privateKey),
+    rpcProvider,
+  );
   return {
     transactingClient: await initContractClient(
       {

--- a/packages/base-contract-io/src/contract.js
+++ b/packages/base-contract-io/src/contract.js
@@ -17,15 +17,11 @@
 const { rangeStep } = require('lodash/fp');
 const ethers = require('ethers');
 const { ResyncingNonceManager } = require('./resyncing-nonce-manager');
+const { toEthersPrivateKey } = require('./private-key');
 
 const QueryMaxBlocks = 500;
 const signerByProvider = new WeakMap();
 const signerWithoutProvider = new Map();
-
-const ensureHexPrefix = (privateKey) => {
-  const prefix = privateKey?.startsWith('0x') ? '' : '0x';
-  return `${prefix}${privateKey}`;
-};
 
 const initProvider = (rpcUrl, authenticate, chainId) => {
   const network = chainId ? ethers.Network.from(chainId) : undefined;
@@ -82,7 +78,7 @@ const initContractClient = async (
   }
 
   const wallet = privateKey
-    ? initWalletSigner(ensureHexPrefix(privateKey), rpcProvider, cacheSigner)
+    ? initWalletSigner(toEthersPrivateKey(privateKey), rpcProvider, cacheSigner)
     : null;
 
   const contractClient = new ethers.Contract(

--- a/packages/base-contract-io/src/contract.js
+++ b/packages/base-contract-io/src/contract.js
@@ -72,7 +72,10 @@ const initContractClient = async (
   { privateKey, contractAddress, rpcProvider, contractAbi, cacheSigner = true },
   context,
 ) => {
-  context.log.info({ contractAddress }, 'initContractClient');
+  context.log.info(
+    { contractAddress, hasPrivateKey: Boolean(privateKey) },
+    'initContractClient',
+  );
   if (!contractAddress) {
     throw new Error('Check the required parameters: contractAddress');
   }

--- a/packages/base-contract-io/src/contract.js
+++ b/packages/base-contract-io/src/contract.js
@@ -72,7 +72,7 @@ const initContractClient = async (
   { privateKey, contractAddress, rpcProvider, contractAbi, cacheSigner = true },
   context,
 ) => {
-  context.log.info({ privateKey, contractAddress }, 'initContractClient');
+  context.log.info({ contractAddress }, 'initContractClient');
   if (!contractAddress) {
     throw new Error('Check the required parameters: contractAddress');
   }

--- a/packages/base-contract-io/src/private-key.js
+++ b/packages/base-contract-io/src/private-key.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Velocity Team
+ * Copyright 2026 Velocity Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-module.exports = {
-  ...require('./src/ethers-wrappers'),
-  ...require('./src/ibft'),
-  ...require('./src/eth'),
-  ...require('./src/sign-arguments'),
-  ...require('./src/generate-disposable-private-key'),
+const { hexFromJwk } = require('@verii/crypto');
+
+const toEthersPrivateKey = (privateKey) => {
+  const hexKey =
+    typeof privateKey === 'string' ? privateKey : hexFromJwk(privateKey);
+
+  return /^0x/i.test(hexKey) ? `0x${hexKey.slice(2)}` : `0x${hexKey}`;
 };
+
+module.exports = { toEthersPrivateKey };

--- a/packages/base-contract-io/test/contract-with-transacting-client.test.js
+++ b/packages/base-contract-io/test/contract-with-transacting-client.test.js
@@ -16,6 +16,7 @@
 const { after, before, beforeEach, describe, it } = require('node:test');
 const { expect } = require('expect');
 
+const { generateDisposablePrivateKey } = require('@verii/blockchain-functions');
 const { generateKeyPair } = require('@verii/crypto');
 const {
   mongoFactoryWrapper,
@@ -39,7 +40,7 @@ describe(
   'Contract With Transacting Client Test Suite',
   { timeout: 15000 },
   () => {
-    const { privateKey: deployerPrivateKey } = generateKeyPair();
+    const deployerPrivateKey = generateDisposablePrivateKey();
     const rpcUrl = 'http://localhost:8545';
     const authenticate = () => 'TOKEN';
     const rpcProvider = initProvider(rpcUrl, authenticate);
@@ -66,7 +67,7 @@ describe(
         contractInstance = await deployContractWrapper();
       });
       it('Creating a client with no contractAddress should fail', async () => {
-        const { privateKey: clientPrivateKey } = generateKeyPair();
+        const clientPrivateKey = generateDisposablePrivateKey();
         const func = async () =>
           initContractWithTransactingClient(
             {
@@ -82,11 +83,11 @@ describe(
       });
 
       it('Create a client', async () => {
-        const { privateKey: clientPrivateKey } = generateKeyPair();
+        const { privateKey } = generateKeyPair({ format: 'jwk' });
 
         const { transactingClient } = await initContractWithTransactingClient(
           {
-            privateKey: clientPrivateKey,
+            privateKey,
             contractAddress: await contractInstance.getAddress(),
             contractAbi: testEventsAbi,
             rpcProvider,

--- a/packages/base-contract-io/test/contract.test.js
+++ b/packages/base-contract-io/test/contract.test.js
@@ -20,6 +20,7 @@ const {
   beforeEach,
   describe,
   it,
+  mock,
 } = require('node:test');
 const { expect } = require('expect');
 
@@ -95,21 +96,27 @@ describe('Contract Client Test Suite', { timeout: 15000 }, () => {
 
     it('Create a client', async () => {
       const { privateKey } = generateKeyPair({ format: 'jwk' });
+      const contractAddress = await contractInstance.getAddress();
+      const log = { info: mock.fn() };
 
       contractClient = await initContractClient(
         {
           privateKey,
-          contractAddress: await contractInstance.getAddress(),
+          contractAddress,
           contractAbi: testEventsAbi,
           rpcProvider,
         },
-        context,
+        { ...context, log },
       );
 
       expect(contractClient.wallet.provider).toEqual(rpcProvider);
       expect(contractClient.contractClient.runner.provider).toEqual(
         rpcProvider,
       );
+      expect(log.info.mock.calls.map((call) => call.arguments)).toEqual([
+        [{ contractAddress }, 'initContractClient'],
+        ['initContractClient done'],
+      ]);
     });
   });
 

--- a/packages/base-contract-io/test/contract.test.js
+++ b/packages/base-contract-io/test/contract.test.js
@@ -31,7 +31,10 @@ const {
 const { env: config } = require('@spencejs/spence-config');
 const console = require('console');
 
-const { toEthereumAddress } = require('@verii/blockchain-functions');
+const {
+  generateAccount,
+  generateDisposablePrivateKey,
+} = require('@verii/blockchain-functions');
 
 const { wait } = require('@verii/common-functions');
 const testEventsAbi = require('./data/test-events-abi.json');
@@ -44,8 +47,8 @@ const context = {
 };
 
 describe('Contract Client Test Suite', { timeout: 15000 }, () => {
-  const { privateKey: deployerPrivateKey } = generateKeyPair();
-  const randomAccount = toEthereumAddress(generateKeyPair().publicKey);
+  const deployerPrivateKey = generateDisposablePrivateKey();
+  const randomAccount = generateAccount().address;
   const rpcUrl = 'http://localhost:8545';
   const authenticate = () => 'TOKEN';
   const rpcProvider = initProvider(rpcUrl, authenticate);
@@ -75,7 +78,7 @@ describe('Contract Client Test Suite', { timeout: 15000 }, () => {
       contractInstance = await deployContractThatHasEvents();
     });
     it('Creating a client with no contractAddress should fail', async () => {
-      const { privateKey: clientPrivateKey } = generateKeyPair();
+      const clientPrivateKey = generateDisposablePrivateKey();
       const func = async () =>
         initContractClient(
           {
@@ -91,11 +94,11 @@ describe('Contract Client Test Suite', { timeout: 15000 }, () => {
     });
 
     it('Create a client', async () => {
-      const { privateKey: clientPrivateKey } = generateKeyPair();
+      const { privateKey } = generateKeyPair({ format: 'jwk' });
 
       contractClient = await initContractClient(
         {
-          privateKey: clientPrivateKey,
+          privateKey,
           contractAddress: await contractInstance.getAddress(),
           contractAbi: testEventsAbi,
           rpcProvider,
@@ -115,7 +118,7 @@ describe('Contract Client Test Suite', { timeout: 15000 }, () => {
 
     beforeEach(async () => {
       const contractInstance = await deployContractThatHasEvents();
-      const { privateKey: clientPrivateKey } = generateKeyPair();
+      const clientPrivateKey = generateDisposablePrivateKey();
 
       contractWithEventsClient = await initContractClient(
         {

--- a/packages/base-contract-io/test/contract.test.js
+++ b/packages/base-contract-io/test/contract.test.js
@@ -114,7 +114,7 @@ describe('Contract Client Test Suite', { timeout: 15000 }, () => {
         rpcProvider,
       );
       expect(log.info.mock.calls.map((call) => call.arguments)).toEqual([
-        [{ contractAddress }, 'initContractClient'],
+        [{ contractAddress, hasPrivateKey: true }, 'initContractClient'],
         ['initContractClient done'],
       ]);
     });

--- a/packages/base-contract-io/test/helpers/deployContract.js
+++ b/packages/base-contract-io/test/helpers/deployContract.js
@@ -16,6 +16,7 @@
 
 const ethers = require('ethers');
 const { ResyncingNonceManager } = require('../../src/resyncing-nonce-manager');
+const { toEthersPrivateKey } = require('../../src/private-key');
 
 const deployContract = async (
   contractAbi,
@@ -25,7 +26,10 @@ const deployContract = async (
 ) => {
   const provider = new ethers.JsonRpcProvider(rpcUrl);
   provider.pollingInterval = 100;
-  const wallet = new ethers.Wallet(`0x${deployerPrivateKey}`, provider);
+  const wallet = new ethers.Wallet(
+    toEthersPrivateKey(deployerPrivateKey),
+    provider,
+  );
   const managedWallet = new ResyncingNonceManager(wallet);
   const factory = new ethers.ContractFactory(
     contractAbi.abi,

--- a/packages/base-contract-io/test/mock-contract.test.js
+++ b/packages/base-contract-io/test/mock-contract.test.js
@@ -50,7 +50,7 @@ mock.module('ethers', {
 });
 
 const { range, map } = require('lodash/fp');
-const { generateKeyPair } = require('@verii/crypto');
+const { generateDisposablePrivateKey } = require('@verii/blockchain-functions');
 const { env: config } = require('@spencejs/spence-config');
 const console = require('console');
 
@@ -87,7 +87,7 @@ describe.skip('Mocked Contract Client Test Suite', () => {
     let contractWithEventsClient;
 
     beforeEach(async () => {
-      const { privateKey: clientPrivateKey } = generateKeyPair();
+      const clientPrivateKey = generateDisposablePrivateKey();
 
       contractWithEventsClient = await initContractClient(
         {

--- a/packages/base-contract-io/test/nonce-management.test.js
+++ b/packages/base-contract-io/test/nonce-management.test.js
@@ -18,7 +18,7 @@ const { describe, it } = require('node:test');
 const { expect } = require('expect');
 const ethers = require('ethers');
 
-const { generateKeyPair } = require('@verii/crypto');
+const { generateDisposablePrivateKey } = require('@verii/blockchain-functions');
 const { initContractClient, initProvider } = require('../index');
 const { deployContract } = require('./helpers/deployContract');
 const testNoEventsAbi = require('./data/test-no-events-abi.json');
@@ -117,7 +117,7 @@ const detectsNonceCollisionWithRetries = async ({
 
 describe('Contract Client Nonce Management', { timeout: 120000 }, () => {
   it.skip('reproduces nonce collisions when signer caching is disabled', async () => {
-    const { privateKey: deployerPrivateKey } = generateKeyPair();
+    const deployerPrivateKey = generateDisposablePrivateKey();
     const rpcProvider = initProvider(rpcUrl, authenticate);
     const contract = await deployContract(
       testNoEventsAbi,
@@ -136,7 +136,7 @@ describe('Contract Client Nonce Management', { timeout: 120000 }, () => {
   });
 
   it('avoids nonce collisions with the default signer cache', async () => {
-    const { privateKey: deployerPrivateKey } = generateKeyPair();
+    const deployerPrivateKey = generateDisposablePrivateKey();
     const rpcProvider = initProvider(rpcUrl, authenticate);
     const contract = await deployContract(
       testNoEventsAbi,
@@ -156,7 +156,7 @@ describe('Contract Client Nonce Management', { timeout: 120000 }, () => {
   });
 
   it('resyncs cached signer nonce after external wallet transactions', async () => {
-    const { privateKey: deployerPrivateKey } = generateKeyPair();
+    const deployerPrivateKey = generateDisposablePrivateKey();
     const rpcProvider = initProvider(rpcUrl, authenticate);
     const contract = await deployContract(
       testNoEventsAbi,
@@ -188,7 +188,7 @@ describe('Contract Client Nonce Management', { timeout: 120000 }, () => {
     ).wait();
 
     const externalWallet = new ethers.Wallet(
-      `0x${deployerPrivateKey}`,
+      deployerPrivateKey,
       new ethers.JsonRpcProvider(rpcUrl),
     );
     await (

--- a/packages/base-contract-io/test/private-key.test.js
+++ b/packages/base-contract-io/test/private-key.test.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2026 Velocity Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { describe, it } = require('node:test');
+const { expect } = require('expect');
+
+const { generateKeyPair, hexFromJwk } = require('@verii/crypto');
+const { toEthersPrivateKey } = require('../src/private-key');
+
+describe('private key normalizer', () => {
+  it('returns prefixed hex private keys unchanged', () => {
+    const privateKey =
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    expect(toEthersPrivateKey(privateKey)).toEqual(privateKey);
+  });
+
+  it('normalizes uppercase hex prefixes', () => {
+    const privateKey =
+      '0Xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    expect(toEthersPrivateKey(privateKey)).toEqual(
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
+  });
+
+  it('prefixes unprefixed hex private keys', () => {
+    const privateKey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    expect(toEthersPrivateKey(privateKey)).toEqual(`0x${privateKey}`);
+  });
+
+  it('converts private JWKs to prefixed hex private keys', () => {
+    const { privateKey } = generateKeyPair({ format: 'jwk' });
+
+    expect(toEthersPrivateKey(privateKey)).toEqual(
+      `0x${hexFromJwk(privateKey)}`,
+    );
+  });
+
+  it('rejects public JWKs', () => {
+    const { publicKey } = generateKeyPair({ format: 'jwk' });
+
+    expect(() => toEthersPrivateKey(publicKey)).toThrow(
+      'Expected private JWK with d property',
+    );
+  });
+});

--- a/packages/blockchain-functions/src/generate-disposable-private-key.js
+++ b/packages/blockchain-functions/src/generate-disposable-private-key.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2023 Velocity Team
+/*
+ * Copyright 2026 Velocity Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,13 @@
  * limitations under the License.
  */
 
-const { generateKeyPair, jwkFromSecp256k1Key } = require('@verii/crypto');
+const { Wallet } = require('ethers');
 
-const generateKeyPairInHexAndJwk = () => {
-  const { publicKey, privateKey } = generateKeyPair();
-  return {
-    publicKey,
-    publicJwk: jwkFromSecp256k1Key(publicKey, false),
-    privateKey,
-    privateJwk: jwkFromSecp256k1Key(privateKey, true),
-  };
-};
+const generateAccount = () => Wallet.createRandom();
+
+const generateDisposablePrivateKey = () => generateAccount().privateKey;
 
 module.exports = {
-  generateKeyPairInHexAndJwk,
+  generateAccount,
+  generateDisposablePrivateKey,
 };

--- a/packages/blockchain-functions/test/ethers-wrappers.test.js
+++ b/packages/blockchain-functions/test/ethers-wrappers.test.js
@@ -22,6 +22,7 @@ const {
   toHexString,
   toNumber,
 } = require('../src/ethers-wrappers');
+const { generateAccount } = require('../src/generate-disposable-private-key');
 
 describe('Ethers Wrappers', () => {
   describe('Ethereum Addresses', () => {
@@ -36,10 +37,12 @@ describe('Ethers Wrappers', () => {
     });
 
     it('Should return Ethereum address from private key key', () => {
-      const { publicKey, privateKey } = generateKeyPair();
+      const wallet = generateAccount();
 
-      const publicKeyAddress = toEthereumAddress(publicKey);
-      const privateKeyAddress = toEthereumAddress(privateKey);
+      const publicKeyAddress = toEthereumAddress(
+        wallet.signingKey.publicKey.slice(2),
+      );
+      const privateKeyAddress = toEthereumAddress(wallet.privateKey.slice(2));
 
       expect(privateKeyAddress).toEqual(publicKeyAddress);
     });

--- a/packages/blockchain-functions/test/generate-disposable-private-key.test.js
+++ b/packages/blockchain-functions/test/generate-disposable-private-key.test.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Velocity Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { describe, it } = require('node:test');
+const { expect } = require('expect');
+
+const {
+  generateAccount,
+  generateDisposablePrivateKey,
+} = require('../src/generate-disposable-private-key');
+
+describe('generate blockchain account helpers', () => {
+  it('generates an ethers wallet account', () => {
+    const wallet = generateAccount();
+    expect({
+      address: wallet.address,
+      privateKey: wallet.privateKey,
+      publicKey: wallet.signingKey.publicKey,
+    }).toEqual({
+      address: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
+      privateKey: expect.stringMatching(/^0x[0-9a-f]{64}$/),
+      publicKey: expect.stringMatching(/^0x04[0-9a-f]{128}$/),
+    });
+  });
+
+  it('generates an ethers private key hex string', () => {
+    expect(generateDisposablePrivateKey()).toEqual(
+      expect.stringMatching(/^0x[0-9a-f]{64}$/),
+    );
+  });
+});

--- a/packages/contract-permissions/README.md
+++ b/packages/contract-permissions/README.md
@@ -1,12 +1,12 @@
 Example of the usage on your localhost with an EVM based blockchain container.
 
 ```
-const { generateKeyPair } = require('@verii/crypto');
+const { generateAccount } = require('@verii/blockchain-functions');
 const ethers = require('ethers');
 /* eslint-disable no-console */
 const { initPermissions } = require('../index');
 
-const { privateKey } = generateKeyPair();
+const { privateKey } = generateAccount();
 const wallet = new ethers.Wallet(privateKey);
 const contractAddress = '0xf755e1ca66be12f177178e7ea696969e0a55bb64';
 const gasLimit = 470000;

--- a/packages/contract-permissions/test/permissions.test.js
+++ b/packages/contract-permissions/test/permissions.test.js
@@ -16,8 +16,7 @@
 const { after, afterEach, before, describe, it } = require('node:test');
 const { expect } = require('expect');
 
-const { generateKeyPair } = require('@verii/crypto');
-const { toEthereumAddress } = require('@verii/blockchain-functions');
+const { generateAccount } = require('@verii/blockchain-functions');
 const { initProvider } = require('@verii/base-contract-io');
 const {
   mongoFactoryWrapper,
@@ -44,11 +43,6 @@ describe('Permissions Contract Test Suite', { timeout: 120000 }, () => {
 
   let deployedContract;
 
-  const generateAccount = () => {
-    const keyPair = generateKeyPair();
-    return { address: toEthereumAddress(keyPair.publicKey), ...keyPair };
-  };
-
   const clientForAddress = async (privateKey, contract) => {
     return initPermissions(
       {
@@ -68,14 +62,14 @@ describe('Permissions Contract Test Suite', { timeout: 120000 }, () => {
   before(async () => {
     await mongoFactoryWrapper('test-permissions', context);
 
-    const rootKeyPair = generateKeyPair();
+    const rootAccount = generateAccount();
     deployedContract = await deployTestPermissionsContract(
-      rootKeyPair.privateKey,
+      rootAccount.privateKey,
       rpcUrl,
     );
 
     rootPermissioningContractClient = await clientForAddress(
-      rootKeyPair.privateKey,
+      rootAccount.privateKey,
       deployedContract,
     );
 
@@ -278,15 +272,14 @@ describe('Permissions Contract Test Suite', { timeout: 120000 }, () => {
     });
 
     it('Should return zero address if operator has not primary', async () => {
-      const { publicKey } = generateKeyPair();
-      const address = toEthereumAddress(publicKey);
+      const { address } = generateAccount();
       await expect(
         permissioningContractClient.lookupPrimary(address),
       ).resolves.toEqual(zeroAddress);
     });
 
     it("A key that is not the Primary's Permissioning key should not be able to add an operator", async () => {
-      const testOperatorKey = toEthereumAddress(generateKeyPair().publicKey);
+      const { address: testOperatorKey } = generateAccount();
 
       await expect(
         rootPermissioningContractClient.addOperatorKey({

--- a/packages/crypto/test/crypto.test.js
+++ b/packages/crypto/test/crypto.test.js
@@ -240,7 +240,7 @@ describe('Crypto tests', () => {
   });
 
   describe('signing and verifying object payloads', () => {
-    it('should sign and verify a object payload', () => {
+    it('should sign and verify an object payload', () => {
       const payload = { message: 'TEST MESSAGE' };
       const signature = signPayload(payload, privateKey);
       expect(signature).toEqual(
@@ -251,7 +251,7 @@ describe('Crypto tests', () => {
       expect(verifiedPayload).toEqual(true);
     });
 
-    it('should sign and fail to verify a object payload', () => {
+    it('should sign and fail to verify an object payload', () => {
       const { publicKey: fakePublicKey } = generateKeyPair();
       const payload = { message: 'TEST MESSAGE' };
       const signature = signPayload(payload, privateKey);
@@ -382,7 +382,7 @@ describe('Crypto tests', () => {
       const buildRefreshToken = initBuildRefreshToken();
       expect(buildRefreshToken()).toHaveLength(128);
     });
-    it('should use input param to override the dfault token length', async () => {
+    it('should use input param to override the default token length', async () => {
       const buildRefreshToken = initBuildRefreshToken(256);
       expect(buildRefreshToken()).toHaveLength(64);
     });

--- a/packages/crypto/test/vnf-signature.test.js
+++ b/packages/crypto/test/vnf-signature.test.js
@@ -130,9 +130,12 @@ describe('vnf signature library', () => {
     });
 
     it('should fail to verify if the key changes', () => {
+      const { publicKey: wrongPublicKey } = generateKeyPair({ format: 'hex' });
       expect(
         verifyVnfSignature(body, proof, {
-          publicKey: generateKeyPair().publicKey,
+          config: {
+            vnfHeaderSignatureVerificationKey: wrongPublicKey,
+          },
         }),
       ).toEqual(false);
     });

--- a/packages/did-doc/src/common.js
+++ b/packages/did-doc/src/common.js
@@ -62,9 +62,6 @@ const generatePublicKeySection = (
   return publicKey;
 };
 
-const toProofSigningKey = (privateKey) =>
-  privateKey?.d == null ? privateKey : hexFromJwk(privateKey);
-
 const generateProof = (payload, privateKey, verificationMethod) => {
   if (isNil(payload)) {
     throw newError('Payload is null or undefined', {
@@ -81,7 +78,7 @@ const generateProof = (payload, privateKey, verificationMethod) => {
     verificationMethod,
   };
 
-  const jws = signPayload(payload, toProofSigningKey(privateKey), options);
+  const jws = signPayload(payload, hexFromJwk(privateKey), options);
 
   return {
     ...options,

--- a/packages/did-doc/src/common.js
+++ b/packages/did-doc/src/common.js
@@ -17,12 +17,7 @@
 const newError = require('http-errors');
 const { default: bs58 } = require('bs58');
 const { find, isNil, reduce } = require('lodash/fp');
-const {
-  signPayload,
-  generateKeyPair,
-  hexFromJwk,
-  jwkFromSecp256k1Key,
-} = require('@verii/crypto');
+const { signPayload, generateKeyPair, hexFromJwk } = require('@verii/crypto');
 
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 
@@ -34,7 +29,9 @@ const signatureKeyType = 'EcdsaSecp256k1Signature2019';
 const generateDidInfo = (
   { did: existingDid, keyId } = { did: null, keyId: 'key-1' },
 ) => {
-  const { privateKey, publicKey } = generateKeyPair();
+  const { privateKey, publicKey } = generateKeyPair({
+    format: 'jwk',
+  });
   const did = existingDid || `did:velocity:${toEthereumAddress(publicKey)}`;
   const kid = `${did}#${keyId}`;
 
@@ -119,14 +116,6 @@ const publicKeyToHex = (publicKey) => {
   throw newError(500, 'unsupported public key encoding', { publicKey });
 };
 
-const publicKeyToJwk = (publicKey) => {
-  if (publicKey?.publicKeyHex) {
-    return jwkFromSecp256k1Key(publicKey.publicKeyHex, false);
-  }
-
-  return publicKey?.publicKeyJwk;
-};
-
 const initExtractKeyByMethod = (keyHolderProp) => (didDoc, kid) => {
   const publicKey = extractPublicKeyMethod(didDoc, kid, keyHolderProp);
   if (publicKey == null) {
@@ -167,5 +156,4 @@ module.exports = {
   generateProof,
   extractVerificationKey,
   extractVerificationMethod,
-  publicKeyToJwk,
 };

--- a/packages/did-doc/src/common.js
+++ b/packages/did-doc/src/common.js
@@ -24,7 +24,7 @@ const { toEthereumAddress } = require('@verii/blockchain-functions');
 const { toRelativeKeyId } = require('./normalize-id');
 
 const verificationKeyType = 'EcdsaSecp256k1VerificationKey2019';
-const signatureKeyType = 'EcdsaSecp256k1Signature2019';
+const signatureKeyType = 'JsonWebKey2020';
 
 const generateDidInfo = (
   { did: existingDid, keyId } = { did: null, keyId: 'key-1' },
@@ -62,6 +62,9 @@ const generatePublicKeySection = (
   return publicKey;
 };
 
+const toProofSigningKey = (privateKey) =>
+  privateKey?.d == null ? privateKey : hexFromJwk(privateKey);
+
 const generateProof = (payload, privateKey, verificationMethod) => {
   if (isNil(payload)) {
     throw newError('Payload is null or undefined', {
@@ -78,7 +81,7 @@ const generateProof = (payload, privateKey, verificationMethod) => {
     verificationMethod,
   };
 
-  const jws = signPayload(payload, privateKey, options);
+  const jws = signPayload(payload, toProofSigningKey(privateKey), options);
 
   return {
     ...options,

--- a/packages/did-doc/test/common.test.js
+++ b/packages/did-doc/test/common.test.js
@@ -27,7 +27,6 @@ const {
   jwkFromSecp256k1Key,
 } = require('@verii/crypto');
 
-const { rootPrivateKey } = require('@verii/sample-data');
 const {
   verificationKeyType,
   signatureKeyType,
@@ -282,24 +281,6 @@ describe('DID Documents Common', () => {
         verificationMethod: 'VERIFICATION-METHOD',
       };
       const jws = signPayload(payload, hexFromJwk(privateKey), testProof);
-
-      expect(proof).toEqual({ ...testProof, jws });
-    });
-
-    it('Should generate a proof with a private hex key', () => {
-      const payload = { field: 'value' };
-      const proof = generateProof(
-        payload,
-        rootPrivateKey,
-        'VERIFICATION-METHOD',
-      );
-      const testProof = {
-        type: signatureKeyType,
-        proofPurpose: 'assertionMethod',
-        created: proof.created,
-        verificationMethod: 'VERIFICATION-METHOD',
-      };
-      const jws = signPayload(payload, rootPrivateKey, testProof);
 
       expect(proof).toEqual({ ...testProof, jws });
     });

--- a/packages/did-doc/test/common.test.js
+++ b/packages/did-doc/test/common.test.js
@@ -22,6 +22,7 @@ const { last } = require('lodash/fp');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 const {
   generateKeyPair,
+  hexFromJwk,
   signPayload,
   jwkFromSecp256k1Key,
 } = require('@verii/crypto');
@@ -34,7 +35,6 @@ const {
   generatePublicKeySection,
   generateProof,
   extractVerificationKey,
-  publicKeyToJwk,
 } = require('../src/common');
 
 describe('DID Documents Common', () => {
@@ -51,7 +51,8 @@ describe('DID Documents Common', () => {
   });
 
   describe('extract public key', () => {
-    const { publicKey } = generateKeyPair();
+    const { publicKey: publicJwk } = generateKeyPair({ format: 'jwk' });
+    const publicKey = hexFromJwk(publicJwk, false);
     const did = `did:key:${publicKey}`;
     const kidFragment = '#key-1';
     const kid = `${did}${kidFragment}`;
@@ -198,21 +199,6 @@ describe('DID Documents Common', () => {
       };
 
       expect(() => extractVerificationKey(didDoc, kid)).toThrow(Error);
-    });
-  });
-
-  describe('publicKeyToJwk', () => {
-    const { publicKey: publicKeyHex } = generateKeyPair();
-    const publicKeyJwk = jwkFromSecp256k1Key(publicKeyHex, false);
-
-    it('should return publicKeyJwk when publicKeyHex is passed', () => {
-      const publicKey = publicKeyToJwk({ publicKeyHex });
-      expect(publicKey).toEqual(publicKeyJwk);
-    });
-
-    it('should return publicKeyJwk when publicKeyJwk is passed', () => {
-      const publicKey = publicKeyToJwk({ publicKeyJwk });
-      expect(publicKey).toEqual(publicKeyJwk);
     });
   });
 

--- a/packages/did-doc/test/common.test.js
+++ b/packages/did-doc/test/common.test.js
@@ -271,7 +271,22 @@ describe('DID Documents Common', () => {
       expect(result).toThrow(Error);
     });
 
-    it('Should generate a proof when passed parameters are valid', () => {
+    it('Should generate a proof with a private jwk', () => {
+      const payload = { field: 'value' };
+      const { privateKey } = generateKeyPair({ format: 'jwk' });
+      const proof = generateProof(payload, privateKey, 'VERIFICATION-METHOD');
+      const testProof = {
+        type: signatureKeyType,
+        proofPurpose: 'assertionMethod',
+        created: proof.created,
+        verificationMethod: 'VERIFICATION-METHOD',
+      };
+      const jws = signPayload(payload, hexFromJwk(privateKey), testProof);
+
+      expect(proof).toEqual({ ...testProof, jws });
+    });
+
+    it('Should generate a proof with a private hex key', () => {
       const payload = { field: 'value' };
       const proof = generateProof(
         payload,

--- a/packages/did-doc/test/common.test.js
+++ b/packages/did-doc/test/common.test.js
@@ -219,36 +219,37 @@ describe('DID Documents Common', () => {
   });
 
   describe('DID Proof Generation', () => {
-    it('Should throw error when payload is undefined', () => {
+    const { privateKey } = generateKeyPair({ format: 'jwk' });
+
+    it('should throw when payload is undefined', () => {
       const result = () =>
-        generateProof(undefined, 'PRIVATE-KEY', 'VERIFICATION-METHOD');
+        generateProof(undefined, privateKey, 'VERIFICATION-METHOD');
 
       expect(result).toThrow(Error);
     });
 
-    it('Should throw error when payload is null', () => {
+    it('should throw when payload is null', () => {
       const result = () =>
-        generateProof(null, 'PRIVATE-KEY', 'VERIFICATION-METHOD');
+        generateProof(null, privateKey, 'VERIFICATION-METHOD');
 
       expect(result).toThrow(Error);
     });
 
-    it('Should throw error when payload is an empty string', () => {
-      const result = () =>
-        generateProof('', 'PRIVATE-KEY', 'VERIFICATION-METHOD');
+    it('should throw when payload is an empty string', () => {
+      const result = () => generateProof('', privateKey, 'VERIFICATION-METHOD');
 
       expect(result).toThrow(Error);
     });
 
-    it('Should throw error when payload is not JSON', () => {
+    it('should throw when payload is not JSON', () => {
       const payload = 'NOT_JSON';
       const result = () =>
-        generateProof(payload, 'PRIVATE-KEY', 'VERIFICATION-METHOD');
+        generateProof(payload, privateKey, 'VERIFICATION-METHOD');
 
       expect(result).toThrow(Error);
     });
 
-    it('Should throw error when private key is undefined', () => {
+    it('should throw when private key is undefined', () => {
       const payload = { field: 'value' };
       const result = () =>
         generateProof(payload, undefined, 'VERIFICATION-METHOD');
@@ -256,23 +257,22 @@ describe('DID Documents Common', () => {
       expect(result).toThrow(Error);
     });
 
-    it('Should throw error when private key is null', () => {
+    it('should throw when private key is null', () => {
       const payload = { field: 'value' };
       const result = () => generateProof(payload, null, 'VERIFICATION-METHOD');
 
       expect(result).toThrow(Error);
     });
 
-    it('Should throw error when private key is an empty string', () => {
+    it('should throw when private key is an empty string', () => {
       const payload = { field: 'value' };
       const result = () => generateProof(payload, '', 'VERIFICATION-METHOD');
 
       expect(result).toThrow(Error);
     });
 
-    it('Should generate a proof with a private jwk', () => {
+    it('should generate a JsonWebKey2020 proof signed with a private JWK', () => {
       const payload = { field: 'value' };
-      const { privateKey } = generateKeyPair({ format: 'jwk' });
       const proof = generateProof(payload, privateKey, 'VERIFICATION-METHOD');
       const testProof = {
         type: signatureKeyType,

--- a/packages/endpoints-organizations-registrar/src/entities/organizations/factories/organizations-factory.js
+++ b/packages/endpoints-organizations-registrar/src/entities/organizations/factories/organizations-factory.js
@@ -15,6 +15,7 @@
  *
  */
 
+const { randomBytes } = require('crypto');
 const { compact, filter, flow, map } = require('lodash/fp');
 const { register } = require('@spencejs/spence-factories');
 const { createDidDoc, toRelativeServiceId } = require('@verii/did-doc');
@@ -50,7 +51,7 @@ module.exports = (app) => {
     'organization',
     organizationsRepoPlugin(app)(app),
     async (overrides, { getOrBuild }) => {
-      const nonce = generateKeyPair().privateKey;
+      const nonce = randomBytes(32).toString('hex');
       const website = await getOrBuild(
         'website',
         () => `https://www.${nonce}.organization.com`,

--- a/packages/endpoints-organizations-registrar/src/helpers/init-permissions-contract.js
+++ b/packages/endpoints-organizations-registrar/src/helpers/init-permissions-contract.js
@@ -17,7 +17,7 @@
 const { initPermissions } = require('@verii/contract-permissions');
 
 const { ObjectId } = require('mongodb');
-const { KeyPurposes, hexFromJwk } = require('@verii/crypto');
+const { KeyPurposes } = require('@verii/crypto');
 
 const initPermissionsContract = async (organization, context) => {
   const { repos } = context;
@@ -36,7 +36,7 @@ const initPermissionsContractByKeyId = async (keyId, context) => {
   return withKmsKey(keyId, ({ privateJwk }) =>
     initPermissions(
       {
-        privateKey: hexFromJwk(privateJwk, true),
+        privateKey: privateJwk,
         contractAddress: config.permissionsContractAddress,
         rpcProvider,
       },

--- a/packages/endpoints-organizations-registrar/test/organization-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/organization-controller.test.js
@@ -2058,7 +2058,7 @@ describe('Organization Registrar Test Suite', { timeout: 20000 }, () => {
       });
 
       it('should return credential check failures if root jwk is incorrect', async () => {
-        const rootPrivateKey = generateKeyPair().publicKey;
+        const { privateKey: rootPrivateKey } = generateKeyPair();
 
         fastify.overrides.reqConfig = (config) => ({
           ...config,

--- a/packages/endpoints-organizations-registrar/test/organization-keys-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/organization-keys-controller.test.js
@@ -447,7 +447,8 @@ describe('Organization Keys Test Suite', () => {
       it('Should return 400 when actual publicKey encoding does not match the specified encoding', async () => {
         const organization = await persistOrganization();
         const did = organization.didDoc.id;
-        const { publicKey } = generateKeyPair();
+        const { publicKey: publicJwk } = generateKeyPair({ format: 'jwk' });
+        const publicKey = hexFromJwk(publicJwk, false);
         const nonHexPublicKey = publicKey.replace(/.$/, 'g');
         const response = await fastify.injectJson({
           method: 'POST',

--- a/packages/endpoints-organizations-registrar/test/organizations-full-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/organizations-full-controller.test.js
@@ -159,7 +159,6 @@ const {
   KeyPurposes,
   generateKeyPair,
   decryptCollection,
-  hexFromJwk,
 } = require('@verii/crypto');
 const { decodeCredentialJwt } = require('@verii/jwt');
 const { mapWithIndex, runSequentially } = require('@verii/common-functions');
@@ -5829,32 +5828,33 @@ describe('Organizations Full Test Suite', () => {
       },
       expect.any(Object),
     ]);
-    expect(mockInitPermission.mock.calls[1].arguments).toEqual([
-      {
-        contractAddress: fastify.config.permissionsContractAddress,
-        privateKey: expect.any(String),
-        rpcProvider: expect.any(Object),
-      },
-      expect.any(Object),
-    ]);
-    expect(mockAddPrimary.mock.callCount()).toEqual(1);
     const permissioningKey = findKeyByPurpose(
       KeyPurposes.PERMISSIONING,
       dbKeys,
     );
+    const [permissionsOptions, permissionsContext] =
+      mockInitPermission.mock.calls[1].arguments;
+    expect(permissionsOptions.contractAddress).toEqual(
+      fastify.config.permissionsContractAddress,
+    );
+    expect(permissionsOptions.privateKey).toEqual(
+      expect.objectContaining({
+        crv: 'secp256k1',
+        d: expect.any(String),
+        kty: 'EC',
+      }),
+    );
+    expect(permissionsOptions.rpcProvider).toEqual(expect.any(Object));
+    expect(permissionsContext).toEqual(expect.any(Object));
+    expect(mockAddPrimary.mock.callCount()).toEqual(1);
     expect(
       mockAddPrimary.mock.calls.map((call) => call.arguments),
     ).toContainEqual([
       {
         primary: organization.ids.ethereumAccount,
-        permissioning: toEthereumAddress(
-          hexFromJwk(permissioningKey.publicKey, false),
-        ),
+        permissioning: toEthereumAddress(permissioningKey.publicKey),
         rotation: toEthereumAddress(
-          hexFromJwk(
-            findKeyByPurpose(KeyPurposes.ROTATION, dbKeys).publicKey,
-            false,
-          ),
+          findKeyByPurpose(KeyPurposes.ROTATION, dbKeys).publicKey,
         ),
       },
     ]);
@@ -5864,10 +5864,7 @@ describe('Organizations Full Test Suite', () => {
     ).toContainEqual([
       {
         operator: toEthereumAddress(
-          hexFromJwk(
-            findKeyByPurpose(KeyPurposes.DLT_TRANSACTIONS, dbKeys).publicKey,
-            false,
-          ),
+          findKeyByPurpose(KeyPurposes.DLT_TRANSACTIONS, dbKeys).publicKey,
         ),
         primary: organization.ids.ethereumAccount,
       },

--- a/packages/jwt/src/core.js
+++ b/packages/jwt/src/core.js
@@ -57,6 +57,16 @@ const toKeyObject = (key, header) => {
 
 const DEFAULT_ASYMMETRIC_ALG = 'ES256K';
 const DEFAULT_SYMMETRIC_ALG = 'HS256';
+const DERIVE_JWK_HEX_DEPRECATION_CODE = 'VERII_JWT_DEP001';
+
+const emitDeriveJwkHexDeprecationWarning = () =>
+  process.emitWarning(
+    'Passing a hex key to deriveJwk is deprecated. Pass a JWK instead.',
+    {
+      code: DERIVE_JWK_HEX_DEPRECATION_CODE,
+      type: 'DeprecationWarning',
+    },
+  );
 
 const jwtSign = async (
   payload,
@@ -177,13 +187,11 @@ const jwtSignSymmetric = async (payload, key, { alg = 'HS256' } = {}) => {
 
 const deriveJwk = (jwt, key) => {
   const candidate = key != null ? key : jwtDecode(jwt)?.header?.jwk;
-  return candidate.x != null
-    ? candidate
-    : jwkFromSecp256k1Key(candidate, false);
-};
-
-const toJwk = (key, priv = true) => {
-  return key.x != null ? key : jwkFromSecp256k1Key(key, priv);
+  if (candidate.x != null) {
+    return candidate;
+  }
+  emitDeriveJwkHexDeprecationWarning();
+  return jwkFromSecp256k1Key(candidate, false);
 };
 
 const prepAlgAndKey = async (keyOrSecret, optionsAlg) =>
@@ -215,7 +223,6 @@ module.exports = {
   safeJwtDecode,
   stringifyJwk,
   tamperJwt,
-  toJwk,
   base64UrlToJwk,
   jwkToPublicBase64Url,
   keyAlgorithmToJoseAlg,

--- a/packages/jwt/test/core.test.js
+++ b/packages/jwt/test/core.test.js
@@ -474,8 +474,8 @@ describe('JWT Tests', () => {
     });
   });
 
-  describe('deriveJwk from JWT test suite', () => {
-    it('Should derive jwk from JWT when jwk is embedded in the header', async () => {
+  describe('deriveJwk', () => {
+    it('should derive a JWK from the JWT header', async () => {
       const { privateKey, publicKey } = generateKeyPair({ format: 'jwk' });
       const jwt = await jwtSign({ foo: 'bar' }, privateKey, {
         jwk: publicKey,
@@ -483,13 +483,13 @@ describe('JWT Tests', () => {
       const derivedJwk = deriveJwk(jwt);
       expect(derivedJwk).toEqual(publicKey);
     });
-    it('Should derive jwk when jwk is passed explicitly', async () => {
+    it('should return an explicitly passed JWK', async () => {
       const { privateKey, publicKey } = generateKeyPair({ format: 'jwk' });
       const jwt = await jwtSign({ foo: 'bar' }, privateKey);
       const derivedJwk = deriveJwk(jwt, publicKey);
       expect(derivedJwk).toEqual(publicKey);
     });
-    it('Should derive jwk when hex is passed explicitly', async () => {
+    it('should derive a JWK from deprecated hex input and warn', async () => {
       const emitWarning = mock.method(process, 'emitWarning', () => {});
       const { privateKey, publicKey } = generateKeyPair();
       const privateKeyJwk = jwkFromSecp256k1Key(privateKey, true);

--- a/packages/jwt/test/core.test.js
+++ b/packages/jwt/test/core.test.js
@@ -34,7 +34,6 @@ const {
   jwtVerify,
   jwsVerify,
   jwkFromSecp256k1Key,
-  hexFromJwk,
   tamperJwt,
   deriveJwk,
   safeJwtDecode,
@@ -417,22 +416,14 @@ describe('JWT Tests', () => {
       );
     });
 
-    it('should convert jwks to hex', () => {
-      const { publicKey } = generateKeyPair();
-      const publicJwk = jwkFromSecp256k1Key(publicKey, false);
-      expect(hexFromJwk(publicJwk, false)).toEqual(publicKey);
-    });
-
     it('Should init JWK key', async () => {
-      const { privateKey } = generateKeyPair();
-      const jwkKey = jwkFromSecp256k1Key(privateKey);
+      const { privateKey: jwkKey } = generateKeyPair({ format: 'jwk' });
       const jwt = await jwtSign(payload, jwkKey);
       const verified = await jwtVerify(jwt, jwkKey);
 
       expect(jwkKey).toEqual({
         kty: 'EC',
         crv: 'secp256k1',
-        use: 'sig',
         x: expect.any(String),
         y: expect.any(String),
         d: expect.any(String),
@@ -451,8 +442,7 @@ describe('JWT Tests', () => {
     });
 
     it('should verify with a JWK key missing alg', async () => {
-      const { privateKey } = generateKeyPair();
-      const jwkKey = jwkFromSecp256k1Key(privateKey);
+      const { privateKey: jwkKey } = generateKeyPair({ format: 'jwk' });
       const jwt = await jwtSign(payload, jwkKey);
       const verified = await jwtVerify(jwt, omit(['alg'], jwkKey));
       expect(verified).toEqual({

--- a/packages/jwt/test/core.test.js
+++ b/packages/jwt/test/core.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const { before, describe, it } = require('node:test');
+const { before, describe, it, mock } = require('node:test');
 const { expect } = require('expect');
 
 const {
@@ -37,7 +37,6 @@ const {
   tamperJwt,
   deriveJwk,
   safeJwtDecode,
-  toJwk,
   jwkToPublicBase64Url,
   base64UrlToJwk,
 } = require('../src/core');
@@ -361,42 +360,6 @@ describe('JWT Tests', () => {
   });
 
   describe('Parse key', () => {
-    it('should generate jwks for public keys hexes', () => {
-      const secp256kKeyPair1 = generateKeyPair();
-      expect(jwkFromSecp256k1Key(secp256kKeyPair1.publicKey, false)).toEqual({
-        kty: 'EC',
-        crv: 'secp256k1',
-        use: 'sig',
-        x: expect.any(String),
-        y: expect.any(String),
-      });
-    });
-
-    it('should generate jwks for private keys from private key only', () => {
-      const secp256kKeyPair1 = generateKeyPair();
-      const publicJwk = jwkFromSecp256k1Key(secp256kKeyPair1.publicKey, false);
-      expect(jwkFromSecp256k1Key(secp256kKeyPair1.privateKey)).toEqual({
-        ...publicJwk,
-        d: expect.any(String),
-      });
-    });
-
-    it('should generate public jwks from private keys', async () => {
-      const secp256kKeyPair1 = generateKeyPair();
-      const publicJwk = jwkFromSecp256k1Key(secp256kKeyPair1.publicKey, false);
-      const publicJwkFromPrivateKey = jwkFromSecp256k1Key(
-        secp256kKeyPair1.privateKey,
-        false,
-      );
-      const jwt = await jwtSign(
-        { message: 'HELLO MR NAUGHTY' },
-        jwkFromSecp256k1Key(secp256kKeyPair1.privateKey),
-      );
-      expect(await jwtVerify(jwt, publicJwkFromPrivateKey)).toEqual(
-        await jwtVerify(jwt, publicJwk),
-      );
-    });
-
     it('Should fail to verify a modified jwt ', async () => {
       const jwt = await jwtSign(payload, secp256kKeyPair.privateKey);
       await expect(() =>
@@ -527,37 +490,21 @@ describe('JWT Tests', () => {
       expect(derivedJwk).toEqual(publicKey);
     });
     it('Should derive jwk when hex is passed explicitly', async () => {
+      const emitWarning = mock.method(process, 'emitWarning', () => {});
       const { privateKey, publicKey } = generateKeyPair();
       const privateKeyJwk = jwkFromSecp256k1Key(privateKey, true);
       const publicKeyJwk = jwkFromSecp256k1Key(privateKey, false);
       const jwt = await jwtSign({ foo: 'bar' }, privateKeyJwk);
       const derivedJwk = deriveJwk(jwt, publicKey);
       expect(derivedJwk).toEqual(publicKeyJwk);
-    });
-  });
-
-  describe('toJwk test suite', () => {
-    it('Should return original public jwk if already a public jwk', async () => {
-      const { publicKey } = generateKeyPair({ format: 'jwk' });
-      const result = toJwk(publicKey, false);
-      expect(result).toEqual(publicKey);
-    });
-
-    it('Should return original private jwk if already a private jwk', async () => {
-      const { privateKey } = generateKeyPair({ format: 'jwk' });
-      const result = toJwk(privateKey, true);
-      expect(result).toEqual(privateKey);
-    });
-
-    it('Should return equivalent public jwk of a public hex', async () => {
-      const { publicKey } = generateKeyPair();
-      const result = toJwk(publicKey, false);
-      expect(result).toEqual(jwkFromSecp256k1Key(publicKey, false));
-    });
-    it('Should return equivalent private jwk of a private hex', async () => {
-      const { privateKey } = generateKeyPair();
-      const result = toJwk(privateKey, true);
-      expect(result).toEqual(jwkFromSecp256k1Key(privateKey, true));
+      expect(emitWarning.mock.calls).toHaveLength(1);
+      expect(emitWarning.mock.calls[0].arguments).toEqual([
+        'Passing a hex key to deriveJwk is deprecated. Pass a JWK instead.',
+        {
+          code: 'VERII_JWT_DEP001',
+          type: 'DeprecationWarning',
+        },
+      ]);
     });
   });
 });

--- a/packages/jwt/test/docs.test.js
+++ b/packages/jwt/test/docs.test.js
@@ -18,10 +18,10 @@ const { expect } = require('expect');
 
 const { generateKeyPair } = require('@verii/crypto');
 const { generateDocJwt } = require('../src/docs');
-const { jwkFromSecp256k1Key, jwtVerify } = require('../src/core');
+const { jwtVerify } = require('../src/core');
 
 describe('generate doc jwt', () => {
-  const keyPair = generateKeyPair();
+  const keyPair = generateKeyPair({ format: 'jwk' });
 
   describe('Generate simple JWT', () => {
     it('Should generate JWT from generic payload', async () => {
@@ -31,10 +31,7 @@ describe('generate doc jwt', () => {
         issuer,
         audience: 'something',
       });
-      const verified = await jwtVerify(
-        result,
-        jwkFromSecp256k1Key(keyPair.publicKey, false),
-      );
+      const verified = await jwtVerify(result, keyPair.publicKey);
 
       expect(verified).toEqual({
         payload: {
@@ -50,7 +47,6 @@ describe('generate doc jwt', () => {
           jwk: {
             crv: 'secp256k1',
             kty: 'EC',
-            use: 'sig',
             x: expect.any(String),
             y: expect.any(String),
           },
@@ -66,10 +62,7 @@ describe('generate doc jwt', () => {
         issuer,
         kid,
       });
-      const verified = await jwtVerify(
-        result,
-        jwkFromSecp256k1Key(keyPair.publicKey, false),
-      );
+      const verified = await jwtVerify(result, keyPair.publicKey);
 
       expect(verified).toEqual({
         payload: {
@@ -89,10 +82,7 @@ describe('generate doc jwt', () => {
     it('Should generate JWT with no options sent', async () => {
       const doc = { field: 'value' };
       const result = await generateDocJwt(doc, keyPair.privateKey);
-      const verified = await jwtVerify(
-        result,
-        jwkFromSecp256k1Key(keyPair.publicKey, false),
-      );
+      const verified = await jwtVerify(result, keyPair.publicKey);
 
       expect(verified).toEqual({
         payload: {
@@ -106,7 +96,6 @@ describe('generate doc jwt', () => {
           jwk: {
             crv: 'secp256k1',
             kty: 'EC',
-            use: 'sig',
             x: expect.any(String),
             y: expect.any(String),
           },

--- a/packages/jwt/test/verifiables-decoders.test.js
+++ b/packages/jwt/test/verifiables-decoders.test.js
@@ -32,10 +32,10 @@ const {
   decodePresentationJwt,
   verifyPresentationJwt,
 } = require('../src/verifiable-decoders');
-const { jwtDecode, jwkFromSecp256k1Key } = require('../src/core');
+const { jwtDecode } = require('../src/core');
 
 describe('Verifiable Decoder Tests', () => {
-  const keyPair = generateKeyPair();
+  const keyPair = generateKeyPair({ format: 'jwk' });
 
   const credential = {
     ...credentialUnexpired,
@@ -129,7 +129,9 @@ describe('Verifiable Decoder Tests', () => {
     });
 
     it('Should fail verification if key is invalid', async () => {
-      const { publicKey: wrongPublicKey } = generateKeyPair();
+      const { publicKey: wrongPublicKey } = generateKeyPair({
+        format: 'jwk',
+      });
       const credentialJwt = await generateCredentialJwt(
         { vc: credential },
         keyPair.privateKey,
@@ -147,13 +149,12 @@ describe('Verifiable Decoder Tests', () => {
         presentation,
         keyPair.privateKey,
       );
-      const jwk = jwkFromSecp256k1Key(keyPair.publicKey, false);
 
       const decodedPresentationAgnosticJwt = jwtDecode(presentationJwt);
       expect(decodedPresentationAgnosticJwt).toEqual({
         header: {
           alg: 'ES256K',
-          jwk,
+          jwk: keyPair.publicKey,
           typ: 'JWT',
         },
         payload: {
@@ -238,7 +239,9 @@ describe('Verifiable Decoder Tests', () => {
     });
 
     it('Presentation should fail verification if key is invalid', async () => {
-      const { publicKey: wrongPublicKey } = generateKeyPair();
+      const { publicKey: wrongPublicKey } = generateKeyPair({
+        format: 'jwk',
+      });
       const presentationJwt = await generatePresentationJwt(
         presentation,
         keyPair.privateKey,

--- a/packages/metadata-registration/README.md
+++ b/packages/metadata-registration/README.md
@@ -1,12 +1,12 @@
 Example of the usage on your localhost with an EVM based blockchain container.
 
 ```
-const { generateKeyPair } = require('@verii/crypto');
+const { generateAccount } = require('@verii/blockchain-functions');
 const ethers = require('ethers');
 /* eslint-disable no-console */
 const { initRevocationRegistry } = require('../index');
 
-const { privateKey } = generateKeyPair();
+const { privateKey } = generateAccount();
 const wallet = new ethers.Wallet(privateKey);
 const contractAddress = '0xf755e1ca66be12f177178e7ea696969e0a55bb64';
 const gasLimit = 470000;

--- a/packages/metadata-registration/test/helpers/deploy-contracts.js
+++ b/packages/metadata-registration/test/helpers/deploy-contracts.js
@@ -21,7 +21,8 @@ const {
 const {
   deployTestPermissionsContract,
 } = require('@verii/contract-permissions/test/helpers/deploy-test-permissions-contract');
-const { generateKeyPair, get2BytesHash } = require('@verii/crypto');
+const { generateDisposablePrivateKey } = require('@verii/blockchain-functions');
+const { get2BytesHash } = require('@verii/crypto');
 const { initProvider } = require('@verii/base-contract-io');
 const { initVerificationCoupon, initMetadataRegistry } = require('../../index');
 const verificationCouponAbi = require('../../src/contracts/verification-coupon.json');
@@ -32,7 +33,7 @@ const initRevocationRegistry = require('../../src/revocation-registry');
 const rpcUrl = 'http://localhost:8545';
 const authenticate = () => 'TOKEN';
 const rpcProvider = initProvider(rpcUrl, authenticate);
-const { privateKey: deployerPrivateKey } = generateKeyPair();
+const deployerPrivateKey = generateDisposablePrivateKey();
 
 const deployPermissionContract = async () => {
   const permissionsContract = await deployTestPermissionsContract(

--- a/packages/metadata-registration/test/metadata-registry.test.js
+++ b/packages/metadata-registration/test/metadata-registry.test.js
@@ -31,7 +31,7 @@ const {
 } = require('@verii/crypto');
 const { compact, first, map, omit, reduce } = require('lodash/fp');
 const { nanoid } = require('nanoid');
-const { toEthereumAddress } = require('@verii/blockchain-functions');
+const { generateAccount } = require('@verii/blockchain-functions');
 const { initPermissions } = require('@verii/contract-permissions');
 const {
   mongoFactoryWrapper,
@@ -150,11 +150,11 @@ describe('Metadata Registry', { timeout: 600000 }, () => {
       context,
     );
 
-    const primaryKeyPair = generateKeyPair();
-    primaryAddress = toEthereumAddress(primaryKeyPair.publicKey);
+    const primaryAccount = generateAccount();
+    primaryAddress = primaryAccount.address;
 
-    const operatorKeyPair = generateKeyPair();
-    operatorAddress = toEthereumAddress(operatorKeyPair.publicKey);
+    const operatorAccount = generateAccount();
+    operatorAddress = operatorAccount.address;
 
     deployerVerificationCouponClient = await initVerificationCoupon(
       {
@@ -181,7 +181,7 @@ describe('Metadata Registry', { timeout: 600000 }, () => {
 
     const operatorPermissionsClient = await initPermissions(
       {
-        privateKey: primaryKeyPair.privateKey,
+        privateKey: primaryAccount.privateKey,
         contractAddress: permissionsAddress,
         rpcProvider,
       },
@@ -203,7 +203,7 @@ describe('Metadata Registry', { timeout: 600000 }, () => {
 
     operatorMetadataRegistryClient = await initMetadataRegistry(
       {
-        privateKey: operatorKeyPair.privateKey,
+        privateKey: operatorAccount.privateKey,
         contractAddress: metadataAddress,
         rpcProvider,
       },

--- a/packages/metadata-registration/test/revocation-registry.test.js
+++ b/packages/metadata-registration/test/revocation-registry.test.js
@@ -18,15 +18,13 @@ const { after, afterEach, before, describe, it } = require('node:test');
 const { expect } = require('expect');
 
 const { last } = require('lodash/fp');
-const { toNumber } = require('@verii/blockchain-functions');
-const { generateKeyPair } = require('@verii/crypto');
+const { generateAccount, toNumber } = require('@verii/blockchain-functions');
 const {
   mongoFactoryWrapper,
   mongoCloseWrapper,
 } = require('@verii/tests-helpers');
 const { env } = require('@spencejs/spence-config');
 const console = require('console');
-const { toEthereumAddress } = require('@verii/blockchain-functions');
 const { initPermissions } = require('@verii/contract-permissions');
 const { wait } = require('@verii/common-functions');
 const initRevocationRegistry = require('../src/revocation-registry');
@@ -58,10 +56,10 @@ describe('Revocation Registry', { timeout: 240000 }, () => {
       permissionsContractAddress,
       context,
     );
-    const { primaryAddress, operatorKeyPair } =
+    const { primaryAddress, operatorAccount } =
       await initializationPermissions();
     defaultPrimaryAddress = primaryAddress;
-    revocationRegistry = await createRevocationRegistryWallet(operatorKeyPair);
+    revocationRegistry = await createRevocationRegistryWallet(operatorAccount);
   });
 
   afterEach(async () => {
@@ -100,11 +98,11 @@ describe('Revocation Registry', { timeout: 240000 }, () => {
     });
 
     it('Throw an error: the wallet not registered', async () => {
-      const operatorKeyPair = generateKeyPair();
+      const operatorAccount = generateAccount();
 
       const revocationRegistryClient = await initRevocationRegistry(
         {
-          privateKey: operatorKeyPair.privateKey,
+          privateKey: operatorAccount.privateKey,
           contractAddress: revocationRegistryContractAddress,
           rpcProvider,
         },
@@ -340,10 +338,10 @@ describe('Revocation Registry', { timeout: 240000 }, () => {
     });
   });
 
-  const createRevocationRegistryWallet = async (operatorKeyPair) => {
+  const createRevocationRegistryWallet = async (operatorAccount) => {
     const revocationRegistryClient = await initRevocationRegistry(
       {
-        privateKey: operatorKeyPair.privateKey,
+        privateKey: operatorAccount.privateKey,
         contractAddress: revocationRegistryContractAddress,
         rpcProvider,
       },
@@ -356,8 +354,8 @@ describe('Revocation Registry', { timeout: 240000 }, () => {
   };
 
   const initializationPermissions = async () => {
-    const primaryKeyPair = generateKeyPair();
-    const primaryAddress = toEthereumAddress(primaryKeyPair.publicKey);
+    const primaryAccount = generateAccount();
+    const primaryAddress = primaryAccount.address;
 
     const permissionsContractRootClient = await initPermissions(
       {
@@ -380,19 +378,19 @@ describe('Revocation Registry', { timeout: 240000 }, () => {
 
     const operatorPermissionsClient = await initPermissions(
       {
-        privateKey: primaryKeyPair.privateKey,
+        privateKey: primaryAccount.privateKey,
         contractAddress: permissionsContractAddress,
         rpcProvider,
       },
       context,
     );
 
-    const operatorKeyPair = generateKeyPair();
-    const operatorAddress = toEthereumAddress(operatorKeyPair.publicKey);
+    const operatorAccount = generateAccount();
+    const operatorAddress = operatorAccount.address;
     await operatorPermissionsClient.addOperatorKey({
       primary: primaryAddress,
       operator: operatorAddress,
     });
-    return { primaryAddress, operatorAddress, operatorKeyPair };
+    return { primaryAddress, operatorAddress, operatorAccount };
   };
 });

--- a/packages/metadata-registration/test/verification-coupon.test.js
+++ b/packages/metadata-registration/test/verification-coupon.test.js
@@ -25,9 +25,8 @@ const {
 const { expect } = require('expect');
 
 const { startOfSecond } = require('date-fns/fp');
-const { generateKeyPair } = require('@verii/crypto');
 const {
-  toEthereumAddress,
+  generateAccount,
   toHexString,
   toNumber,
 } = require('@verii/blockchain-functions');
@@ -297,9 +296,7 @@ describe('Verification Coupon', { timeout: 240000 }, () => {
         ownerDid,
       });
 
-      const accountWithoutTokens = toEthereumAddress(
-        generateKeyPair().publicKey,
-      );
+      const accountWithoutTokens = generateAccount().address;
       expect(
         verificationCoupon.getCoupon(accountWithoutTokens),
       ).rejects.toThrow('Permissions: operator not pointing to a primary');
@@ -314,8 +311,8 @@ describe('Verification Coupon', { timeout: 240000 }, () => {
   });
 
   const initVerificationCouponClient = async () => {
-    const primaryKeyPair = generateKeyPair();
-    primaryAddress = toEthereumAddress(primaryKeyPair.publicKey);
+    const primaryAccount = generateAccount();
+    primaryAddress = primaryAccount.address;
 
     await deployerPermissionsContractInstance.addPrimary({
       primary: primaryAddress,
@@ -327,15 +324,15 @@ describe('Verification Coupon', { timeout: 240000 }, () => {
       scope: 'transactions:write',
     });
 
-    const operatorKeyPair = generateKeyPair();
-    operatorAddress = toEthereumAddress(operatorKeyPair.publicKey);
+    const operatorAccount = generateAccount();
+    operatorAddress = operatorAccount.address;
     await deployerPermissionsContractInstance.addAddressScope({
       address: operatorAddress,
       scope: 'coupon:burn',
     });
     const operatorPermissionsContractClient = await initPermissions(
       {
-        privateKey: primaryKeyPair.privateKey,
+        privateKey: primaryAccount.privateKey,
         contractAddress: permissionsContractAddress,
         rpcProvider,
       },
@@ -348,7 +345,7 @@ describe('Verification Coupon', { timeout: 240000 }, () => {
 
     return initVerificationCoupon(
       {
-        privateKey: operatorKeyPair.privateKey,
+        privateKey: operatorAccount.privateKey,
         contractAddress: verificationCouponAddress,
         rpcProvider,
       },

--- a/packages/tests-helpers/index.js
+++ b/packages/tests-helpers/index.js
@@ -24,7 +24,6 @@ module.exports = {
   ...require('./src/test-auth-token'),
   ...require('./src/jsonify'),
   ...require('./src/mongoify'),
-  ...require('./src/generate-key-pair-in-hex-and-jwk'),
   ...require('./src/jwk-matchers'),
   ...require('./src/generate-organization-key-matcher'),
   ...require('./src/test-oauth-user'),

--- a/packages/tests-helpers/src/generate-presentation.js
+++ b/packages/tests-helpers/src/generate-presentation.js
@@ -48,7 +48,7 @@ const phonePayload = {
   },
 };
 
-const { privateKey } = generateKeyPair();
+const { privateKey } = generateKeyPair({ format: 'jwk' });
 
 const generateSimpleKYCPresentation = (idDocTypes, options) => {
   const idCredentials = {

--- a/packages/vc-checks/package.json
+++ b/packages/vc-checks/package.json
@@ -24,6 +24,7 @@
     "lodash": "^4.18.1"
   },
   "devDependencies": {
+    "@verii/crypto": "workspace:*",
     "@verii/sample-data": "workspace:*",
     "@verii/tests-helpers": "workspace:*",
     "eslint": "9.39.4",

--- a/packages/vc-checks/test/check-issuer-trust.test.js
+++ b/packages/vc-checks/test/check-issuer-trust.test.js
@@ -16,9 +16,9 @@
 const { before, describe, it, mock } = require('node:test');
 const { expect } = require('expect');
 
-const { generateKeyPairInHexAndJwk } = require('@verii/tests-helpers');
 const { omit, set, times, join } = require('lodash/fp');
 const { generateCredentialJwt } = require('@verii/jwt');
+const { generateKeyPair, hexFromJwk } = require('@verii/crypto');
 const { checkIssuerTrust } = require('../src/check-issuer-trust');
 const {
   verifyPrimarySourceIssuer,
@@ -32,7 +32,8 @@ describe('issuer checks', () => {
     warn: mock.fn(),
     error: mock.fn(),
   };
-  const issuerKeyPair = generateKeyPairInHexAndJwk();
+  const issuerKeyPair = generateKeyPair({ format: 'jwk' });
+  const issuerPublicKey = hexFromJwk(issuerKeyPair.publicKey, false);
 
   const issuerDid = 'did:ion:1234567890';
   const issuerKid = `${issuerDid}#key-1`;
@@ -46,7 +47,7 @@ describe('issuer checks', () => {
     },
   };
   const config = {
-    rootPublicKey: issuerKeyPair.publicKey,
+    rootPublicKey: issuerPublicKey,
     revocationContractAddress: 'any',
     rpcUrl: 'any',
     trustedIssuerCheckMinDate: '2024-02-28T00:00:00Z',
@@ -61,7 +62,7 @@ describe('issuer checks', () => {
   before(async () => {
     boundIssuerVc = await generateCredentialJwt(
       issuerCred,
-      issuerKeyPair.privateJwk,
+      issuerKeyPair.privateKey,
       issuerKid,
     );
     issuerDidDocument = {
@@ -69,7 +70,7 @@ describe('issuer checks', () => {
       verificationMethod: [
         {
           id: '#key-1',
-          publicKeyJwk: issuerKeyPair.publicJwk,
+          publicKeyJwk: issuerKeyPair.publicKey,
         },
       ],
     };
@@ -120,7 +121,7 @@ describe('issuer checks', () => {
         issuerDidDocument: {
           id: issuerDid,
           verificationMethod: [
-            { id: '#wrong-id', publicKeyJwk: issuerKeyPair.publicJwk },
+            { id: '#wrong-id', publicKeyJwk: issuerKeyPair.publicKey },
           ],
         },
       },
@@ -131,7 +132,7 @@ describe('issuer checks', () => {
   });
 
   it('Should FAIL when wrong key', async () => {
-    const { publicJwk: publicKeyJwk } = generateKeyPairInHexAndJwk();
+    const { publicKey: publicKeyJwk } = generateKeyPair({ format: 'jwk' });
 
     const result = await checkIssuerTrust(
       identityCredential,
@@ -174,7 +175,7 @@ describe('issuer checks', () => {
         ...defaultDependencies,
         boundIssuerVc: await generateCredentialJwt(
           issuerCred,
-          issuerKeyPair.privateJwk,
+          issuerKeyPair.privateKey,
         ),
       },
       context,
@@ -190,7 +191,7 @@ describe('issuer checks', () => {
           listId: 1,
         },
       },
-      issuerKeyPair.privateJwk,
+      issuerKeyPair.privateKey,
       issuerKid,
     );
 
@@ -222,10 +223,10 @@ describe('issuer checks', () => {
   });
 
   it('Should FAIL when boundIssuerVC signature invalid', async () => {
-    const { privateJwk } = generateKeyPairInHexAndJwk();
+    const { privateKey } = generateKeyPair({ format: 'jwk' });
     const wrongSigVc = await generateCredentialJwt(
       issuerCred,
-      privateJwk,
+      privateKey,
       issuerKid,
     );
 

--- a/packages/vc-checks/test/check-tampering.test.js
+++ b/packages/vc-checks/test/check-tampering.test.js
@@ -24,7 +24,7 @@ const { checkJwsVcTampering } = require('../src/check-jws-vc-tampering');
 const { CheckResults } = require('../src/check-results');
 
 describe('tampering checks', () => {
-  const { privateKey: privateJwk, publicKey: publicJwk } = generateKeyPair({
+  const { privateKey, publicKey } = generateKeyPair({
     format: 'jwk',
   });
   const context = { log: console };
@@ -34,15 +34,15 @@ describe('tampering checks', () => {
   before(async () => {
     signedCredential = await generateCredentialJwt(
       credentialUnexpired,
-      privateJwk,
+      privateKey,
       'KID',
     );
   });
 
-  it('Should return FAIL when tampered', async () => {
+  it('should return FAIL when tampered', async () => {
     const otherCredential = await generateCredentialJwt(
       { ...credentialUnexpired, issuer: 'TAMPERED' },
-      privateJwk,
+      privateKey,
       'KID',
     );
 
@@ -54,17 +54,17 @@ describe('tampering checks', () => {
 
     const result = await checkJwsVcTampering(
       tamperedCredential,
-      publicJwk,
+      publicKey,
       context,
     );
 
     expect(result).toEqual(CheckResults.FAIL);
   });
 
-  it('Should return PASS when untampered', async () => {
+  it('should return PASS when untampered', async () => {
     const result = await checkJwsVcTampering(
       signedCredential,
-      publicJwk,
+      publicKey,
       context,
     );
 

--- a/packages/vc-checks/test/check-tampering.test.js
+++ b/packages/vc-checks/test/check-tampering.test.js
@@ -18,13 +18,15 @@ const { expect } = require('expect');
 
 const { generateCredentialJwt } = require('@verii/jwt');
 const { credentialUnexpired } = require('@verii/sample-data');
-const { generateKeyPairInHexAndJwk } = require('@verii/tests-helpers');
+const { generateKeyPair } = require('@verii/crypto');
 const console = require('console');
 const { checkJwsVcTampering } = require('../src/check-jws-vc-tampering');
 const { CheckResults } = require('../src/check-results');
 
 describe('tampering checks', () => {
-  const keyPair = generateKeyPairInHexAndJwk();
+  const { privateKey: privateJwk, publicKey: publicJwk } = generateKeyPair({
+    format: 'jwk',
+  });
   const context = { log: console };
 
   let signedCredential;
@@ -32,7 +34,7 @@ describe('tampering checks', () => {
   before(async () => {
     signedCredential = await generateCredentialJwt(
       credentialUnexpired,
-      keyPair.privateJwk,
+      privateJwk,
       'KID',
     );
   });
@@ -40,7 +42,7 @@ describe('tampering checks', () => {
   it('Should return FAIL when tampered', async () => {
     const otherCredential = await generateCredentialJwt(
       { ...credentialUnexpired, issuer: 'TAMPERED' },
-      keyPair.privateJwk,
+      privateJwk,
       'KID',
     );
 
@@ -52,7 +54,7 @@ describe('tampering checks', () => {
 
     const result = await checkJwsVcTampering(
       tamperedCredential,
-      keyPair.publicJwk,
+      publicJwk,
       context,
     );
 
@@ -62,7 +64,7 @@ describe('tampering checks', () => {
   it('Should return PASS when untampered', async () => {
     const result = await checkJwsVcTampering(
       signedCredential,
-      keyPair.publicJwk,
+      publicJwk,
       context,
     );
 

--- a/packages/verii-issuing/src/adapters/get-revocation-registry.js
+++ b/packages/verii-issuing/src/adapters/get-revocation-registry.js
@@ -18,7 +18,7 @@
 /** @import { Issuer, Context } from "../../types/types" */
 
 const { initRevocationRegistry } = require('@verii/metadata-registration');
-const { initCallWithKmsKey, hexFromJwk } = require('@verii/crypto');
+const { initCallWithKmsKey } = require('@verii/crypto');
 
 /**
  * Get revocation registry
@@ -37,7 +37,7 @@ const getRevocationRegistry = (issuer, context) => {
       {
         contractAddress: revocationContractAddress,
         rpcProvider,
-        privateKey: hexFromJwk(key.privateJwk),
+        privateKey: key.privateJwk,
       },
       context,
     ),

--- a/packages/verii-issuing/src/adapters/init-credential-metadata-contract.js
+++ b/packages/verii-issuing/src/adapters/init-credential-metadata-contract.js
@@ -17,11 +17,7 @@
 
 const { initMetadataRegistry } = require('@verii/metadata-registration');
 const { jsonLdToUnsignedVcJwtContent } = require('@verii/jwt');
-const {
-  KeyAlgorithms,
-  initCallWithKmsKey,
-  hexFromJwk,
-} = require('@verii/crypto');
+const { KeyAlgorithms, initCallWithKmsKey } = require('@verii/crypto');
 const { buildIssuerVcUrl } = require('./build-issuer-vc-url');
 
 /** @import { Issuer, CredentialMetadata, Context } from "../../types/types" */
@@ -42,7 +38,7 @@ const initCredentialMetadataContract = async (issuer, context) => {
     ({ privateJwk: dltJwk }) =>
       initMetadataRegistry(
         {
-          privateKey: hexFromJwk(dltJwk),
+          privateKey: dltJwk,
           contractAddress: config.metadataRegistryContractAddress,
           rpcProvider,
         },

--- a/packages/verii-verification/src/verify-credentials.js
+++ b/packages/verii-verification/src/verify-credentials.js
@@ -31,7 +31,6 @@ const {
   toLower,
   uniq,
 } = require('lodash/fp');
-const { hexFromJwk } = require('@verii/crypto');
 const { buildDecodedCredential, jwtDecode } = require('@verii/jwt');
 const {
   initMetadataRegistry,
@@ -175,7 +174,7 @@ const resolveVelocityDidDocument = async (
     const { privateJwk: dltJwk } = await kms.exportKeyOrSecret(
       relyingParty.dltOperatorKMSKeyId,
     );
-    dltPrivateKey = hexFromJwk(dltJwk);
+    dltPrivateKey = dltJwk;
   }
 
   const metadataRegistry = await initMetadataRegistry(

--- a/packages/verii-verification/test/verify-credentials.test.js
+++ b/packages/verii-verification/test/verify-credentials.test.js
@@ -41,22 +41,23 @@ const { jwtSign, jwtDecode, generateCredentialJwt } = require('@verii/jwt');
 const { addHours, setMilliseconds } = require('date-fns/fp');
 const { getDidUriFromJwk } = require('@verii/did-doc');
 const { credentialUnexpired } = require('@verii/sample-data');
-const { generateKeyPairInHexAndJwk } = require('@verii/tests-helpers');
 const {
   CheckResults,
   VeriiProtocolVersions,
   VelocityRevocationListType,
 } = require('@verii/vc-checks');
-const { generateKeyPair } = require('@verii/crypto');
+const { generateKeyPair, hexFromJwk } = require('@verii/crypto');
 const { nanoid } = require('nanoid');
 const { applyOverrides } = require('@verii/common-functions');
 const { verifyCredentials } = require('../src/verify-credentials');
 
 describe('Verify credentials', () => {
-  const orgKeyPair = generateKeyPairInHexAndJwk();
+  const orgKeyPair = generateKeyPair({ format: 'jwk' });
+  const orgPublicKey = hexFromJwk(orgKeyPair.publicKey, false);
+  const orgPrivateKey = hexFromJwk(orgKeyPair.privateKey);
   const issuerDid = 'did:ion:1234567890';
-  const issuerKeyPair = generateKeyPairInHexAndJwk();
-  const issuerDidJwk = getDidUriFromJwk(issuerKeyPair.publicJwk);
+  const issuerKeyPair = generateKeyPair({ format: 'jwk' });
+  const issuerDidJwk = getDidUriFromJwk(issuerKeyPair.publicKey);
 
   const mockGetOrganizationVerifiedProfile = {
     credentialSubject: {
@@ -66,7 +67,7 @@ describe('Verify credentials', () => {
   };
 
   const config = {
-    rootPublicKey: orgKeyPair.publicKey,
+    rootPublicKey: orgPublicKey,
     revocationContractAddress: 'any',
   };
   let issuerVc;
@@ -78,7 +79,7 @@ describe('Verify credentials', () => {
       resolveDid: mock.fn(() =>
         Promise.resolve({
           id: issuerDid,
-          publicKey: [{ id: '#key-1', publicKeyJwk: orgKeyPair.publicJwk }],
+          publicKey: [{ id: '#key-1', publicKeyJwk: orgKeyPair.publicKey }],
         }),
       ),
       getOrganizationVerifiedProfile: mock.fn(() =>
@@ -135,7 +136,7 @@ describe('Verify credentials', () => {
             publicKey: [
               {
                 id: `${credentialDid.toLowerCase()}#key`,
-                publicKeyJwk: orgKeyPair.publicJwk,
+                publicKeyJwk: orgKeyPair.publicKey,
               },
             ],
             service: ['SERVICE'],
@@ -165,7 +166,7 @@ describe('Verify credentials', () => {
             },
           },
         };
-        issuerVc = await jwtSign(issuerCred, orgKeyPair.privateJwk, {
+        issuerVc = await jwtSign(issuerCred, orgKeyPair.privateKey, {
           kid: `${issuerDid}#key-1`,
         });
 
@@ -196,12 +197,12 @@ describe('Verify credentials', () => {
         });
         openBadgeVc = await generateCredentialJwt(
           openBadgeCredential,
-          orgKeyPair.privateJwk,
+          orgKeyPair.privateKey,
           `${credentialDid}#key`,
         );
         idVc = await generateCredentialJwt(
           idCredential,
-          orgKeyPair.privateJwk,
+          orgKeyPair.privateKey,
           `${credentialDid}#key`,
         );
       });
@@ -229,11 +230,17 @@ describe('Verify credentials', () => {
             },
           },
         ]);
+        expect(
+          initMetadataRegistry.mock.calls.map((call) => call.arguments),
+        ).toContainEqual([
+          expect.objectContaining({ privateKey: orgKeyPair.privateKey }),
+          context,
+        ]);
       });
 
       it('should return successful credential check using kms', async () => {
         const keys = {
-          [orgKeyPair.publicKey]: { privateJwk: orgKeyPair.privateJwk },
+          [orgPublicKey]: { privateJwk: orgKeyPair.privateKey },
         };
         const kmsContext = {
           ...context,
@@ -243,7 +250,7 @@ describe('Verify credentials', () => {
           {
             credentials: [idVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltOperatorKMSKeyId: orgKeyPair.publicKey },
+            relyingParty: { dltOperatorKMSKeyId: orgPublicKey },
           },
           fetchers,
           kmsContext,
@@ -289,7 +296,7 @@ describe('Verify credentials', () => {
           {
             credentials: [openBadgeVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -320,7 +327,7 @@ describe('Verify credentials', () => {
         };
         const legacyOpenBadgeVc = await generateCredentialJwt(
           legacyOpenBadgeCredential,
-          orgKeyPair.privateJwk,
+          orgKeyPair.privateKey,
           `${credentialDid}#key`,
         );
 
@@ -328,7 +335,7 @@ describe('Verify credentials', () => {
           {
             credentials: [legacyOpenBadgeVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -353,7 +360,7 @@ describe('Verify credentials', () => {
           {
             credentials: [openBadgeVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -375,7 +382,7 @@ describe('Verify credentials', () => {
 
       it('should return successful credential check using kms', async () => {
         const keys = {
-          [orgKeyPair.publicKey]: { privateJwk: orgKeyPair.privateJwk },
+          [orgPublicKey]: { privateJwk: orgKeyPair.privateKey },
         };
         const kmsContext = {
           ...context,
@@ -385,7 +392,7 @@ describe('Verify credentials', () => {
           {
             credentials: [idVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltOperatorKMSKeyId: orgKeyPair.publicKey },
+            relyingParty: { dltOperatorKMSKeyId: orgPublicKey },
           },
           fetchers,
           kmsContext,
@@ -431,7 +438,7 @@ describe('Verify credentials', () => {
           {
             credentials: [openBadgeVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -462,7 +469,7 @@ describe('Verify credentials', () => {
         };
         const legacyOpenBadgeVc = await generateCredentialJwt(
           legacyOpenBadgeCredential,
-          orgKeyPair.privateJwk,
+          orgKeyPair.privateKey,
           `${credentialDid}#key`,
         );
 
@@ -470,7 +477,7 @@ describe('Verify credentials', () => {
           {
             credentials: [legacyOpenBadgeVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -495,7 +502,7 @@ describe('Verify credentials', () => {
           {
             credentials: [openBadgeVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           {
             ...fetchers,
@@ -527,7 +534,7 @@ describe('Verify credentials', () => {
         const result = await verifyCredentials(
           {
             credentials: [openBadgeVc],
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
             expectedHolderDid: issuerDidJwk,
           },
           fetchers,
@@ -559,14 +566,14 @@ describe('Verify credentials', () => {
         };
         const legacyOpenBadgeVc = await generateCredentialJwt(
           legacyOpenBadgeCredential,
-          orgKeyPair.privateJwk,
+          orgKeyPair.privateKey,
           `${credentialDid}#key`,
         );
 
         const result = await verifyCredentials(
           {
             credentials: [legacyOpenBadgeVc],
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
             expectedHolderDid: issuerDidJwk,
           },
           fetchers,
@@ -597,14 +604,14 @@ describe('Verify credentials', () => {
         };
         const vcWithArrayOfStatus = await generateCredentialJwt(
           credentialWithArrayOfStatus,
-          orgKeyPair.privateKey,
+          orgPrivateKey,
           `${credentialDid}#key`,
         );
         const result = await verifyCredentials(
           {
             credentials: [vcWithArrayOfStatus],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -625,8 +632,8 @@ describe('Verify credentials', () => {
       });
 
       it('should return successful credential check if selfsigned using did:jwk in kid', async () => {
-        const keyPair = generateKeyPairInHexAndJwk();
-        const did = getDidUriFromJwk(keyPair.publicJwk);
+        const keyPair = generateKeyPair({ format: 'jwk' });
+        const did = getDidUriFromJwk(keyPair.publicKey);
         const unsignedCredential = {
           ...omit(
             [
@@ -644,7 +651,7 @@ describe('Verify credentials', () => {
         };
         const signedCredential = await jwtSign(
           { vc: unsignedCredential },
-          keyPair.privateJwk,
+          keyPair.privateKey,
           {
             nbf: new Date(unsignedCredential.issuanceDate),
             iat: new Date(unsignedCredential.issuanceDate),
@@ -680,7 +687,7 @@ describe('Verify credentials', () => {
         await verifyCredentials(
           {
             credentials: [openBadgeVc, openBadgeVc],
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -705,7 +712,7 @@ describe('Verify credentials', () => {
       });
 
       it('should return successful credential check if selfsigned using jwk', async () => {
-        const keyPair = generateKeyPairInHexAndJwk();
+        const keyPair = generateKeyPair({ format: 'jwk' });
         const credentialId = nanoid();
         const unsignedCredential = {
           ...omit(
@@ -717,12 +724,12 @@ describe('Verify credentials', () => {
         };
         const signedCredential = await jwtSign(
           { vc: unsignedCredential },
-          keyPair.privateJwk,
+          keyPair.privateKey,
           {
             nbf: new Date(openBadgeCredential.issuanceDate),
             jti: credentialId,
             iat: new Date(openBadgeCredential.issuanceDate),
-            jwk: keyPair.publicJwk,
+            jwk: keyPair.publicKey,
           },
         );
         const result = await verifyCredentials(
@@ -734,7 +741,7 @@ describe('Verify credentials', () => {
         expect(header).toEqual({
           alg: 'ES256K',
           typ: 'JWT',
-          jwk: keyPair.publicJwk,
+          jwk: keyPair.publicKey,
         });
         expect(result).toEqual([
           {
@@ -759,7 +766,7 @@ describe('Verify credentials', () => {
         const result = await verifyCredentials(
           {
             credentials: [idVc],
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -779,7 +786,7 @@ describe('Verify credentials', () => {
       });
 
       it('UNTAMPERED should return DEPENDENCY_RESOLUTION_ERROR if credential signed using an unsupported did method in kid', async () => {
-        const keyPair = generateKeyPairInHexAndJwk();
+        const keyPair = generateKeyPair({ format: 'jwk' });
         const didWeb = 'did:web:example.com';
         const unsignedCredential = {
           ...omit(['id'], openBadgeCredential),
@@ -790,7 +797,7 @@ describe('Verify credentials', () => {
         };
         const signedCredential = await jwtSign(
           { vc: unsignedCredential },
-          keyPair.privateJwk,
+          keyPair.privateKey,
           {
             nbf: new Date(unsignedCredential.issuanceDate),
             iat: new Date(unsignedCredential.issuanceDate),
@@ -834,7 +841,7 @@ describe('Verify credentials', () => {
             {
               credentials: [idVc],
               expectedHolderDid: issuerDidJwk,
-              relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+              relyingParty: { dltPrivateKey: orgPrivateKey },
             },
             fetchers,
             context,
@@ -863,7 +870,7 @@ describe('Verify credentials', () => {
           {
             credentials: [signedCredential],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -917,11 +924,11 @@ describe('Verify credentials', () => {
             credentials: [
               await generateCredentialJwt(
                 openBadgeCredential,
-                orgKeyPair.privateJwk,
+                orgKeyPair.privateKey,
                 credentialDid,
               ),
             ],
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -946,7 +953,7 @@ describe('Verify credentials', () => {
           {
             credentials: [idVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           { ...fetchers, resolveDid: () => Promise.reject(new Error()) },
           context,
@@ -971,7 +978,7 @@ describe('Verify credentials', () => {
           {
             credentials: [idVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           {
             ...fetchers,
@@ -999,7 +1006,7 @@ describe('Verify credentials', () => {
           {
             credentials: [idVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           {
             ...fetchers,
@@ -1029,7 +1036,7 @@ describe('Verify credentials', () => {
           {
             credentials: [idVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           {
             ...fetchers,
@@ -1057,7 +1064,7 @@ describe('Verify credentials', () => {
           {
             credentials: [idVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           {
             ...fetchers,
@@ -1089,7 +1096,7 @@ describe('Verify credentials', () => {
         const result = await verifyCredentials(
           {
             credentials: [idVc],
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -1116,14 +1123,14 @@ describe('Verify credentials', () => {
         };
         const signedCredential = await generateCredentialJwt(
           credentialWithVnfProtocolV1,
-          orgKeyPair.privateJwk,
+          orgKeyPair.privateKey,
           `${credentialDid}#key`,
         );
 
         const result = await verifyCredentials(
           {
             credentials: [signedCredential],
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -1154,14 +1161,14 @@ describe('Verify credentials', () => {
 
         const vcWithoutCorrectStatus = await generateCredentialJwt(
           credentialWithoutCorrectStatus,
-          orgKeyPair.privateKey,
+          orgPrivateKey,
           `${credentialDid}#key`,
         );
         const result = await verifyCredentials(
           {
             credentials: [vcWithoutCorrectStatus],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -1190,7 +1197,7 @@ describe('Verify credentials', () => {
           {
             credentials: [idVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,
@@ -1219,7 +1226,7 @@ describe('Verify credentials', () => {
           {
             credentials: [idVc],
             expectedHolderDid: issuerDidJwk,
-            relyingParty: { dltPrivateKey: orgKeyPair.privateKey },
+            relyingParty: { dltPrivateKey: orgPrivateKey },
           },
           fetchers,
           context,

--- a/packages/verii-verification/test/verify-verii-credentials.test.js
+++ b/packages/verii-verification/test/verify-verii-credentials.test.js
@@ -41,13 +41,12 @@ const { jwtSign, jwtDecode, generateCredentialJwt } = require('@verii/jwt');
 const { addHours, setMilliseconds } = require('date-fns/fp');
 const { getDidUriFromJwk } = require('@verii/did-doc');
 const { credentialUnexpired } = require('@verii/sample-data');
-const { generateKeyPairInHexAndJwk } = require('@verii/tests-helpers');
 const {
   CheckResults,
   VeriiProtocolVersions,
   VelocityRevocationListType,
 } = require('@verii/vc-checks');
-const { generateKeyPair } = require('@verii/crypto');
+const { generateKeyPair, hexFromJwk } = require('@verii/crypto');
 const { applyOverrides } = require('@verii/common-functions');
 const nock = require('./helpers/nock');
 const { verifyVeriiCredentials } = require('../src/verify-verii-credentials');
@@ -56,10 +55,12 @@ const registrarHost = 'registrar.test';
 const registrarUrl = `https://${registrarHost}`;
 
 describe('Verify verii credentials', () => {
-  const orgKeyPair = generateKeyPairInHexAndJwk();
+  const orgKeyPair = generateKeyPair({ format: 'jwk' });
+  const orgPublicKey = hexFromJwk(orgKeyPair.publicKey, false);
+  const orgPrivateKey = hexFromJwk(orgKeyPair.privateKey);
   const issuerDid = 'did:ion:1234567890';
-  const issuerKeyPair = generateKeyPairInHexAndJwk();
-  const issuerDidJwk = getDidUriFromJwk(issuerKeyPair.publicJwk);
+  const issuerKeyPair = generateKeyPair({ format: 'jwk' });
+  const issuerDidJwk = getDidUriFromJwk(issuerKeyPair.publicKey);
 
   const mockGetOrganizationVerifiedProfile = {
     credentialSubject: {
@@ -77,7 +78,7 @@ describe('Verify verii credentials', () => {
   const credentialTypePath = '/api/v0.6/credential-types';
 
   const config = {
-    rootPublicKey: orgKeyPair.publicKey,
+    rootPublicKey: orgPublicKey,
     revocationContractAddress: 'any',
     registrarUrl,
     isTest: true,
@@ -87,7 +88,7 @@ describe('Verify verii credentials', () => {
 
   before(async () => {
     const keys = {
-      'keyid-1': { privateJwk: orgKeyPair.privateJwk },
+      'keyid-1': { privateJwk: orgKeyPair.privateKey },
     };
 
     context = {
@@ -114,7 +115,7 @@ describe('Verify verii credentials', () => {
             publicKey: [
               {
                 id: `${credentialDid.toLowerCase()}#key`,
-                publicKeyJwk: orgKeyPair.publicJwk,
+                publicKeyJwk: orgKeyPair.publicKey,
               },
             ],
             service: ['SERVICE'],
@@ -138,7 +139,7 @@ describe('Verify verii credentials', () => {
           .get(resolveDidPath)
           .reply(200, {
             id: issuerDid,
-            publicKey: [{ id: '#key-1', publicKeyJwk: orgKeyPair.publicJwk }],
+            publicKey: [{ id: '#key-1', publicKeyJwk: orgKeyPair.publicKey }],
           });
         nock(registrarUrl)
           .get(verifiedProfilePath)
@@ -166,7 +167,7 @@ describe('Verify verii credentials', () => {
             },
           },
         };
-        issuerVc = await jwtSign(issuerCred, orgKeyPair.privateJwk, {
+        issuerVc = await jwtSign(issuerCred, orgKeyPair.privateKey, {
           kid: `${issuerDid}#key-1`,
         });
 
@@ -189,7 +190,7 @@ describe('Verify verii credentials', () => {
         });
         openBadgeVc = await generateCredentialJwt(
           openBadgeCredential,
-          orgKeyPair.privateJwk,
+          orgKeyPair.privateKey,
           `${credentialDid}#key`,
         );
       });
@@ -333,7 +334,7 @@ describe('Verify verii credentials', () => {
         };
         const vcWithArrayOfStatus = await generateCredentialJwt(
           credentialWithArrayOfStatus,
-          orgKeyPair.privateKey,
+          orgPrivateKey,
           `${credentialDid}#key`,
         );
         const result = await verifyVeriiCredentials(
@@ -420,7 +421,7 @@ describe('Verify verii credentials', () => {
       });
 
       it('UNTAMPERED should return DEPENDENCY_RESOLUTION_ERROR if credential signed using an unsupported did method in kid', async () => {
-        const keyPair = generateKeyPairInHexAndJwk();
+        const keyPair = generateKeyPair({ format: 'jwk' });
         const didWeb = 'did:web:example.com';
         const unsignedCredential = {
           ...omit(['id'], openBadgeCredential),
@@ -431,7 +432,7 @@ describe('Verify verii credentials', () => {
         };
         const signedCredential = await jwtSign(
           { vc: unsignedCredential },
-          keyPair.privateJwk,
+          keyPair.privateKey,
           {
             nbf: new Date(unsignedCredential.issuanceDate),
             iat: new Date(unsignedCredential.issuanceDate),
@@ -565,7 +566,7 @@ describe('Verify verii credentials', () => {
             credentials: [
               await generateCredentialJwt(
                 openBadgeCredential,
-                orgKeyPair.privateJwk,
+                orgKeyPair.privateKey,
                 credentialDid,
               ),
             ],
@@ -850,7 +851,7 @@ describe('Verify verii credentials', () => {
 
         const vcWithoutCorrectStatus = await generateCredentialJwt(
           credentialWithoutCorrectStatus,
-          orgKeyPair.privateKey,
+          orgPrivateKey,
           `${credentialDid}#key`,
         );
         const result = await verifyVeriiCredentials(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       '@verii/common-functions':
         specifier: workspace:*
         version: link:../common-functions
+      '@verii/crypto':
+        specifier: workspace:*
+        version: link:../crypto
       '@verii/http-client':
         specifier: workspace:*
         version: link:../http-client
@@ -319,9 +322,6 @@ importers:
       '@spencejs/spence-config':
         specifier: 1.1.0
         version: 1.1.0
-      '@verii/crypto':
-        specifier: workspace:*
-        version: link:../crypto
       '@verii/tests-helpers':
         specifier: workspace:*
         version: link:../tests-helpers

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3710,9 +3710,6 @@ importers:
       '@verii/verii-verification':
         specifier: workspace:*
         version: link:../../packages/verii-verification
-      bs58:
-        specifier: ^6.0.0
-        version: 6.0.0
       chalk:
         specifier: ~5.6.2
         version: 5.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2319,6 +2319,9 @@ importers:
         specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
+      '@verii/crypto':
+        specifier: workspace:*
+        version: link:../crypto
       '@verii/sample-data':
         specifier: workspace:*
         version: link:../sample-data

--- a/servers/credentialagent/e2e/org-registration-and-issuing.e2e.test.js
+++ b/servers/credentialagent/e2e/org-registration-and-issuing.e2e.test.js
@@ -39,7 +39,6 @@ const { ServiceTypes } = require('@verii/organizations-registry');
 //   jwtVerify,
 //   generateDocJwt,
 //   generatePresentationJwt,
-//   toJwk,
 //   jwtSign,
 // } = require('@verii/jwt');
 // const { getDidUriFromJwk } = require('@verii/did-doc');

--- a/servers/credentialagent/src/entities/tenants/orchestrators/add-primary-address-to-tenant.js
+++ b/servers/credentialagent/src/entities/tenants/orchestrators/add-primary-address-to-tenant.js
@@ -15,7 +15,7 @@
  */
 
 const { initPermissions } = require('@verii/contract-permissions');
-const { KeyPurposes, decrypt, hexFromJwk } = require('@verii/crypto');
+const { KeyPurposes, decrypt } = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 
 const addPrimaryAddressToTenant = async ({ _id }, context) => {
@@ -27,7 +27,7 @@ const addPrimaryAddressToTenant = async ({ _id }, context) => {
   };
   const keyDatum = await repos.keys.collection().findOne(filter);
   const stringifiedKey = decrypt(keyDatum.key, context.config.mongoSecret);
-  const privateKey = hexFromJwk(JSON.parse(stringifiedKey));
+  const privateKey = JSON.parse(stringifiedKey);
   const publicAddress = toEthereumAddress(privateKey);
   const permissionContract = await initPermissions(
     {

--- a/servers/credentialagent/test/holder/credential-manifest-controller.test.js
+++ b/servers/credentialagent/test/holder/credential-manifest-controller.test.js
@@ -81,10 +81,10 @@ describe('get credential manifests', () => {
     await mongoDb().collection('exchanges').deleteMany({});
 
     tenant = await persistTenant();
-    const { publicKey } = generateKeyPair();
+    const { publicKey: publicJwk } = generateKeyPair({ format: 'jwk' });
     orgDidDoc = {
       id: tenant.did,
-      publicKey: [{ id: `${tenant.did}#key-1`, publicKeyHex: publicKey }],
+      publicKey: [{ id: `${tenant.did}#key-1`, publicKeyJwk: publicJwk }],
       service: [
         {
           id: `${tenant.did}#service-1`,
@@ -1043,11 +1043,11 @@ describe('get credential manifests', () => {
     it("should 200, when route has a tenant's did alias", async () => {
       const didAlias = 'did:aka:foo';
       const customTenant = await persistTenant({ dids: [didAlias] });
-      const { publicKey } = generateKeyPair();
+      const { publicKey: publicJwk } = generateKeyPair({ format: 'jwk' });
       const customOrgDidDoc = {
         id: customTenant.did,
         publicKey: [
-          { id: `${customTenant.did}#key-1`, publicKeyHex: publicKey },
+          { id: `${customTenant.did}#key-1`, publicKeyJwk: publicJwk },
         ],
         service: [
           {
@@ -1679,11 +1679,11 @@ describe('get credential manifests', () => {
 
     it('should 200, when no disclosureId, no exchangeId nor types are passed', async () => {
       const customTenant = await persistTenant();
-      const { publicKey } = generateKeyPair();
+      const { publicKey: publicJwk } = generateKeyPair({ format: 'jwk' });
       const customOrgDidDoc = {
         id: customTenant.did,
         publicKey: [
-          { id: `${customTenant.did}#key-1`, publicKeyHex: publicKey },
+          { id: `${customTenant.did}#key-1`, publicKeyJwk: publicJwk },
         ],
         service: [
           {

--- a/servers/credentialagent/test/holder/helpers/generate-presentation.js
+++ b/servers/credentialagent/test/holder/helpers/generate-presentation.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const { generateKeyPair, jwkFromSecp256k1Key } = require('@verii/crypto');
+const { generateKeyPair } = require('@verii/crypto');
 const { mapWithIndex } = require('@verii/common-functions');
 const {
   castArray,
@@ -301,7 +301,7 @@ const whateverPayload = {
   },
 };
 
-const { privateKey, publicKey } = generateKeyPair();
+const { privateKey, publicKey } = generateKeyPair({ format: 'jwk' });
 
 const generateKYCPresentation = (exchange, idDocTypes, options) => {
   const idCredentials = {
@@ -349,15 +349,13 @@ const doGeneratePresentation = async (
     map((c) => generateCredentialJwt(c, privateKey), credentials),
   );
 
-  const publicJwk = jwkFromSecp256k1Key(publicKey, false);
-
   const presentation =
     get('protocolMetadata.protocol', exchange) === ExchangeProtocols.OIDC_SIOP
       ? {
           id: nanoid(),
           state: exchange._id,
-          sub: await jwkThumbprint(publicJwk),
-          sub_jwk: publicJwk,
+          sub: await jwkThumbprint(publicKey),
+          sub_jwk: publicKey,
           aud: exchange.protocolMetadata.redirect_uri,
           nonce: exchange.protocolMetadata.nonce,
           iss: 'https://self-issuanceDate.me',

--- a/servers/credentialagent/test/operator/credentials-revoke.test.js
+++ b/servers/credentialagent/test/operator/credentials-revoke.test.js
@@ -34,8 +34,11 @@ const { mongoDb } = require('@spencejs/spence-mongo-repos');
 
 const nock = require('../helpers/nock');
 const { mongoify, errorResponseMatcher } = require('@verii/tests-helpers');
-const { generateKeyPair, KeyPurposes, hexFromJwk } = require('@verii/crypto');
-const { toEthereumAddress } = require('@verii/blockchain-functions');
+const { generateKeyPair, KeyPurposes } = require('@verii/crypto');
+const {
+  generateAccount,
+  toEthereumAddress,
+} = require('@verii/blockchain-functions');
 const { ObjectId } = require('mongodb');
 
 const buildFastify = require('./helpers/credentialagent-operator-build-fastify');
@@ -54,8 +57,8 @@ const getUrl = (tenant, credentialId) =>
 
 describe('Credentials checking tests', () => {
   const keyPair = generateKeyPair({ format: 'jwk' });
-  const primaryPair = generateKeyPair();
-  const primaryAddress = toEthereumAddress(primaryPair.privateKey);
+  const primaryAccount = generateAccount();
+  const primaryAddress = primaryAccount.address;
 
   let fastify;
   let tenant;
@@ -167,7 +170,7 @@ describe('Credentials checking tests', () => {
     ).toEqual([
       [
         expect.objectContaining({
-          privateKey: hexFromJwk(keyPair.privateKey, true),
+          privateKey: keyPair.privateKey,
         }),
         expect.any(Object),
       ],
@@ -221,7 +224,7 @@ describe('Credentials checking tests', () => {
       type: ['SomeType'],
       credentialStatus: {
         id: `ethereum:0xB457b50B6914A17Be513eD17c4aF9A9FECDB164C/getRevokedStatus?address=${toEthereumAddress(
-          hexFromJwk(fallbackKeyPair.publicKey, false),
+          fallbackKeyPair.publicKey,
         )}&listId=1000257453&index=5682`,
       },
       exchange,
@@ -253,7 +256,7 @@ describe('Credentials checking tests', () => {
       initRevocationRegistry.mock.calls.map((call) => call.arguments),
     ).toContainEqual([
       expect.objectContaining({
-        privateKey: hexFromJwk(fallbackKeyPair.privateKey),
+        privateKey: fallbackKeyPair.privateKey,
       }),
       expect.any(Object),
     ]);

--- a/servers/credentialagent/test/operator/helpers/create-test-org-doc.js
+++ b/servers/credentialagent/test/operator/helpers/create-test-org-doc.js
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-const { generateKeyPair, jwkFromSecp256k1Key } = require('@verii/crypto');
+const { generateKeyPair, hexFromJwk } = require('@verii/crypto');
 
 const { nanoid } = require('nanoid/non-secure');
 
 const createOrgDoc = async () => {
-  const { privateKey, publicKey } = generateKeyPair();
-  const publicKeyJwk = jwkFromSecp256k1Key(publicKey, false);
+  const { privateKey, publicKey } = generateKeyPair({
+    format: 'jwk',
+  });
   const key = {
     id: '#velocity-key-1',
-    publicKeyJwk,
+    publicKeyJwk: publicKey,
     algorithm: 'SECP256K1',
     encoding: 'hex',
     controller: 'did:key:01230123012',
@@ -51,8 +52,8 @@ const createOrgDoc = async () => {
       assertionMethod: [key.id],
       verificationMethod: [key],
     },
-    orgKey: privateKey,
-    orgPublicKey: publicKey,
+    orgKey: hexFromJwk(privateKey),
+    orgPublicKey: hexFromJwk(publicKey, false),
   };
 };
 module.exports = {

--- a/servers/credentialagent/test/operator/helpers/generate-primary-and-add-operator-to-primary.js
+++ b/servers/credentialagent/test/operator/helpers/generate-primary-and-add-operator-to-primary.js
@@ -16,8 +16,7 @@
 
 const { rootPrivateKey } = require('@verii/sample-data');
 const { initPermissions } = require('@verii/contract-permissions');
-const { generateKeyPair } = require('@verii/crypto');
-const { toEthereumAddress } = require('@verii/blockchain-functions');
+const { generateAccount } = require('@verii/blockchain-functions');
 const { initProvider } = require('@verii/base-contract-io');
 
 const generatePrimaryAndAddOperatorToPrimary = async (
@@ -37,8 +36,8 @@ const generatePrimaryAndAddOperatorToPrimary = async (
     },
     { ...context, repos: {} },
   );
-  const primaryKeyPair = generateKeyPair();
-  const primaryPublicAddress = toEthereumAddress(primaryKeyPair.publicKey);
+  const primaryAccount = generateAccount();
+  const primaryPublicAddress = primaryAccount.address;
   await permissionRootContract.addPrimary({
     primary: primaryPublicAddress,
     permissioning: primaryPublicAddress,
@@ -46,7 +45,7 @@ const generatePrimaryAndAddOperatorToPrimary = async (
   });
   const permissionContract = await initPermissions(
     {
-      privateKey: primaryKeyPair.privateKey,
+      privateKey: primaryAccount.privateKey,
       contractAddress: permissionsContractAddress,
       rpcProvider,
     },

--- a/servers/credentialagent/test/operator/tenants-controller-v0.8.test.js
+++ b/servers/credentialagent/test/operator/tenants-controller-v0.8.test.js
@@ -25,7 +25,10 @@ const {
   OBJECT_ID_FORMAT,
 } = require('@verii/test-regexes');
 const { errorResponseMatcher } = require('@verii/tests-helpers');
-const { toEthereumAddress } = require('@verii/blockchain-functions');
+const {
+  generateDisposablePrivateKey,
+  toEthereumAddress,
+} = require('@verii/blockchain-functions');
 const { rootPrivateKey } = require('@verii/sample-data');
 const {
   KeyPurposes,
@@ -2073,17 +2076,13 @@ describe.skip('Private key to ethereum account test suite', () => {
     }
   });
   it('brute force eth account conversion with original hex', () => {
-    // This test is different from the previous test in that it uses the
-    // hexes coming directly out of generateKeyPair
-    // results seem the same, possibly slightly more common
+    // This test is different from the previous test in that it uses a
+    // disposable blockchain private key.
 
     for (let i = 0; i < 300; i++) {
-      const keyPairHexInternal = generateKeyPair({ format: 'hex' });
-      const privateJwkInternalToHex = keyPairHexInternal.privateKey;
-      const publicFromPrivateHex = publicKeyFromPrivateKey(
-        privateJwkInternalToHex,
-      );
-      const ethAccountFromPrivate = toEthereumAddress(privateJwkInternalToHex);
+      const privateKeyHex = generateDisposablePrivateKey();
+      const publicFromPrivateHex = publicKeyFromPrivateKey(privateKeyHex);
+      const ethAccountFromPrivate = toEthereumAddress(privateKeyHex.slice(2));
 
       // eslint-disable-next-line no-console
       console.log(`Will we finish iteration ${i}?: --------------`);

--- a/servers/credentialinghub/e2e/org-registration-and-issuing.e2e.test.js
+++ b/servers/credentialinghub/e2e/org-registration-and-issuing.e2e.test.js
@@ -22,7 +22,11 @@ const { MongoClient } = require('mongodb');
 const { nanoid, customAlphabet } = require('nanoid');
 const { lowercase } = require('nanoid-dictionary');
 const { filter, first, find, map, omit } = require('lodash/fp');
-const { KeyPurposes, generateKeyPair } = require('@verii/crypto');
+const {
+  KeyPurposes,
+  generateKeyPair,
+  jwkFromSecp256k1Key,
+} = require('@verii/crypto');
 const {
   applyOverrides,
   formatAsDate,
@@ -40,7 +44,6 @@ const {
   jwtVerify,
   generateDocJwt,
   generatePresentationJwt,
-  toJwk,
   jwtSign,
 } = require('@verii/jwt');
 const { getDidUriFromJwk } = require('@verii/did-doc');
@@ -520,7 +523,7 @@ describe('org registration and issuing e2e', () => {
     );
     const { payload: credentialManifest } = await jwtVerify(
       credentialManifestJson.issuing_request,
-      toJwk(key.didDocumentKey.publicKeyMultibase, false),
+      jwkFromSecp256k1Key(key.didDocumentKey.publicKeyMultibase, false),
     );
     expect(credentialManifest).toEqual({
       ...expectedCredentialManifest(profile, tenant, service, [

--- a/servers/credentialinghub/src/entities/keys/adapters/load-primary-account.js
+++ b/servers/credentialinghub/src/entities/keys/adapters/load-primary-account.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  */
-const { hexFromJwk } = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 const { initPermissions } = require('@verii/contract-permissions');
 
@@ -23,11 +22,10 @@ const loadPrimaryAccount = async (dltKey, context) => {
     config: { permissionsContractAddress: contractAddress },
     rpcProvider,
   } = context;
-  const hexKey = hexFromJwk(dltKey.jwk);
-  const publicAddress = toEthereumAddress(hexKey);
+  const publicAddress = toEthereumAddress(dltKey.jwk);
   const permissionContract = await initPermissions(
     {
-      hexKey,
+      privateKey: dltKey.jwk,
       contractAddress,
       rpcProvider,
     },

--- a/servers/credentialinghub/test/operator/presentations-controller.test.js
+++ b/servers/credentialinghub/test/operator/presentations-controller.test.js
@@ -47,7 +47,6 @@ const { initMetadataRegistry } = require('@verii/metadata-registration');
 const { mongoDb } = require('@spencejs/spence-mongo-repos');
 const { generateKeyPair } = require('@verii/crypto');
 const { applyOverrides, mapWithIndex } = require('@verii/common-functions');
-const { generateKeyPairInHexAndJwk } = require('@verii/tests-helpers');
 const { CheckResults } = require('@verii/vc-checks');
 const { getDidUriFromJwk } = require('@verii/did-doc');
 const {
@@ -135,8 +134,8 @@ describe('Presentations Test Suite', () => {
       kid: `${tenant.did}#key-1`,
     });
 
-    holderKeyPair = generateKeyPairInHexAndJwk();
-    holderDid = getDidUriFromJwk(holderKeyPair.publicJwk);
+    holderKeyPair = generateKeyPair({ format: 'jwk' });
+    holderDid = getDidUriFromJwk(holderKeyPair.publicKey);
     resetMockHttpClient();
     mockHttpClientJsonRoute(
       'get',
@@ -359,7 +358,7 @@ describe('Presentations Test Suite', () => {
             verifiableCredential: [vc],
             issuer: holderDid,
           },
-          holderKeyPair.privateJwk,
+          holderKeyPair.privateKey,
           `${holderDid}#key`,
         );
       });
@@ -443,7 +442,7 @@ describe('Presentations Test Suite', () => {
 
         const vp2 = await generatePresentationJwt(
           { verifiableCredential: [vc2], issuer: holderDid },
-          holderKeyPair.privateJwk,
+          holderKeyPair.privateKey,
           `${holderDid}#key`,
         );
 
@@ -510,7 +509,7 @@ describe('Presentations Test Suite', () => {
             verifiableCredential: [vc2],
             issuer: holderDid,
           },
-          holderKeyPair.privateJwk,
+          holderKeyPair.privateKey,
           `${holderDid}#key`,
         );
 

--- a/servers/credentialinghub/test/operator/tenants-controller.test.js
+++ b/servers/credentialinghub/test/operator/tenants-controller.test.js
@@ -594,6 +594,18 @@ describe('Tenants management test suite', () => {
         keyMetadatas: expectedKeyMetadatas(payload.keys),
         requestId: expect.any(String),
       });
+      expect(
+        mockContractPermissionsModule.initPermissions.mock.calls.map(
+          (call) => call.arguments,
+        ),
+      ).toContainEqual([
+        expect.objectContaining({
+          privateKey: payload.keys[0].jwk,
+          contractAddress: fastify.config.permissionsContractAddress,
+          rpcProvider: expect.any(Object),
+        }),
+        expect.any(Object),
+      ]);
 
       const tenantFromDb = await loadDbTenant(response.json.tenant.id);
 

--- a/tools/verifgen/README.md
+++ b/tools/verifgen/README.md
@@ -42,6 +42,11 @@ Now that you have a set of credentials then you can create presentations for sen
 - Support organization signed credentials
 
 
+## Generating Keys
+`$ node ./src/verifgen.js keys --public-key-file pub.key.json --private-key-file prv.key.json`
+
+The key files are written as JSON Web Keys. The private key file contains a private JWK and must be stored securely.
+
 ## Creating agent jwt token
 `$ node ./src/verifgen agent-jwt --secret 'cc7e0d44fd473002f1c42167459001140ec6389b7353f8088f4d9a95f2f596f2' --email example@example.com --groupId 123654`
 
@@ -80,25 +85,18 @@ With a persona of johndoe, the following files would be expected.
    The important thing here is that the `id` property is present, and represents the identity of the persona
 
 
-2. One of the following:
-   1. A private jwk in a file named `johndoe.prv.key.json`, with JSON contents like:
-      ```
-      {
-        "kty": "...",
-        "crv": "...",
-        "d": "...",
-        "x": "...",
-        "y": "..."
-      }
-      ```
-   2. A private hex string in a file named `johndoe.prv.key` with a string like:
-      ```
-      8a2c1...
-      ```
-      The CLI will attempt to load the JWK first. 
-      Otherwise the CLI will attempt to load the hex file.
-      
-      This private key will be used to sign whatever JWTs are relevant to the CLI tool being used.
-      So using `verifgen presentation`, this key will be used to sign the presentation.
-      And using `verifgen proof`, this key will be used to sign the proof.
-      And same goes for other instances where the `-p <persona` option is specified.
+2. A private JWK in a file named `johndoe.prv.key.json`, with JSON contents like:
+   ```
+   {
+     "kty": "...",
+     "crv": "...",
+     "d": "...",
+     "x": "...",
+     "y": "..."
+   }
+   ```
+
+   This private key will be used to sign whatever JWTs are relevant to the CLI tool being used.
+   So using `verifgen presentation`, this key will be used to sign the presentation.
+   And using `verifgen proof`, this key will be used to sign the proof.
+   And same goes for other instances where the `-p <persona>` option is specified.

--- a/tools/verifgen/package.json
+++ b/tools/verifgen/package.json
@@ -40,7 +40,6 @@
     "@verii/jwt": "workspace:*",
     "@verii/verii-verification": "workspace:*",
     "@verii/vc-checks": "workspace:*",
-    "bs58": "^6.0.0",
     "chalk": "~5.6.2",
     "commander": "~14.0.3",
     "lodash": "^4.18.1",

--- a/tools/verifgen/src/common.js
+++ b/tools/verifgen/src/common.js
@@ -1,10 +1,9 @@
 const console = require('console');
 const chalkModule = require('chalk');
 const fs = require('fs');
-const { default: bs58 } = require('bs58');
 const path = require('path');
 const { getOr } = require('lodash/fp');
-const { generateKeyPair } = require('@verii/crypto');
+const { generateKeyPair, hexFromJwk } = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 const { generateProof } = require('@verii/did-doc');
 
@@ -43,12 +42,18 @@ const resolveInputPath = (filePath) => {
 
 const printError = (ex) => console.error(ex);
 const printInfo = (data) => console.info(data);
+const stringifyJson = (value) => JSON.stringify(value, null, 2);
+
+const toProofSigningKey = (privateKey) =>
+  privateKey?.d == null ? privateKey : hexFromJwk(privateKey);
 
 const generateDid = (controller = {}) => {
-  const { privateKey, publicKey } = generateKeyPair();
+  const { privateKey, publicKey } = generateKeyPair({ format: 'jwk' });
   const address = toEthereumAddress(publicKey);
   const did = `did:velocity:${address}`;
-  const proofSigningKey = getOr(privateKey, 'privateKey', controller);
+  const proofSigningKey = toProofSigningKey(
+    getOr(privateKey, 'privateKey', controller),
+  );
   const proofController = getOr(did, 'did.id', controller);
   const didObject = {
     '@context': [
@@ -59,9 +64,9 @@ const generateDid = (controller = {}) => {
     publicKey: [
       {
         id: `${did}#key-1`,
-        type: 'EcdsaSecp256k1VerificationKey2019',
+        type: 'JsonWebKey2020',
         controller: did,
-        publicKeyBase58: bs58.encode(Buffer.from(publicKey, 'hex')),
+        publicKeyJwk: publicKey,
       },
     ],
     created: new Date().toISOString(),
@@ -93,12 +98,8 @@ const loadPersonaFiles = (persona) => {
 const loadPersonaPrivateKey = (persona) => {
   const missingErrorMessage = `Persona ${persona}  private key file not found`;
   const jwkFilePath = resolveInputPath(`${persona}.prv.key.json`);
-  const filePath = resolveInputPath(`${persona}.prv.key`);
-  if (fs.existsSync(jwkFilePath)) {
-    const jsonStr = readFile(jwkFilePath, missingErrorMessage);
-    return JSON.parse(jsonStr);
-  }
-  return readFile(filePath, missingErrorMessage);
+  const jsonStr = readFile(jwkFilePath, missingErrorMessage);
+  return JSON.parse(jsonStr);
 };
 
 module.exports = {
@@ -113,4 +114,5 @@ module.exports = {
   dataPath,
   resolveDataPath,
   resolveInputPath,
+  stringifyJson,
 };

--- a/tools/verifgen/src/common.js
+++ b/tools/verifgen/src/common.js
@@ -3,7 +3,7 @@ const chalkModule = require('chalk');
 const fs = require('fs');
 const path = require('path');
 const { getOr } = require('lodash/fp');
-const { generateKeyPair, hexFromJwk } = require('@verii/crypto');
+const { generateKeyPair } = require('@verii/crypto');
 const { toEthereumAddress } = require('@verii/blockchain-functions');
 const { generateProof } = require('@verii/did-doc');
 
@@ -44,16 +44,11 @@ const printError = (ex) => console.error(ex);
 const printInfo = (data) => console.info(data);
 const stringifyJson = (value) => JSON.stringify(value, null, 2);
 
-const toProofSigningKey = (privateKey) =>
-  privateKey?.d == null ? privateKey : hexFromJwk(privateKey);
-
 const generateDid = (controller = {}) => {
   const { privateKey, publicKey } = generateKeyPair({ format: 'jwk' });
   const address = toEthereumAddress(publicKey);
   const did = `did:velocity:${address}`;
-  const proofSigningKey = toProofSigningKey(
-    getOr(privateKey, 'privateKey', controller),
-  );
+  const proofSigningKey = getOr(privateKey, 'privateKey', controller);
   const proofController = getOr(did, 'did.id', controller);
   const didObject = {
     '@context': [
@@ -75,7 +70,6 @@ const generateDid = (controller = {}) => {
 
   didObject.proof = generateProof(
     didObject,
-    proofController,
     proofSigningKey,
     `${proofController}#key-1`,
   );

--- a/tools/verifgen/src/verifgen-address.js
+++ b/tools/verifgen/src/verifgen-address.js
@@ -4,7 +4,9 @@ const common = require('./common');
 
 const generateAddress = (publicKeyFile, addressFile) => {
   try {
-    const publicKey = common.readFile(publicKeyFile, 'Public key not found');
+    const publicKey = JSON.parse(
+      common.readFile(publicKeyFile, 'Public key not found'),
+    );
     const address = toEthereumAddress(publicKey);
 
     common.writeFile(addressFile, address);
@@ -20,7 +22,7 @@ program
   .option(
     '-b, --public-key-file <filename>',
     'Input public key file name',
-    'pub.key',
+    'pub.key.json',
   )
   .option(
     '-a, --address-file <filename>',

--- a/tools/verifgen/src/verifgen-did.js
+++ b/tools/verifgen/src/verifgen-did.js
@@ -8,10 +8,10 @@ const generateDidFiles = ({ persona, controllerPersona }) => {
       : null;
 
     const { privateKey, didObject } = common.generateDid(controller);
-    const privateKeyFileName = `${persona}.prv.key`;
+    const privateKeyFileName = `${persona}.prv.key.json`;
     const didFileName = `${persona}.did`;
 
-    common.writeFile(privateKeyFileName, privateKey);
+    common.writeFile(privateKeyFileName, common.stringifyJson(privateKey));
     common.writeFile(didFileName, JSON.stringify(didObject, null, 2));
   } catch (ex) {
     common.printError(ex);

--- a/tools/verifgen/src/verifgen-keys.js
+++ b/tools/verifgen/src/verifgen-keys.js
@@ -4,10 +4,10 @@ const common = require('./common');
 
 const generateKeys = (publicKeyFile, privateKeyFile) => {
   try {
-    const { privateKey, publicKey } = generateKeyPair();
+    const { privateKey, publicKey } = generateKeyPair({ format: 'jwk' });
 
-    common.writeFile(publicKeyFile, publicKey);
-    common.writeFile(privateKeyFile, privateKey);
+    common.writeFile(publicKeyFile, common.stringifyJson(publicKey));
+    common.writeFile(privateKeyFile, common.stringifyJson(privateKey));
   } catch (ex) {
     common.printError(ex);
   }
@@ -20,12 +20,12 @@ program
   .option(
     '-b, --public-key-file <filename>',
     'Output public key file name',
-    'pub.key',
+    'pub.key.json',
   )
   .option(
     '-v, --private-key-file <filename>',
     'Output private key file name',
-    'prv.key',
+    'prv.key.json',
   )
   .action(() => {
     const options = program.opts();

--- a/tools/verifgen/src/verifgen-presentation.js
+++ b/tools/verifgen/src/verifgen-presentation.js
@@ -1,7 +1,7 @@
 const { program } = require('commander');
 const { map, isEmpty } = require('lodash/fp');
 const { nanoid } = require('nanoid');
-const { generatePresentationJwt, toJwk } = require('@verii/jwt');
+const { generatePresentationJwt } = require('@verii/jwt');
 const { mapWithIndex } = require('@verii/common-functions');
 const { generateKeyPair, publicKeyFromPrivateKey } = require('@verii/crypto');
 const { getDidUriFromJwk } = require('@verii/did-doc');
@@ -99,7 +99,7 @@ const getIssuer = ({ issuer, protocolVersion }) => {
   }
 
   const publicKey = publicKeyFromPrivateKey(issuer?.privateKey);
-  return getDidUriFromJwk(toJwk(publicKey, false));
+  return getDidUriFromJwk(publicKey);
 };
 
 const loadIssuerData = (issuerPersona) => {

--- a/tools/verifgen/src/verifgen-proof/generate-proof.js
+++ b/tools/verifgen/src/verifgen-proof/generate-proof.js
@@ -1,6 +1,6 @@
 const { isEmpty } = require('lodash/fp');
 const { publicKeyFromPrivateKey } = require('@verii/crypto');
-const { jwtSign, toJwk } = require('@verii/jwt');
+const { jwtSign } = require('@verii/jwt');
 const { getDidUriFromJwk } = require('@verii/did-doc');
 const common = require('../common');
 
@@ -42,10 +42,10 @@ const loadNonce = (options) => {
 };
 
 const buildProofJwt = async ({ nonce, keyPair, typ, options }) => {
-  const kid = getDidUriFromJwk(toJwk(keyPair.publicKey, false));
+  const kid = getDidUriFromJwk(keyPair.publicKey);
   const jwt = await jwtSign(
     { aud: options.audience, nonce, iss: kid },
-    toJwk(keyPair.privateKey),
+    keyPair.privateKey,
     {
       kid: `${kid}#0`,
       typ,

--- a/tools/verifgen/src/verifgen-proof/verifgen-proof.js
+++ b/tools/verifgen/src/verifgen-proof/verifgen-proof.js
@@ -22,7 +22,7 @@ program
   )
   .requiredOption(
     '-p, --persona <persona>',
-    'The persona that will sign the proof. Must be hex format.',
+    'The persona that will sign the proof. Must be JWK format.',
   )
   .action(() => {
     const options = program.opts();

--- a/tools/verifgen/test/proof.test.js
+++ b/tools/verifgen/test/proof.test.js
@@ -5,17 +5,12 @@ const fs = require('fs').promises;
 const os = require('os');
 const path = require('path');
 
-const { generateKeyPair, jwkFromSecp256k1Key } = require('@verii/crypto');
+const { generateKeyPair } = require('@verii/crypto');
 const { jwtVerify } = require('@verii/jwt');
 const { getDidUriFromJwk } = require('@verii/did-doc');
 const { generateProof } = require('../src/verifgen-proof/generate-proof');
 
-const createPersona = async (testDir, name, body) => {
-  await fs.writeFile(path.join(testDir, `${name}.prv.key`), body);
-  await fs.writeFile(path.join(testDir, `${name}.did`), JSON.stringify({}));
-};
-
-const createJwkPersona = async (testDir, name, privateKey) => {
+const createPersona = async (testDir, name, privateKey) => {
   await fs.writeFile(
     path.join(testDir, `${name}.prv.key.json`),
     JSON.stringify(privateKey),
@@ -32,7 +27,7 @@ describe('Test proof cli tool', () => {
     originalCwd = process.cwd();
     testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'verifgen-proof-test-'));
     process.chdir(testDir);
-    keyPair = await generateKeyPair();
+    keyPair = await generateKeyPair({ format: 'jwk' });
     await createPersona(testDir, 'persona1', keyPair.privateKey);
   });
 
@@ -51,8 +46,7 @@ describe('Test proof cli tool', () => {
     ).rejects.toThrow('Persona not-exist DID File not found');
   });
 
-  it('should generate a proof by a prv.key', async () => {
-    JSON.stringify(keyPair.privateKey);
+  it('should generate a proof by the default prv.key.json persona', async () => {
     const proof = await generateProof({
       challenge: 'abc',
       persona: 'persona1',
@@ -62,13 +56,8 @@ describe('Test proof cli tool', () => {
     await expect(
       fs.access(path.join(testDir, 'proof.jwt')),
     ).resolves.toBeUndefined();
-    const parsedJwt = await jwtVerify(
-      proof,
-      jwkFromSecp256k1Key(keyPair.publicKey, false),
-    );
-    const expectedKid = getDidUriFromJwk(
-      jwkFromSecp256k1Key(keyPair.publicKey, false),
-    );
+    const parsedJwt = await jwtVerify(proof, keyPair.publicKey);
+    const expectedKid = getDidUriFromJwk(keyPair.publicKey);
     expect(parsedJwt).toStrictEqual({
       header: {
         alg: 'ES256K',
@@ -86,7 +75,7 @@ describe('Test proof cli tool', () => {
 
   it('should generate a proof by a prv.key.json', async () => {
     const persona2Keypair = await generateKeyPair({ format: 'jwk' });
-    await createJwkPersona(testDir, 'persona2', persona2Keypair.privateKey);
+    await createPersona(testDir, 'persona2', persona2Keypair.privateKey);
     const proof = await generateProof({
       challenge: 'abc',
       persona: 'persona2',
@@ -112,7 +101,7 @@ describe('Test proof cli tool', () => {
 
   it('should generate an openid4vci proof by a prv.key.json', async () => {
     const persona2Keypair = await generateKeyPair({ format: 'jwk' });
-    await createJwkPersona(testDir, 'persona2', persona2Keypair.privateKey);
+    await createPersona(testDir, 'persona2', persona2Keypair.privateKey);
     const proof = await generateProof({
       challenge: 'abc',
       persona: 'persona2',

--- a/tools/verifgen/test/proof.test.js
+++ b/tools/verifgen/test/proof.test.js
@@ -18,7 +18,7 @@ const createPersona = async (testDir, name, privateKey) => {
   await fs.writeFile(path.join(testDir, `${name}.did`), JSON.stringify({}));
 };
 
-describe('Test proof cli tool', () => {
+describe('proof cli tool', () => {
   let keyPair;
   let originalCwd;
   let testDir;
@@ -46,7 +46,7 @@ describe('Test proof cli tool', () => {
     ).rejects.toThrow('Persona not-exist DID File not found');
   });
 
-  it('should generate a proof by the default prv.key.json persona', async () => {
+  it('should generate a proof using the default persona private JWK', async () => {
     const proof = await generateProof({
       challenge: 'abc',
       persona: 'persona1',
@@ -73,17 +73,17 @@ describe('Test proof cli tool', () => {
     });
   });
 
-  it('should generate a proof by a prv.key.json', async () => {
-    const persona2Keypair = await generateKeyPair({ format: 'jwk' });
-    await createPersona(testDir, 'persona2', persona2Keypair.privateKey);
+  it('should generate a proof using a named persona private JWK', async () => {
+    const persona2KeyPair = await generateKeyPair({ format: 'jwk' });
+    await createPersona(testDir, 'persona2', persona2KeyPair.privateKey);
     const proof = await generateProof({
       challenge: 'abc',
       persona: 'persona2',
       audience: 'http://test.com',
     });
     expect(proof).toBeDefined();
-    const parsedJwt = await jwtVerify(proof, persona2Keypair.publicKey);
-    const expectedKid = getDidUriFromJwk(persona2Keypair.publicKey);
+    const parsedJwt = await jwtVerify(proof, persona2KeyPair.publicKey);
+    const expectedKid = getDidUriFromJwk(persona2KeyPair.publicKey);
     expect(parsedJwt).toStrictEqual({
       header: {
         alg: 'ES256K',
@@ -99,9 +99,9 @@ describe('Test proof cli tool', () => {
     });
   });
 
-  it('should generate an openid4vci proof by a prv.key.json', async () => {
-    const persona2Keypair = await generateKeyPair({ format: 'jwk' });
-    await createPersona(testDir, 'persona2', persona2Keypair.privateKey);
+  it('should generate an OpenID4VCI proof using a named persona private JWK', async () => {
+    const persona2KeyPair = await generateKeyPair({ format: 'jwk' });
+    await createPersona(testDir, 'persona2', persona2KeyPair.privateKey);
     const proof = await generateProof({
       challenge: 'abc',
       persona: 'persona2',
@@ -109,8 +109,8 @@ describe('Test proof cli tool', () => {
       openid4vci: true,
     });
     expect(proof).toBeDefined();
-    const parsedJwt = await jwtVerify(proof, persona2Keypair.publicKey);
-    const expectedKid = getDidUriFromJwk(persona2Keypair.publicKey);
+    const parsedJwt = await jwtVerify(proof, persona2KeyPair.publicKey);
+    const expectedKid = getDidUriFromJwk(persona2KeyPair.publicKey);
     expect(parsedJwt).toStrictEqual({
       header: {
         alg: 'ES256K',


### PR DESCRIPTION
## Summary

- Adds ethers-backed `generateAccount()` and `generateDisposablePrivateKey()` in `@verii/blockchain-functions`.
- Allows base contract clients to accept private JWKs or hex strings at the package boundary and normalizes them for ethers.
- Updates blockchain package callers to pass private JWKs directly and removes the dual-format test helper.
- Cleans up review feedback around account generation, nonce generation, DID docs, and unnecessary local fixtures.

## Validation

- `corepack $(node -p "require('./package.json').packageManager") exec eslint --fix $(git diff --name-only --diff-filter=ACMRT -- '*.js')`
- `@verii/blockchain-functions test`
- `@verii/did-doc test`
- `@verii/crypto test`
- `@verii/jwt test`
- `@verii/vc-checks test`
- `@verii/verii-verification test`
- `@verii/verifgen test`
- `@verii/contract-permissions test`
- full `@verii/endpoints-organizations-registrar test`
- targeted base-contract-io, credentialagent, credentialinghub tests
- targeted metadata-registration files with `--test-skip-pattern="Should pull"`: 78 passed, 0 failed

Note: full metadata-registration was not run because the local event-pull tests are known to fail in this environment.