### PR TITLE
fix: authenticate CIH e2e GHCR pulls

### DIFF
--- a/.github/workflows/node-ci-e2e-cih.workflow.yml
+++ b/.github/workflows/node-ci-e2e-cih.workflow.yml
@@ -67,9 +67,16 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Log in to GHCR
-        run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: |
+          if [ -z "$GHCR_READ_USER" ] || [ -z "$GHCR_READ_TOKEN" ]; then
+            echo "::error::GHCR_READ_USER and GHCR_READ_TOKEN secrets are required to pull the Fineract image"
+            exit 1
+          fi
+
+          echo "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_READ_USER" --password-stdin
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GHCR_READ_USER: ${{ secrets.GHCR_READ_USER }}
+          GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
 
       - name: Start Containers
         run: docker compose -f "$COMPOSE_FILE" up -d --build

--- a/.github/workflows/node-ci-e2e-cih.workflow.yml
+++ b/.github/workflows/node-ci-e2e-cih.workflow.yml
@@ -66,6 +66,11 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
+      - name: Log in to GHCR
+        run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
       - name: Start Containers
         run: docker compose -f "$COMPOSE_FILE" up -d --build
 

--- a/eng/docker/Dockerfile-NodeE2E
+++ b/eng/docker/Dockerfile-NodeE2E
@@ -14,7 +14,7 @@ RUN apt-get update \
 
 USER node
 
-COPY --chown=node:node package*.json pnpm-lock.yaml pnpm-workspace.yaml lerna.json ./
+COPY --chown=node:node package*.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --chown=node:node .husky ./.husky
 COPY --chown=node:node packages ./packages
 COPY --chown=node:node servers ./servers


### PR DESCRIPTION
## Summary
- add a GHCR Docker login step to the CIH E2E workflow before `docker compose up`
- use `GHCR_READ_USER` and `GHCR_READ_TOKEN` repository secrets for the cross-org Fineract image pull
- fail early with a clear error if those secrets are missing
- remove stale `lerna.json` from the E2E Dockerfile COPY list after the Nx release migration removed that file

## Root cause
CIH E2E initially failed before tests started because Docker could not pull `ghcr.io/velocitynetworkfoundation/fineract:dev` from the GitHub runner. The built-in `GITHUB_TOKEN` can authenticate to GHCR, but it is not authorized to read the cross-org `velocitynetworkfoundation/fineract` package.

After switching to the GHCR read secrets, CI got past the Fineract pull and exposed a separate Docker build failure: `eng/docker/Dockerfile-NodeE2E` still copied `lerna.json`, which no longer exists in the repo.

## Validation
- `actionlint .github/workflows/node-ci-e2e-cih.workflow.yml`
- `git diff --check`
- targeted guard confirmed `Log in to GHCR` uses `secrets.GHCR_READ_USER` and `secrets.GHCR_READ_TOKEN`
- targeted guard confirmed `Dockerfile-NodeE2E` no longer references missing `lerna.json`
- CIH E2E manual run passed: https://github.com/LFDT-Verii/core/actions/runs/28628794670

## Notes
`GHCR_READ_USER` and `GHCR_READ_TOKEN` are required repository secrets. The token should be a read-only package token from an account that can pull `ghcr.io/velocitynetworkfoundation/fineract:dev`.