### PR TITLE
feat(registrar): support unapproved service searches

### DIFF
--- a/packages/endpoints-organizations-registrar/src/controllers/organizations/controller.js
+++ b/packages/endpoints-organizations-registrar/src/controllers/organizations/controller.js
@@ -11,7 +11,6 @@ const {
 } = require('lodash/fp');
 const newError = require('http-errors');
 const { prepCamelCase } = require('@verii/common-functions');
-const { ServiceCategories } = require('@verii/organizations-registry');
 const {
   buildDidDocWithAlternativeId,
   getDidAndAliases,
@@ -44,21 +43,6 @@ const custodiedFinder = (existingFinder) => ({
     didNotCustodied: { $ne: true },
   },
 });
-
-const validateUnapprovedServiceSearch = (query) => {
-  if (!query.includeUnapprovedServices) {
-    return;
-  }
-  const serviceCategories = query.filter?.serviceTypes;
-  if (
-    serviceCategories?.length !== 1 ||
-    serviceCategories[0] !== ServiceCategories.HolderAppProvider
-  ) {
-    throw newError.BadRequest(
-      'Unapproved service search is only available for Holder App Providers.',
-    );
-  }
-};
 
 const organizationController = async (fastify) => {
   const prepareProfileVc = initPrepareProfileVc(fastify);
@@ -102,7 +86,6 @@ const organizationController = async (fastify) => {
       },
       async (req) => {
         const { repos, query } = req;
-        validateUnapprovedServiceSearch(query);
         const serviceTypes = getServiceTypesFromCategories(query);
 
         let organizations =

--- a/packages/endpoints-organizations-registrar/src/controllers/organizations/controller.js
+++ b/packages/endpoints-organizations-registrar/src/controllers/organizations/controller.js
@@ -11,6 +11,7 @@ const {
 } = require('lodash/fp');
 const newError = require('http-errors');
 const { prepCamelCase } = require('@verii/common-functions');
+const { ServiceCategories } = require('@verii/organizations-registry');
 const {
   buildDidDocWithAlternativeId,
   getDidAndAliases,
@@ -43,6 +44,21 @@ const custodiedFinder = (existingFinder) => ({
     didNotCustodied: { $ne: true },
   },
 });
+
+const validateUnapprovedServiceSearch = (query) => {
+  if (!query.includeUnapprovedServices) {
+    return;
+  }
+  const serviceCategories = query.filter?.serviceTypes;
+  if (
+    serviceCategories?.length !== 1 ||
+    serviceCategories[0] !== ServiceCategories.HolderAppProvider
+  ) {
+    throw newError.BadRequest(
+      'Unapproved service search is only available for Holder App Providers.',
+    );
+  }
+};
 
 const organizationController = async (fastify) => {
   const prepareProfileVc = initPrepareProfileVc(fastify);
@@ -86,6 +102,7 @@ const organizationController = async (fastify) => {
       },
       async (req) => {
         const { repos, query } = req;
+        validateUnapprovedServiceSearch(query);
         const serviceTypes = getServiceTypesFromCategories(query);
 
         let organizations =

--- a/packages/endpoints-organizations-registrar/src/controllers/organizations/schemas/organization.search-profile.query-params.schema.json
+++ b/packages/endpoints-organizations-registrar/src/controllers/organizations/schemas/organization.search-profile.query-params.schema.json
@@ -44,6 +44,10 @@
     "no-service-endpoint-transform": {
       "type": "string",
       "enum": ["1", "true"]
+    },
+    "include-unapproved-services": {
+      "type": "string",
+      "enum": ["1", "true"]
     }
   },
   "additionalProperties": false

--- a/packages/endpoints-organizations-registrar/src/entities/organization-services/domains/transform-profile-service.js
+++ b/packages/endpoints-organizations-registrar/src/entities/organization-services/domains/transform-profile-service.js
@@ -38,10 +38,21 @@ const transformProfileService = (
   caoServiceRefs,
   { query },
 ) => {
-  const pipeline = [
-    buildPublicServices,
-    filter((service) => includes(service.id, organization.activatedServiceIds)),
-  ];
+  const pipeline = [buildPublicServices];
+  if (query.includeUnapprovedServices) {
+    pipeline.push(
+      map((service) => ({
+        ...service,
+        approved: includes(service.id, organization.activatedServiceIds),
+      })),
+    );
+  } else {
+    pipeline.push(
+      filter((service) =>
+        includes(service.id, organization.activatedServiceIds),
+      ),
+    );
+  }
   if (!isEmpty(serviceTypes)) {
     pipeline.push(filter((service) => includes(service.type, serviceTypes)));
   }

--- a/packages/endpoints-organizations-registrar/src/entities/organizations/repos/search-by-aggregation-extension.js
+++ b/packages/endpoints-organizations-registrar/src/entities/organizations/repos/search-by-aggregation-extension.js
@@ -38,7 +38,12 @@ const searchByAggregationExtension = (parent) => ({
     aggregationPipeline.push(matchStage);
 
     if (serviceTypes) {
-      aggregationPipeline.push(buildServiceAggregationStage(serviceTypes));
+      aggregationPipeline.push(
+        buildServiceAggregationStage(
+          serviceTypes,
+          input.includeUnapprovedServices,
+        ),
+      );
       aggregationPipeline.push({
         $match: {
           services: { $type: 'array', $ne: [] },
@@ -64,7 +69,10 @@ const transformIdFilter = (input) =>
         'didDoc.id': { $in: input.filter.did },
       });
 
-const buildServiceAggregationStage = (serviceTypes) => {
+const buildServiceAggregationStage = (
+  serviceTypes,
+  includeUnapprovedServices,
+) => {
   const [issuerServiceTypes, nonIssuerServiceTypes] = partition(
     (s) => ISSUER_SERVICE_TYPES.includes(s),
     serviceTypes,
@@ -88,9 +96,13 @@ const buildServiceAggregationStage = (serviceTypes) => {
                   [...issuerServiceTypes, ...nonIssuerServiceTypes],
                 ],
               },
-              {
-                $in: ['$$itemService.id', '$activatedServiceIds'],
-              },
+              ...(includeUnapprovedServices
+                ? []
+                : [
+                    {
+                      $in: ['$$itemService.id', '$activatedServiceIds'],
+                    },
+                  ]),
             ],
           },
         },

--- a/packages/endpoints-organizations-registrar/test/search-organizations-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/search-organizations-controller.test.js
@@ -924,11 +924,11 @@ describe('Organizations Test Suite', () => {
         });
       });
 
-      it('Should return a list with matching "filter.serviceTypes" and only activated services', async () => {
+      it('Should include unapproved services for any requested service type only when explicitly requested', async () => {
         const service = [
           {
-            id: '#identityIssuer-1',
-            type: ServiceTypes.IdDocumentIssuerType,
+            id: '#careerIssuer-1',
+            type: ServiceTypes.CareerIssuerType,
             serviceEndpoint: 'https://node.example.com',
           },
           {
@@ -942,13 +942,17 @@ describe('Organizations Test Suite', () => {
           service,
           activatedServiceIds: ['#careerIssuer-2'],
         });
-        const response = await fastify.injectJson({
+        const defaultResponse = await fastify.injectJson({
           method: 'GET',
           url: `${baseUrl}/search-profiles?filter.serviceTypes=Issuer`,
         });
+        const unapprovedResponse = await fastify.injectJson({
+          method: 'GET',
+          url: `${baseUrl}/search-profiles?filter.serviceTypes=Issuer&include-unapproved-services=true`,
+        });
 
-        expect(response.statusCode).toEqual(200);
-        expect(response.json).toEqual({
+        expect(defaultResponse.statusCode).toEqual(200);
+        expect(defaultResponse.json).toEqual({
           result: map(
             (_org) =>
               searchResult(_org, servicesByOrg[_org.didDoc.id] || [service[1]]),
@@ -962,78 +966,16 @@ describe('Organizations Test Suite', () => {
             ],
           ),
         });
-      });
-
-      it('Should mark activated holder services as approved when unapproved services are requested', async () => {
-        const response = await fastify.injectJson({
-          method: 'GET',
-          url: `${baseUrl}/search-profiles?q=Organization01&filter.serviceTypes=HolderAppProvider&include-unapproved-services=true`,
-        });
-
-        expect(response.statusCode).toEqual(200);
-        expect(response.json).toEqual({
-          result: [
-            {
-              ...omit(
-                ['alsoKnownAs'],
-                searchResult(orgs[3], servicesByOrg[orgs[3].didDoc.id]),
-              ),
-              service: [
-                {
-                  ...buildPublicService(servicesByOrg[orgs[3].didDoc.id][0]),
-                  approved: true,
-                },
-              ],
-            },
-          ],
-        });
-      });
-
-      it('Should return awaiting-approval holder services only when explicitly requested', async () => {
-        await mongoDb()
-          .collection('organizations')
-          .updateOne(
-            { 'didDoc.id': orgs[3].didDoc.id },
-            { $set: { activatedServiceIds: [] } },
-          );
-
-        const defaultResponse = await fastify.injectJson({
-          method: 'GET',
-          url: `${baseUrl}/search-profiles?q=Organization01&filter.serviceTypes=HolderAppProvider`,
-        });
-        const pendingResponse = await fastify.injectJson({
-          method: 'GET',
-          url: `${baseUrl}/search-profiles?q=Organization01&filter.serviceTypes=HolderAppProvider&include-unapproved-services=1`,
-        });
-
-        expect(defaultResponse.statusCode).toEqual(200);
-        expect(defaultResponse.json).toEqual({ result: [] });
-        expect(pendingResponse.statusCode).toEqual(200);
-        expect(pendingResponse.json).toEqual({
-          result: [
-            {
-              ...omit(
-                ['alsoKnownAs'],
-                searchResult(orgs[3], servicesByOrg[orgs[3].didDoc.id]),
-              ),
-              service: [
-                {
-                  ...buildPublicService(servicesByOrg[orgs[3].didDoc.id][0]),
-                  approved: false,
-                },
-              ],
-            },
-          ],
-        });
-      });
-
-      it('Should reject unapproved service searches outside the Holder App Provider category', async () => {
-        const response = await fastify.injectJson({
-          method: 'GET',
-          url: `${baseUrl}/search-profiles?filter.serviceTypes=Issuer&include-unapproved-services=true`,
-        });
-
-        expect(response.statusCode).toEqual(400);
+        expect(unapprovedResponse.statusCode).toEqual(200);
+        const organization = unapprovedResponse.json.result.find(
+          ({ id }) => id === org.didDoc.id,
+        );
+        expect(
+          map(({ id, approved }) => ({ id, approved }), organization.service),
+        ).toEqual([
+          { id: '#careerIssuer-1', approved: false },
+          { id: '#careerIssuer-2', approved: true },
+        ]);
       });
 
       it('Should not return a list with an items when provided "filter.serviceTypes" param is not match with eatch item', async () => {

--- a/packages/endpoints-organizations-registrar/test/search-organizations-controller.test.js
+++ b/packages/endpoints-organizations-registrar/test/search-organizations-controller.test.js
@@ -964,6 +964,78 @@ describe('Organizations Test Suite', () => {
         });
       });
 
+      it('Should mark activated holder services as approved when unapproved services are requested', async () => {
+        const response = await fastify.injectJson({
+          method: 'GET',
+          url: `${baseUrl}/search-profiles?q=Organization01&filter.serviceTypes=HolderAppProvider&include-unapproved-services=true`,
+        });
+
+        expect(response.statusCode).toEqual(200);
+        expect(response.json).toEqual({
+          result: [
+            {
+              ...omit(
+                ['alsoKnownAs'],
+                searchResult(orgs[3], servicesByOrg[orgs[3].didDoc.id]),
+              ),
+              service: [
+                {
+                  ...buildPublicService(servicesByOrg[orgs[3].didDoc.id][0]),
+                  approved: true,
+                },
+              ],
+            },
+          ],
+        });
+      });
+
+      it('Should return awaiting-approval holder services only when explicitly requested', async () => {
+        await mongoDb()
+          .collection('organizations')
+          .updateOne(
+            { 'didDoc.id': orgs[3].didDoc.id },
+            { $set: { activatedServiceIds: [] } },
+          );
+
+        const defaultResponse = await fastify.injectJson({
+          method: 'GET',
+          url: `${baseUrl}/search-profiles?q=Organization01&filter.serviceTypes=HolderAppProvider`,
+        });
+        const pendingResponse = await fastify.injectJson({
+          method: 'GET',
+          url: `${baseUrl}/search-profiles?q=Organization01&filter.serviceTypes=HolderAppProvider&include-unapproved-services=1`,
+        });
+
+        expect(defaultResponse.statusCode).toEqual(200);
+        expect(defaultResponse.json).toEqual({ result: [] });
+        expect(pendingResponse.statusCode).toEqual(200);
+        expect(pendingResponse.json).toEqual({
+          result: [
+            {
+              ...omit(
+                ['alsoKnownAs'],
+                searchResult(orgs[3], servicesByOrg[orgs[3].didDoc.id]),
+              ),
+              service: [
+                {
+                  ...buildPublicService(servicesByOrg[orgs[3].didDoc.id][0]),
+                  approved: false,
+                },
+              ],
+            },
+          ],
+        });
+      });
+
+      it('Should reject unapproved service searches outside the Holder App Provider category', async () => {
+        const response = await fastify.injectJson({
+          method: 'GET',
+          url: `${baseUrl}/search-profiles?filter.serviceTypes=Issuer&include-unapproved-services=true`,
+        });
+
+        expect(response.statusCode).toEqual(400);
+      });
+
       it('Should not return a list with an items when provided "filter.serviceTypes" param is not match with eatch item', async () => {
         const response = await fastify.injectJson({
           method: 'GET',


### PR DESCRIPTION
## Summary

- add an opt-in `include-unapproved-services` profile-search parameter for every service category
- include non-activated services in the search aggregation only when explicitly requested
- add an `approved` boolean to returned services while preserving the existing activated-only default
- consolidate the endpoint coverage into one test that verifies default filtering plus approved and unapproved results for a non-wallet service category

## Why

Consumers involved in service onboarding and approval need to find services before activation, regardless of service type.

## Impact

Existing Registrar consumers keep the current activated-services-only behavior. Any profile search can explicitly include awaiting-approval services, and each returned service indicates its approval state.

## Companion change

- Consumed by velocitycareerlabs/monorepo#11923.

## Validation

- focused public-endpoint integration test
- full `@verii/endpoints-organizations-registrar` test suite
- `@verii/endpoints-organizations-registrar` lint
