### PR TITLE
chore(deps): remove redundant jsdom undici override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ overrides:
   mocha>serialize-javascript: 7.0.7
   auth0>uuid: 14.0.1
   eslint-plugin-better-mutation>lodash: 4.18.1
-  jsdom>undici: 7.29.0
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,9 +11,6 @@ overrides:
   # Temporary: remove this override once eslint-plugin-better-mutation stops
   # pinning lodash 4.17.x.
   "eslint-plugin-better-mutation>lodash": "4.18.1"
-  # Temporary: remove this override once jsdom publishes a release that depends
-  # on patched undici instead of 7.25.0.
-  "jsdom>undici": "7.29.0"
 onlyBuiltDependencies:
   - "@sentry/profiling-node"
   - "@swc/core"


### PR DESCRIPTION
## Summary
- remove the redundant `jsdom>undici` pnpm override
- regenerate the lockfile without changing the resolved dependency graph

## Why
`jsdom@29.1.1` declares `undici ^7.25.0`, so pnpm naturally resolves the existing patched `undici@7.29.0` without an override.

## Validation
- `pnpm install --lockfile-only --no-frozen-lockfile`
- `pnpm install --frozen-lockfile`
- verified `pnpm why undici` resolves `jsdom@29.1.1` to `undici@7.29.0`
- confirmed the diff contains only four deleted override lines