### PR TITLE
feat(credentialinghub): support pluggable operator authentication

### DIFF
--- a/packages/base-contract-io/README.md
+++ b/packages/base-contract-io/README.md
@@ -1,1 +1,37 @@
-hi
+# `@verii/base-contract-io`
+
+## VNF client credential resolution
+
+The VNF authentication plugin decorates Fastify with
+`resolveVnfClientCredentials(request)`. Applications can install this
+decorator before registering `authenticateVnfClientPlugin` to select VNF
+credentials for each request.
+
+A resolver returns credential metadata and a lazy credential loader:
+
+```js
+fastify.decorate('resolveVnfClientCredentials', async (request) => ({
+  cacheKey: `tenant:${request.tenantId}:version:2`,
+  loadCredentials: async () => ({
+    clientId: await readClientId(request.tenantId),
+    clientSecret: await readClientSecret(request.tenantId),
+  }),
+}));
+```
+
+`cacheKey` must be a non-empty, stable, non-secret string that changes whenever
+the selected credential pair changes. Do not include a client secret, a digest
+of a client secret, or any value derived from a client secret. Tokens are
+cached by both their audience and this resolver cache key.
+
+The plugin calls the resolver on every authentication so that an application
+can select the current credential version. It invokes `loadCredentials` only
+when there is no live token for the resulting audience and cache key. This
+allows credential stores such as KMS to remain untouched on token-cache hits.
+
+If an application does not install a resolver, the plugin installs a default
+one backed by `fastify.config.vnfClientId` and
+`fastify.config.vnfClientSecret`. Both values are required when the plugin
+starts in this mode. A custom resolver is preserved as-is: if it rejects, the
+authentication rejects and the plugin does not fall back to the configured
+credentials.

--- a/packages/base-contract-io/src/authenticate-vnf-client.js
+++ b/packages/base-contract-io/src/authenticate-vnf-client.js
@@ -21,52 +21,101 @@ const { initHttpClient } = require('@verii/http-client');
 
 const TOKEN_EXPIRATION_SAFE_BUFFER = 5;
 
-const isTokenCached = (tokensCache, audience) =>
-  tokensCache.get(audience) && tokensCache.get(audience).expiresAt > new Date();
+const buildTokenCacheKey = (audience, resolverCacheKey) =>
+  JSON.stringify([audience, resolverCacheKey]);
+
+const pruneExpiredTokens = (tokensCache) => {
+  const now = new Date();
+  for (const [key, token] of tokensCache) {
+    if (!(token.expiresAt > now)) {
+      tokensCache.delete(key);
+    }
+  }
+};
 
 const initAuthenticateVnfClient = (fastify) => {
-  return async ({ audience, clientId, clientSecret }, req) => {
-    const httpClient = initHttpClient(fastify.config)(req);
-
-    if (!isTokenCached(fastify.vnfAuthTokensCache, audience)) {
-      const response = await httpClient.post(
-        fastify.config.vnfOAuthTokensEndpoint,
-        {
-          grant_type: 'client_credentials',
-          client_id: clientId,
-          client_secret: clientSecret,
-          audience,
-        },
+  return async ({ audience, cacheKey, loadCredentials }, req) => {
+    if (typeof cacheKey !== 'string' || cacheKey.length === 0) {
+      throw new TypeError('VNF credential resolver cacheKey must be non-empty');
+    }
+    if (typeof loadCredentials !== 'function') {
+      throw new TypeError(
+        'VNF credential resolver loadCredentials must be a function',
       );
-
-      const authResult = await response.json();
-
-      fastify.vnfAuthTokensCache.set(audience, {
-        accessToken: authResult.access_token,
-        expiresAt: addSeconds(
-          authResult.expires_in - TOKEN_EXPIRATION_SAFE_BUFFER,
-          new Date(),
-        ),
-      });
     }
 
-    return fastify.vnfAuthTokensCache.get(audience).accessToken;
+    pruneExpiredTokens(fastify.vnfAuthTokensCache);
+    const tokenCacheKey = buildTokenCacheKey(audience, cacheKey);
+    const cachedToken = fastify.vnfAuthTokensCache.get(tokenCacheKey);
+
+    if (cachedToken) {
+      return cachedToken.accessToken;
+    }
+
+    const { clientId, clientSecret } = await loadCredentials();
+    const httpClient = initHttpClient(fastify.config)(req);
+    const response = await httpClient.post(
+      fastify.config.vnfOAuthTokensEndpoint,
+      {
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: clientSecret,
+        audience,
+      },
+    );
+    const authResult = await response.json();
+    const token = {
+      accessToken: authResult.access_token,
+      expiresAt: addSeconds(
+        authResult.expires_in - TOKEN_EXPIRATION_SAFE_BUFFER,
+        new Date(),
+      ),
+    };
+
+    fastify.vnfAuthTokensCache.set(tokenCacheKey, token);
+
+    return token.accessToken;
   };
 };
+
+const initDefaultVnfClientCredentialsResolver = (fastify) => async () => ({
+  cacheKey: `config:${fastify.config.vnfClientId}`,
+  loadCredentials: async () => ({
+    clientId: fastify.config.vnfClientId,
+    clientSecret: fastify.config.vnfClientSecret,
+  }),
+});
+
 const initAuthenticateVnfBlockchainClient = (fastify, req) => {
   const authenticateVnfClient = initAuthenticateVnfClient(fastify);
-  return () =>
-    authenticateVnfClient(
+  return async () => {
+    const resolution = await fastify.resolveVnfClientCredentials(req);
+
+    return authenticateVnfClient(
       {
         audience: fastify.config.blockchainApiAudience,
-        clientId: fastify.config.vnfClientId,
-        clientSecret: fastify.config.vnfClientSecret,
+        ...resolution,
       },
       req,
     );
+  };
 };
 
 const initAuthenticateVnfClientPlugin = (fastify, options, next) => {
+  if (!fastify.hasDecorator('resolveVnfClientCredentials')) {
+    if (!fastify.config.vnfClientId) {
+      throw new Error('fastify.config.vnfClientId is required');
+    }
+    if (!fastify.config.vnfClientSecret) {
+      throw new Error('fastify.config.vnfClientSecret is required');
+    }
+
+    fastify.decorate(
+      'resolveVnfClientCredentials',
+      initDefaultVnfClientCredentialsResolver(fastify),
+    );
+  }
+
   fastify
     .decorate('vnfAuthTokensCache', new Map())
     .decorateRequest('vnfBlockchainAuthenticate', null)

--- a/packages/base-contract-io/test/authenticate-vnf-client.test.js
+++ b/packages/base-contract-io/test/authenticate-vnf-client.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-const { mock, beforeEach, describe, it, after } = require('node:test');
+const { after, beforeEach, describe, it, mock } = require('node:test');
 const { expect } = require('expect');
 
 const initHttpClient = mock.fn();
@@ -22,128 +22,390 @@ mock.module('@verii/http-client', { namedExports: { initHttpClient } });
 
 const {
   initAuthenticateVnfClient,
-  initAuthenticateVnfBlockchainClient,
   initAuthenticateVnfClientPlugin,
 } = require('../src/authenticate-vnf-client');
 
-describe('VNF Identity Provider Authentication', () => {
-  const addHook2 = mock.fn(() => {});
-  const decorateRequest2 = mock.fn(() => ({ addHook: addHook2 }));
-  const addHook = mock.fn(() => ({ decorateRequest: decorateRequest2 }));
-  const decorateRequest = mock.fn(() => ({ addHook }));
-  const decorate = mock.fn(() => ({ decorateRequest }));
-  const createFastify = () => ({
-    config: {},
-    vnfAuthTokensCache: new Map(),
-    decorate,
-  });
-  const tokenResult = {
-    access_token: 'TOKEN',
-    expires_in: 60,
+const TOKEN_ENDPOINT = 'https://auth.velocitynetwork.test/oauth/token';
+const BLOCKCHAIN_AUDIENCE = 'https://velocitynetwork.node';
+
+const createFastify = (config = {}) => {
+  const hooks = new Map();
+  const fastify = {
+    config: {
+      vnfClientId: 'config-client',
+      vnfClientSecret: 'config-secret',
+      vnfOAuthTokensEndpoint: TOKEN_ENDPOINT,
+      blockchainApiAudience: BLOCKCHAIN_AUDIENCE,
+      ...config,
+    },
+    decorate(name, value) {
+      this[name] = value;
+      return this;
+    },
+    hasDecorator(name) {
+      return Object.hasOwn(this, name);
+    },
+    decorateRequest() {
+      return this;
+    },
+    addHook(name, hook) {
+      hooks.set(name, hook);
+      return this;
+    },
+    runPreValidation: async (request) => {
+      await hooks.get('preValidation')(request);
+    },
   };
-  const undiciMockPost = mock.fn((result) => ({
-    json: () => Promise.resolve(result),
-  }));
-  const undiciMock = (result) => () => ({
-    post: () => undiciMockPost(result),
+
+  return fastify;
+};
+
+const registerPlugin = async (fastify) =>
+  new Promise((resolve, reject) => {
+    try {
+      initAuthenticateVnfClientPlugin(fastify, {}, (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    } catch (error) {
+      reject(error);
+    }
   });
+
+const invokeRequestAuthentication = async (fastify, request = {}) => {
+  await fastify.runPreValidation(request);
+  return request.vnfBlockchainAuthenticate();
+};
+
+describe('VNF Identity Provider Authentication', () => {
+  const tokenResponses = [];
+  const post = mock.fn(async () => ({
+    json: async () => tokenResponses.shift(),
+  }));
   let fastify;
-  let vnfAuthenticate;
+  let authenticateVnfClient;
 
   beforeEach(() => {
     initHttpClient.mock.resetCalls();
-    undiciMockPost.mock.resetCalls();
+    post.mock.resetCalls();
+    tokenResponses.length = 0;
+    initHttpClient.mock.mockImplementation(() => () => ({ post }));
     fastify = createFastify();
-    vnfAuthenticate = initAuthenticateVnfClient(fastify);
+    fastify.vnfAuthTokensCache = new Map();
+    authenticateVnfClient = initAuthenticateVnfClient(fastify);
   });
 
   after(() => {
     mock.reset();
   });
 
-  describe('VNF Authenticate', () => {
-    it('Base VNF authenticate call', async () => {
-      initHttpClient.mock.mockImplementationOnce(() => undiciMock(tokenResult));
+  describe('VNF authenticate', () => {
+    it('loads credentials lazily and posts the client credentials grant', async () => {
+      tokenResponses.push({ access_token: 'TOKEN', expires_in: 60 });
+      const loadCredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
 
-      const result = await vnfAuthenticate('API-IDENTIFIER');
+      const result = await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          cacheKey: 'did:velocity:cao-a:3',
+          loadCredentials,
+        },
+        {},
+      );
 
-      expect(result).toEqual(tokenResult.access_token);
+      expect(result).toEqual('TOKEN');
+      expect(loadCredentials.mock.callCount()).toEqual(1);
+      expect(post.mock.calls[0].arguments).toEqual([
+        TOKEN_ENDPOINT,
+        {
+          grant_type: 'client_credentials',
+          client_id: 'cao-a-client',
+          client_secret: 'cao-a-secret',
+          audience: BLOCKCHAIN_AUDIENCE,
+        },
+      ]);
     });
 
-    it('Get cached token', async () => {
-      initHttpClient.mock.mockImplementationOnce(() => undiciMock(tokenResult));
-
-      await vnfAuthenticate('API-IDENTIFIER');
-
-      const otherTokenResult = {
-        ...tokenResult,
-        access_token: 'OTHER_TOKEN',
+    it('reuses a token for the same audience and resolver cache key', async () => {
+      tokenResponses.push({ access_token: 'TOKEN', expires_in: 60 });
+      const loadCredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
+      const authentication = {
+        audience: BLOCKCHAIN_AUDIENCE,
+        cacheKey: 'did:velocity:cao-a:3',
+        loadCredentials,
       };
 
-      initHttpClient.mock.mockImplementationOnce(() =>
-        undiciMock(otherTokenResult),
-      );
+      const firstToken = await authenticateVnfClient(authentication, {});
+      const secondToken = await authenticateVnfClient(authentication, {});
 
-      const result = await vnfAuthenticate('API-IDENTIFIER');
-
-      expect(result).toEqual(tokenResult.access_token);
+      expect([firstToken, secondToken]).toEqual(['TOKEN', 'TOKEN']);
+      expect(loadCredentials.mock.callCount()).toEqual(1);
+      expect(post.mock.callCount()).toEqual(1);
     });
 
-    it('Get new token when cached expired', async () => {
-      initHttpClient.mock.mockImplementationOnce(() =>
-        undiciMock({
-          ...tokenResult,
-          expires_in: 0,
-        }),
+    it('requests separate tokens for two resolver cache keys', async () => {
+      tokenResponses.push(
+        { access_token: 'CAO_A_TOKEN', expires_in: 60 },
+        { access_token: 'CAO_B_TOKEN', expires_in: 60 },
+      );
+      const loadCaoACredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
+      const loadCaoBCredentials = mock.fn(async () => ({
+        clientId: 'cao-b-client',
+        clientSecret: 'cao-b-secret',
+      }));
+
+      const caoAToken = await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          cacheKey: 'did:velocity:cao-a:3',
+          loadCredentials: loadCaoACredentials,
+        },
+        {},
+      );
+      const caoBToken = await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          cacheKey: 'did:velocity:cao-b:7',
+          loadCredentials: loadCaoBCredentials,
+        },
+        {},
       );
 
-      await vnfAuthenticate('API-IDENTIFIER');
+      expect([caoAToken, caoBToken]).toEqual(['CAO_A_TOKEN', 'CAO_B_TOKEN']);
+      expect(post.mock.callCount()).toEqual(2);
+    });
 
-      const otherTokenResult = {
-        ...tokenResult,
-        access_token: 'OTHER_TOKEN',
+    it('reloads credentials and requests a token after expiry', async () => {
+      tokenResponses.push(
+        { access_token: 'EXPIRED_TOKEN', expires_in: 0 },
+        { access_token: 'FRESH_TOKEN', expires_in: 60 },
+      );
+      const loadCredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
+      const authentication = {
+        audience: BLOCKCHAIN_AUDIENCE,
+        cacheKey: 'did:velocity:cao-a:3',
+        loadCredentials,
       };
 
-      initHttpClient.mock.mockImplementationOnce(() =>
-        undiciMock(otherTokenResult),
-      );
+      await authenticateVnfClient(authentication, {});
+      const result = await authenticateVnfClient(authentication, {});
 
-      const result = await vnfAuthenticate('API-IDENTIFIER');
-
-      expect(result).toEqual(otherTokenResult.access_token);
+      expect(result).toEqual('FRESH_TOKEN');
+      expect(loadCredentials.mock.callCount()).toEqual(2);
+      expect(post.mock.callCount()).toEqual(2);
     });
-  });
 
-  describe('VNF Blockchain Authenticate', () => {
-    it('Blockchain VNF authenticate call should make network request and then use cache', async () => {
-      initHttpClient.mock.mockImplementation(() => undiciMock(tokenResult));
-      const authenticate = initAuthenticateVnfBlockchainClient(fastify, {});
-      const result1 = await authenticate();
-      expect(result1).toEqual(tokenResult.access_token);
-      expect(undiciMockPost.mock.callCount()).toEqual(1);
-      const result2 = await authenticate();
-      expect(result2).toEqual(tokenResult.access_token);
-      expect(undiciMockPost.mock.callCount()).toEqual(1);
-    });
-  });
-
-  describe('VNF Authentication Plugin', () => {
-    it('Register VNF authentication functions', async () => {
-      initAuthenticateVnfClientPlugin(fastify, {}, () => {});
-
-      const req = {};
-      await addHook.mock.calls[0].arguments[1](req);
-      expect(req).toEqual({
-        vnfBlockchainAuthenticate: expect.any(Function),
+    it('prunes expired entries while preserving live cached tokens', async () => {
+      tokenResponses.push({ access_token: 'NEW_TOKEN', expires_in: 60 });
+      fastify.vnfAuthTokensCache.set('legacy-unreachable-entry', {
+        accessToken: 'EXPIRED_TOKEN',
+        expiresAt: new Date(0),
+      });
+      fastify.vnfAuthTokensCache.set('live-entry', {
+        accessToken: 'LIVE_TOKEN',
+        expiresAt: new Date(Date.now() + 60000),
       });
 
-      expect(
-        decorateRequest.mock.calls.map((call) => call.arguments),
-      ).toContainEqual(['vnfBlockchainAuthenticate', null]);
-      expect(addHook.mock.calls.map((call) => call.arguments)).toContainEqual([
-        'preValidation',
-        expect.anything(),
+      await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          cacheKey: 'did:velocity:cao-a:3',
+          loadCredentials: async () => ({
+            clientId: 'cao-a-client',
+            clientSecret: 'cao-a-secret',
+          }),
+        },
+        {},
+      );
+
+      expect(fastify.vnfAuthTokensCache.has('legacy-unreachable-entry')).toBe(
+        false,
+      );
+      expect(fastify.vnfAuthTokensCache.has('live-entry')).toBe(true);
+      expect(fastify.vnfAuthTokensCache.size).toEqual(2);
+    });
+
+    it('rejects an empty resolver cache key before loading credentials', async () => {
+      const loadCredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
+
+      await expect(
+        authenticateVnfClient(
+          {
+            audience: BLOCKCHAIN_AUDIENCE,
+            cacheKey: '',
+            loadCredentials,
+          },
+          {},
+        ),
+      ).rejects.toThrow('cacheKey');
+      expect(loadCredentials.mock.callCount()).toEqual(0);
+      expect(post.mock.callCount()).toEqual(0);
+    });
+
+    it('rejects a non-function credential loader before requesting a token', async () => {
+      await expect(
+        authenticateVnfClient(
+          {
+            audience: BLOCKCHAIN_AUDIENCE,
+            cacheKey: 'did:velocity:cao-a:3',
+            loadCredentials: null,
+          },
+          {},
+        ),
+      ).rejects.toThrow('loadCredentials');
+      expect(post.mock.callCount()).toEqual(0);
+    });
+  });
+
+  describe('VNF authentication plugin', () => {
+    it('uses config credentials through the default resolver', async () => {
+      tokenResponses.push({ access_token: 'CONFIG_TOKEN', expires_in: 60 });
+      fastify = createFastify({
+        vnfClientId: 'configured-client',
+        vnfClientSecret: 'configured-secret',
+      });
+
+      await registerPlugin(fastify);
+      const resolution = await fastify.resolveVnfClientCredentials({});
+      const result = await invokeRequestAuthentication(fastify);
+
+      expect(resolution.cacheKey).toEqual('config:configured-client');
+      await expect(resolution.loadCredentials()).resolves.toEqual({
+        clientId: 'configured-client',
+        clientSecret: 'configured-secret',
+      });
+      expect(result).toEqual('CONFIG_TOKEN');
+      expect(post.mock.calls[0].arguments[1]).toEqual({
+        grant_type: 'client_credentials',
+        client_id: 'configured-client',
+        client_secret: 'configured-secret',
+        audience: BLOCKCHAIN_AUDIENCE,
+      });
+    });
+
+    it('resolves metadata for every request but loads credentials only on a cache miss', async () => {
+      tokenResponses.push({ access_token: 'CUSTOM_TOKEN', expires_in: 60 });
+      const loadCredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
+      const resolveVnfClientCredentials = mock.fn(async () => ({
+        cacheKey: 'did:velocity:cao-a:3',
+        loadCredentials,
+      }));
+      fastify = createFastify({
+        vnfClientId: undefined,
+        vnfClientSecret: undefined,
+      });
+      fastify.resolveVnfClientCredentials = resolveVnfClientCredentials;
+
+      await registerPlugin(fastify);
+      const firstToken = await invokeRequestAuthentication(fastify, {
+        id: 'request-1',
+      });
+      const secondToken = await invokeRequestAuthentication(fastify, {
+        id: 'request-2',
+      });
+
+      expect([firstToken, secondToken]).toEqual([
+        'CUSTOM_TOKEN',
+        'CUSTOM_TOKEN',
       ]);
+      expect(resolveVnfClientCredentials.mock.callCount()).toEqual(2);
+      expect(loadCredentials.mock.callCount()).toEqual(1);
+      expect(post.mock.callCount()).toEqual(1);
+    });
+
+    it('preserves a pre-existing custom credential resolver', async () => {
+      tokenResponses.push({ access_token: 'CUSTOM_TOKEN', expires_in: 60 });
+      const customResolver = async () => ({
+        cacheKey: 'did:velocity:cao-a:3',
+        loadCredentials: async () => ({
+          clientId: 'custom-client',
+          clientSecret: 'custom-secret',
+        }),
+      });
+      fastify = createFastify({
+        vnfClientId: undefined,
+        vnfClientSecret: undefined,
+      });
+      fastify.resolveVnfClientCredentials = customResolver;
+
+      await registerPlugin(fastify);
+      const result = await invokeRequestAuthentication(fastify);
+
+      expect(result).toEqual('CUSTOM_TOKEN');
+      expect(fastify.resolveVnfClientCredentials).toBe(customResolver);
+      expect(post.mock.calls[0].arguments[1]).toEqual({
+        grant_type: 'client_credentials',
+        client_id: 'custom-client',
+        client_secret: 'custom-secret',
+        audience: BLOCKCHAIN_AUDIENCE,
+      });
+    });
+
+    it('returns a custom resolver rejection without falling back to config', async () => {
+      const customError = new Error('custom resolver failed');
+      const config = {
+        vnfOAuthTokensEndpoint: TOKEN_ENDPOINT,
+        blockchainApiAudience: BLOCKCHAIN_AUDIENCE,
+      };
+      Object.defineProperties(config, {
+        vnfClientId: {
+          enumerable: true,
+          get: () => {
+            throw new Error('default client ID was accessed');
+          },
+        },
+        vnfClientSecret: {
+          enumerable: true,
+          get: () => {
+            throw new Error('default client secret was accessed');
+          },
+        },
+      });
+      fastify = createFastify();
+      fastify.config = config;
+      fastify.resolveVnfClientCredentials = async () => {
+        throw customError;
+      };
+
+      await registerPlugin(fastify);
+
+      await expect(invokeRequestAuthentication(fastify)).rejects.toBe(
+        customError,
+      );
+      expect(post.mock.callCount()).toEqual(0);
+    });
+
+    it('fails plugin startup when the default client ID is missing', async () => {
+      fastify = createFastify({ vnfClientId: undefined });
+
+      await expect(registerPlugin(fastify)).rejects.toThrow('vnfClientId');
+    });
+
+    it('fails plugin startup when the default client secret is missing', async () => {
+      fastify = createFastify({ vnfClientSecret: undefined });
+
+      await expect(registerPlugin(fastify)).rejects.toThrow('vnfClientSecret');
     });
   });
 });

--- a/packages/db-kms/src/db-kms.js
+++ b/packages/db-kms/src/db-kms.js
@@ -101,6 +101,23 @@ const initDbKms = (fastify, kmsOptions = {}) => {
     };
 
     /**
+     * Deletes a key or secret
+     * @param {Id} keyId the key or secret id to delete
+     * @returns {Promise<boolean>} whether a key or secret was deleted
+     */
+    const deleteKeyOrSecret = async (keyId) => {
+      const existing = await repo.findOne(
+        { filter: { _id: keyId } },
+        { _id: 1 },
+      );
+      if (existing == null) {
+        return false;
+      }
+      await repo.del(existing._id);
+      return true;
+    };
+
+    /**
      * The key to load internally
      * @param {Id} keyId the key id to load
      * @returns {Promise<KeySpec & { _id: Id, privateJwk: JsonWebKey, secret: string }>} the key returned
@@ -202,6 +219,7 @@ const initDbKms = (fastify, kmsOptions = {}) => {
       createKey,
       importKey,
       importSecret,
+      deleteKeyOrSecret,
       exportKeyOrSecret,
       signJwt,
       verifyJwt,

--- a/packages/db-kms/test/db-kms.test.js
+++ b/packages/db-kms/test/db-kms.test.js
@@ -196,6 +196,21 @@ describe('db kms', () => {
     });
   });
 
+  describe('deleting keys & secrets', () => {
+    it('should delete imported secrets and generated asymmetric keys', async () => {
+      const imported = await kms.importSecret({ secret: 'vnf-secret' });
+
+      await expect(kms.deleteKeyOrSecret(imported.id)).resolves.toBe(true);
+      await expect(kms.exportKeyOrSecret(imported.id)).resolves.toBeNull();
+      await expect(kms.deleteKeyOrSecret(imported.id)).resolves.toBe(false);
+
+      const key = await kms.createKey(keySpecs.es256);
+
+      await expect(kms.deleteKeyOrSecret(key.id)).resolves.toBe(true);
+      await expect(kms.exportKeyOrSecret(key.id)).resolves.toBeNull();
+    });
+  });
+
   describe('jwt operations', () => {
     let keys;
     let alternativeKeys;

--- a/packages/db-kms/types/types.d.ts
+++ b/packages/db-kms/types/types.d.ts
@@ -58,6 +58,7 @@ export interface KMS {
   createKey: (kmsSpec: KeySpec) => Promise<KmsKey>;
   importKey: (importableKey: ImportableKey) => Promise<KmsKey>;
   importSecret: (importableSecret: ImportableSecret) => Promise<KmsSecret>;
+  deleteKeyOrSecret: (keyId: Id) => Promise<boolean>;
   exportKeyOrSecret: (keyId: Id) => Promise<ExportedKey>;
   signJwt: (
     payload: Record<string, unknown>,

--- a/packages/logger/src/log.js
+++ b/packages/logger/src/log.js
@@ -95,6 +95,21 @@ const SECURITY_PATHS = [
   'vnfBrokerClientSecret',
   'vnfClientSecret',
   'yotiSecret',
+  'operatorApiToken',
+  'clientSecret',
+  'client_secret',
+  'vnfClientId',
+  'vnfClientSecret',
+  'blockchainCredentials.secretId',
+  'cao.blockchainCredentials.secretId',
+  'provisioningCode',
+  "headers['x-provisioning-code']",
+  'body.clientSecret',
+  'body.client_secret',
+  'body.vnfClientId',
+  'body.vnfClientSecret',
+  'body.blockchainCredentials.secretId',
+  'body.provisioningCode',
 ];
 
 const prettyPrint = (nodeEnv) =>
@@ -143,10 +158,11 @@ const loggerProvider = ({
     }),
   };
   const redact = {};
-  redact.paths =
-    /^debug$/i.test(logSeverity) && nodeEnv === 'dev'
-      ? SPAM_PATHS
-      : [...SPAM_PATHS, ...SECURITY_PATHS, ...JSON_VC_PATHS];
+  const verbosePayloadPaths =
+    /^debug$/i.test(logSeverity) && nodeEnv === 'development'
+      ? []
+      : JSON_VC_PATHS;
+  redact.paths = [...SPAM_PATHS, ...SECURITY_PATHS, ...verbosePayloadPaths];
   redact.censor = (value, path) => {
     if (last(path) === 'file') {
       return '...large file...';

--- a/packages/logger/test/log.test.js
+++ b/packages/logger/test/log.test.js
@@ -21,6 +21,104 @@ const { Writable } = require('node:stream');
 const { loggerProvider } = require('../index');
 
 const store = {};
+const CENSOR = '...shhh...';
+const sensitiveDataForLog = () => ({
+  operatorApiToken: 'static-token',
+  clientSecret: 'client-secret',
+  client_secret: 'oauth-client-secret',
+  vnfClientId: 'vnf-client-id',
+  vnfClientSecret: 'vnf-client-secret',
+  blockchainCredentials: {
+    secretId: 'kms-secret-id',
+  },
+  provisioningCode: 'provisioning-code',
+  headers: {
+    authorization: 'Basic Y2xpZW50OnNlY3JldA==',
+    'x-provisioning-code': 'provisioning-code',
+  },
+  body: {
+    access_token: 'jwt',
+    clientSecret: 'returned-secret',
+    vnfClientId: 'submitted-vnf-client-id',
+    vnfClientSecret: 'submitted-vnf-secret',
+    blockchainCredentials: {
+      secretId: 'submitted-kms-secret-id',
+    },
+  },
+});
+
+const additionalSensitiveDataForLog = () => ({
+  cao: {
+    blockchainCredentials: {
+      secretId: 'cao-kms-secret-id',
+    },
+  },
+  body: {
+    client_secret: 'submitted-oauth-client-secret',
+    provisioningCode: 'submitted-provisioning-code',
+  },
+});
+
+const expectSensitiveDataToBeRedacted = (output) => {
+  for (const secret of [
+    'static-token',
+    'client-secret',
+    'oauth-client-secret',
+    'vnf-client-id',
+    'vnf-client-secret',
+    'kms-secret-id',
+    'Basic Y2xpZW50OnNlY3JldA==',
+    'jwt',
+    'returned-secret',
+    'submitted-vnf-client-id',
+    'submitted-vnf-secret',
+    'submitted-kms-secret-id',
+  ]) {
+    expect(output).not.toContain(secret);
+  }
+  expect(output).not.toContain('"provisioningCode":"provisioning-code"');
+  expect(output).not.toContain('"x-provisioning-code":"provisioning-code"');
+
+  expect(JSON.parse(output)).toMatchObject({
+    operatorApiToken: CENSOR,
+    clientSecret: CENSOR,
+    client_secret: CENSOR,
+    vnfClientId: CENSOR,
+    vnfClientSecret: CENSOR,
+    blockchainCredentials: { secretId: CENSOR },
+    provisioningCode: CENSOR,
+    headers: {
+      authorization: CENSOR,
+      'x-provisioning-code': CENSOR,
+    },
+    body: {
+      access_token: CENSOR,
+      clientSecret: CENSOR,
+      vnfClientId: CENSOR,
+      vnfClientSecret: CENSOR,
+      blockchainCredentials: { secretId: CENSOR },
+    },
+  });
+};
+
+const expectAdditionalSensitiveDataToBeRedacted = (output) => {
+  for (const secret of [
+    'cao-kms-secret-id',
+    'submitted-oauth-client-secret',
+    'submitted-provisioning-code',
+  ]) {
+    expect(output).not.toContain(secret);
+  }
+
+  expect(JSON.parse(output)).toMatchObject({
+    cao: { blockchainCredentials: { secretId: CENSOR } },
+    body: {
+      client_secret: CENSOR,
+      provisioningCode: CENSOR,
+    },
+  });
+};
+
 class MemoryStream extends Writable {
   constructor(key, options) {
     super(options);
@@ -620,5 +718,65 @@ describe('Test pino logger provider with redaction', () => {
     const logInfo = '"body":{"file":"...large file..."}';
 
     expect(logStream.toString()).toMatch(logInfo);
+  });
+
+  it('redacts operator credentials in debug logs for dev', () => {
+    const stream = new MemoryStream('dev-debug-log');
+    const debugLog = loggerProvider({
+      nodeEnv: 'dev',
+      logSeverity: 'debug',
+      version: '1.0',
+      traceIdHeader: 'x-trace-id',
+      destination: stream,
+    });
+
+    debugLog.debug(sensitiveDataForLog());
+
+    expectSensitiveDataToBeRedacted(stream.toString());
+  });
+
+  it('redacts operator credentials in debug logs for development', () => {
+    const stream = new MemoryStream('development-debug-log');
+    const debugLog = loggerProvider({
+      nodeEnv: 'development',
+      logSeverity: 'debug',
+      version: '1.0',
+      traceIdHeader: 'x-trace-id',
+      destination: stream,
+    });
+
+    debugLog.debug(sensitiveDataForLog());
+
+    expectSensitiveDataToBeRedacted(stream.toString());
+  });
+
+  it('redacts additional operator credentials in debug logs for dev', () => {
+    const stream = new MemoryStream('additional-dev-debug-log');
+    const debugLog = loggerProvider({
+      nodeEnv: 'dev',
+      logSeverity: 'debug',
+      version: '1.0',
+      traceIdHeader: 'x-trace-id',
+      destination: stream,
+    });
+
+    debugLog.debug(additionalSensitiveDataForLog());
+
+    expectAdditionalSensitiveDataToBeRedacted(stream.toString());
+  });
+
+  it('redacts additional operator credentials in debug logs for development', () => {
+    const stream = new MemoryStream('additional-development-debug-log');
+    const debugLog = loggerProvider({
+      nodeEnv: 'development',
+      logSeverity: 'debug',
+      version: '1.0',
+      traceIdHeader: 'x-trace-id',
+      destination: stream,
+    });
+
+    debugLog.debug(additionalSensitiveDataForLog());
+
+    expectAdditionalSensitiveDataToBeRedacted(stream.toString());
   });
 });

--- a/packages/server/src/common-create-server.js
+++ b/packages/server/src/common-create-server.js
@@ -48,6 +48,9 @@ const velocityFavicon = readFileSync(
   resolve(__dirname, 'assets/velocity-favicon.png'),
 );
 
+const isSensitiveRoute = (req) =>
+  req.routeOptions?.config?.sensitiveLogging === true;
+
 const commonCreateServer = (config, log) => {
   const { customFastifyOptions, traceIdHeader } = config;
 
@@ -121,17 +124,14 @@ const commonCreateServer = (config, log) => {
     })
     .addHook('onError', async (req, reply, error) => {
       const { body } = req;
+      const errorLog = isSensitiveRoute(req)
+        ? { req: req.raw, err: error }
+        : { req: req.raw, body, res: reply.raw, err: error };
 
       if (error.validation) {
-        req.log.warn(
-          { req: req.raw, body, res: reply.raw, err: error },
-          error && error.message,
-        );
+        req.log.warn(errorLog, error && error.message);
       } else {
-        req.log.error(
-          { req: req.raw, body, res: reply.raw, err: error },
-          error && error.message,
-        );
+        req.log.error(errorLog, error && error.message);
       }
     })
     // request cache

--- a/packages/server/src/create-server.js
+++ b/packages/server/src/create-server.js
@@ -22,6 +22,9 @@ const {
   createCommonLog,
 } = require('./common-create-server');
 
+const isSensitiveRoute = (req) =>
+  req.routeOptions?.config?.sensitiveLogging === true;
+
 const createServer = (config) => {
   const log = createCommonLog(config);
   log.info(config, 'Server Configured');
@@ -36,12 +39,12 @@ const createServer = (config) => {
       })
       // logging
       .addHook('preValidation', async (req) => {
-        if (req.body) {
+        if (req.body && !isSensitiveRoute(req)) {
           req.log.debug({ headers: req.headers, body: req.body }, 'request');
         }
       })
       .addHook('preSerialization', async (req, reply, payload) => {
-        if (payload) {
+        if (payload && !isSensitiveRoute(req)) {
           req.log.debug({ body: payload }, 'response body');
         }
         return payload;

--- a/packages/server/test/server.test.js
+++ b/packages/server/test/server.test.js
@@ -36,6 +36,32 @@ const listenTestServer = async (server) => {
   await server.listen({ port: appPort, host: appHost });
 };
 
+const captureLogs = async (server, callback) => {
+  const writes = [];
+  let logger = server.log;
+  let streamSymbol;
+  while (logger && !streamSymbol) {
+    streamSymbol = Object.getOwnPropertySymbols(logger).find(
+      (symbol) => symbol.toString() === 'Symbol(pino.stream)',
+    );
+    logger = Object.getPrototypeOf(logger);
+  }
+  const stream = server.log[streamSymbol];
+  server.log[streamSymbol] = {
+    write: (chunk) => {
+      writes.push(chunk.toString());
+    },
+  };
+
+  try {
+    await callback();
+  } finally {
+    server.log[streamSymbol] = stream;
+  }
+
+  return writes.join('');
+};
+
 describe('Server package variant tests ', () => {
   let server;
 
@@ -111,6 +137,112 @@ describe('Server package variant tests ', () => {
     } catch (e) {
       expect(e.response.statusCode).toEqual(500);
     }
+  });
+
+  it('omits sensitive route payloads from logs while retaining normal debug payload logs', async () => {
+    await server.close();
+    server = createServer({
+      ...genericConfig,
+      logSeverity: 'debug',
+      mongoConnection,
+    });
+    server.post(
+      '/sensitive',
+      { config: { sensitiveLogging: true } },
+      async () => ({
+        result: 'sensitive-response-body',
+        clientSecret: 'returned-secret',
+      }),
+    );
+    server.post(
+      '/sensitive-error',
+      { config: { sensitiveLogging: true } },
+      async () => {
+        throw new Error('safe failure');
+      },
+    );
+    server.post('/not-sensitive', async () => ({
+      result: 'public-response-body',
+    }));
+
+    const logs = await captureLogs(server, async () => {
+      const sensitiveResponse = await server.inject({
+        method: 'post',
+        url: '/sensitive',
+        headers: {
+          authorization: 'Basic c2Vuc2l0aXZlOnNlY3JldA==',
+          'x-provisioning-code': 'sensitive-provisioning-code',
+        },
+        payload: {
+          request: 'sensitive-request-body',
+          clientSecret: 'submitted-secret',
+        },
+      });
+      const sensitiveErrorResponse = await server.inject({
+        method: 'post',
+        url: '/sensitive-error',
+        headers: {
+          authorization: 'Basic ZmFpbHVyZTpzZWNyZXQ=',
+          'x-provisioning-code': 'failure-provisioning-code',
+        },
+        payload: {
+          request: 'sensitive-error-request-body',
+          clientSecret: 'failure-submitted-secret',
+        },
+      });
+      const normalResponse = await server.inject({
+        method: 'post',
+        url: '/not-sensitive',
+        payload: { request: 'public-request-body' },
+      });
+
+      expect(sensitiveResponse.statusCode).toEqual(200);
+      expect(sensitiveErrorResponse.statusCode).toEqual(500);
+      expect(normalResponse.statusCode).toEqual(200);
+    });
+
+    for (const sensitiveValue of [
+      'sensitive-request-body',
+      'sensitive-response-body',
+      'submitted-secret',
+      'returned-secret',
+      'sensitive-error-request-body',
+      'failure-submitted-secret',
+      'Basic c2Vuc2l0aXZlOnNlY3JldA==',
+      'Basic ZmFpbHVyZTpzZWNyZXQ=',
+      'sensitive-provisioning-code',
+      'failure-provisioning-code',
+    ]) {
+      expect(logs).not.toContain(sensitiveValue);
+    }
+
+    const logEntries = logs.trim().split('\n').map(JSON.parse);
+    const logEntriesForRoute = (url) => {
+      const requestLog = logEntries.find(
+        (entry) => entry.req?.url === url && entry.msg === 'incoming request',
+      );
+      return logEntries.filter((entry) => entry.reqId === requestLog.reqId);
+    };
+    const sensitiveLogs = logEntriesForRoute('/sensitive');
+    const sensitiveErrorLogs = logEntriesForRoute('/sensitive-error');
+    const publicLogs = logEntriesForRoute('/not-sensitive');
+
+    for (const logEntry of [...sensitiveLogs, ...sensitiveErrorLogs]) {
+      expect(logEntry).not.toHaveProperty('body');
+      expect(logEntry).not.toHaveProperty('headers');
+    }
+    expect(publicLogs).toContainEqual(
+      expect.objectContaining({
+        body: { request: 'public-request-body' },
+        msg: 'request',
+      }),
+    );
+    expect(publicLogs).toContainEqual(
+      expect.objectContaining({
+        body: { result: 'public-response-body' },
+        msg: 'response body',
+      }),
+    );
   });
 });
 

--- a/servers/credentialinghub/README.md
+++ b/servers/credentialinghub/README.md
@@ -31,11 +31,28 @@ const operatorAuthPlugin = fp(async (fastify) => {
 
   // Optional. Omit this decorator to use VNF_OAUTH_CLIENT_ID and
   // VNF_OAUTH_CLIENT_SECRET.
-  fastify.decorate('resolveVnfClientCredentials', async (request) => ({
-    cacheKey: `${request.operatorPrincipal.caoDid}:1`,
-    loadCredentials: async () =>
-      loadVnfCredentials(request.operatorPrincipal.caoDid),
-  }));
+  fastify.decorate('resolveVnfClientCredentials', async (request) => {
+    const tenantCaoDid = request.tenant?.caoDid;
+    const principalCaoDid = request.operatorPrincipal?.caoDid;
+
+    if (
+      tenantCaoDid != null &&
+      principalCaoDid != null &&
+      tenantCaoDid !== principalCaoDid
+    ) {
+      throw new Error('tenant and Operator principal CAO DIDs must match');
+    }
+
+    const caoDid = tenantCaoDid ?? principalCaoDid;
+    if (caoDid == null) {
+      throw new Error('request must resolve to a CAO DID');
+    }
+
+    return {
+      cacheKey: `${caoDid}:1`,
+      loadCredentials: async () => loadVnfCredentials(caoDid),
+    };
+  });
 
   // Keep private endpoints encapsulated beneath the capability plugin.
   fastify.register(privateOperatorRoutes);
@@ -76,7 +93,11 @@ normalized fields on `request.operatorPrincipal`.
 
 The optional VNF resolver is selected by decoration, not configuration. Once
 a custom resolver is installed, its errors are returned to the caller and
-never fall back to the static VNF client ID and secret.
+never fall back to the static VNF client ID and secret. Public VN/OpenID
+requests resolve their CAO from the loaded tenant, while authenticated Operator
+requests resolve it from the Operator principal. A resolver must reject the
+request when both sources exist but disagree, or when neither source supplies a
+CAO DID.
 
 ## Data Migrations
 

--- a/servers/credentialinghub/README.md
+++ b/servers/credentialinghub/README.md
@@ -6,6 +6,78 @@ Credentialing Hub runtime code is maintained in this package.
 
 - [Notification webhooks design](docs/notification-webhooks-design.md)
 
+## Operator Authentication Extension
+
+The open-source Hub uses a static `OPERATOR_API_TOKEN` bearer token by
+default. A wrapper can replace that behavior by supplying an Operator
+authentication extension to `createAppServer` or `startAppServer`:
+
+```js
+const fp = require('fastify-plugin');
+const {
+  startAppServer,
+} = require('@verii/server-credentialing-hub');
+
+const operatorAuthPlugin = fp(async (fastify) => {
+  fastify.decorate('authenticateOperator', async (request) => {
+    const claims = await verifyOperatorAccessToken(request);
+    request.operatorPrincipal = {
+      caoDid: claims.caoDid,
+      subject: claims.subject,
+      subjectType: 'client',
+      authenticationMethod: 'oauth2_client_credentials',
+    };
+  });
+
+  // Optional. Omit this decorator to use VNF_OAUTH_CLIENT_ID and
+  // VNF_OAUTH_CLIENT_SECRET.
+  fastify.decorate('resolveVnfClientCredentials', async (request) => ({
+    cacheKey: `${request.operatorPrincipal.caoDid}:1`,
+    loadCredentials: async () =>
+      loadVnfCredentials(request.operatorPrincipal.caoDid),
+  }));
+
+  // Keep private endpoints encapsulated beneath the capability plugin.
+  fastify.register(privateOperatorRoutes);
+});
+
+startAppServer({
+  operatorAuthExtension: {
+    plugin: operatorAuthPlugin,
+    tenantIsolation: 'cao',
+    documentation: {
+      operatorSecurityScheme: {
+        type: 'oauth2',
+        flows: {
+          clientCredentials: {
+            tokenUrl: '/operator/oauth/token',
+            scopes: {},
+          },
+        },
+      },
+      securitySchemes: {
+        operatorClientBasic: { type: 'http', scheme: 'basic' },
+      },
+      tags: [
+        {
+          name: 'Operator Authentication',
+          description: 'Machine-to-machine authentication.',
+        },
+      ],
+    },
+  },
+});
+```
+
+`tenantIsolation` must be either `legacy` or `cao`. CAO isolation requires a
+non-empty principal `caoDid`; every principal also requires `subject`,
+`subjectType`, and `authenticationMethod`. The Hub exposes only those four
+normalized fields on `request.operatorPrincipal`.
+
+The optional VNF resolver is selected by decoration, not configuration. Once
+a custom resolver is installed, its errors are returned to the caller and
+never fall back to the static VNF client ID and secret.
+
 ## Data Migrations
 
 Credentialing Hub database migrations remain in the monorepo Docker/wrapper package under `servers/credentialinghub/migrations`.

--- a/servers/credentialinghub/src/config/config.js
+++ b/servers/credentialinghub/src/config/config.js
@@ -91,7 +91,7 @@ module.exports = {
   },
   deepLinkProtocol: env.get('DEEP_LINK_PROTOCOL').required().asString(),
   keyEncryptionSecret: env.get('KEY_ENCRYPTION_SECRET').required().asString(),
-  operatorApiToken: env.get('OPERATOR_API_TOKEN').required().asString(),
+  operatorApiToken: env.get('OPERATOR_API_TOKEN').asString(),
   registrarUrl: env.get('REGISTRAR_URL').required().asString(),
   libUrl: env.get('LIB_URL').required().asString(),
   credentialExtensionsContextUrl: env
@@ -126,8 +126,8 @@ module.exports = {
     .default('0xf755E1Ca66bE12F177178E7Ea696969E0A55Bb64')
     .asString(),
   defaultCaoDid: env.get('DEFAULT_CAO_DID').asString(),
-  vnfClientId: env.get('VNF_OAUTH_CLIENT_ID').required().asString(),
-  vnfClientSecret: env.get('VNF_OAUTH_CLIENT_SECRET').required().asString(),
+  vnfClientId: env.get('VNF_OAUTH_CLIENT_ID').asString(),
+  vnfClientSecret: env.get('VNF_OAUTH_CLIENT_SECRET').asString(),
   vnfOAuthTokensEndpoint: env
     .get('VNF_OAUTH_TOKENS_ENDPOINT')
     .required()

--- a/servers/credentialinghub/src/config/swagger-config.js
+++ b/servers/credentialinghub/src/config/swagger-config.js
@@ -22,6 +22,32 @@ const {
 const OPERATOR_TITLE = 'Velocity Credentialing Hub — Operator API';
 const OPENID4VC_TITLE = 'Velocity Credentialing Hub — OpenID4VC Wallet API';
 const VN_API_TITLE = 'Velocity Credentialing Hub — VN-API Wallet API';
+const DEFAULT_OPERATOR_AUTH = {
+  type: 'http',
+  scheme: 'bearer',
+  description: 'Operator API token',
+};
+const DEFAULT_OPERATOR_TAGS = [
+  { name: 'Tenants', description: 'Manage Credentialing Hub tenants.' },
+  {
+    name: 'Issuer Services',
+    description: 'Manage issuer services.',
+  },
+  {
+    name: 'Relying Party Services',
+    description: 'Manage relying party services.',
+  },
+  { name: 'Depots', description: 'Manage depots.' },
+  { name: 'Credentials', description: 'Manage credentials.' },
+  { name: 'Presentations', description: 'Verify presentations.' },
+  { name: 'Issue Links', description: 'Manage issue links.' },
+  {
+    name: 'Presentation Links',
+    description: 'Manage presentation links.',
+  },
+  { name: 'Exchanges', description: 'Inspect exchanges.' },
+  { name: 'Utilities', description: 'Healthcheck and testing utilities.' },
+];
 
 const createAudienceTransform =
   (audience) =>
@@ -39,7 +65,20 @@ const createAudienceTransform =
     };
   };
 
-const createSwaggerConfig = (version) => ({
+const assertNoReservedScheme = (securitySchemes, reservedName) => {
+  if (Object.hasOwn(securitySchemes, reservedName)) {
+    throw new Error(`${reservedName} is reserved for operator authentication`);
+  }
+};
+
+const assertUniqueTagNames = (tags) => {
+  const names = tags.map(({ name }) => name);
+  if (new Set(names).size !== names.length) {
+    throw new Error('Swagger tag names must be unique');
+  }
+};
+
+const createDefaultSwaggerConfig = (version) => ({
   swaggerInfo: {
     info: {
       title: OPERATOR_TITLE,
@@ -48,34 +87,10 @@ const createSwaggerConfig = (version) => ({
     },
     components: {
       securitySchemes: {
-        operatorBearer: {
-          type: 'http',
-          scheme: 'bearer',
-          description: 'Operator API token',
-        },
+        operatorAuth: DEFAULT_OPERATOR_AUTH,
       },
     },
-    tags: [
-      { name: 'Tenants', description: 'Manage Credentialing Hub tenants.' },
-      {
-        name: 'Issuer Services',
-        description: 'Manage issuer services.',
-      },
-      {
-        name: 'Relying Party Services',
-        description: 'Manage relying party services.',
-      },
-      { name: 'Depots', description: 'Manage depots.' },
-      { name: 'Credentials', description: 'Manage credentials.' },
-      { name: 'Presentations', description: 'Verify presentations.' },
-      { name: 'Issue Links', description: 'Manage issue links.' },
-      {
-        name: 'Presentation Links',
-        description: 'Manage presentation links.',
-      },
-      { name: 'Exchanges', description: 'Inspect exchanges.' },
-      { name: 'Utilities', description: 'Healthcheck and testing utilities.' },
-    ],
+    tags: DEFAULT_OPERATOR_TAGS,
   },
   swaggerOptions: {
     transform: createAudienceTransform('operator'),
@@ -156,5 +171,31 @@ const createSwaggerConfig = (version) => ({
     ],
   },
 });
+
+const createSwaggerConfig = (version, operatorDocumentation = {}) => {
+  const config = createDefaultSwaggerConfig(version);
+  const operatorSecurityScheme =
+    operatorDocumentation.operatorSecurityScheme ?? DEFAULT_OPERATOR_AUTH;
+  const additionalSchemes = operatorDocumentation.securitySchemes ?? {};
+  const extensionTags = operatorDocumentation.tags ?? [];
+
+  assertNoReservedScheme(additionalSchemes, 'operatorAuth');
+  assertUniqueTagNames([...extensionTags, ...DEFAULT_OPERATOR_TAGS]);
+
+  return {
+    ...config,
+    swaggerInfo: {
+      ...config.swaggerInfo,
+      components: {
+        ...config.swaggerInfo.components,
+        securitySchemes: {
+          operatorAuth: operatorSecurityScheme,
+          ...additionalSchemes,
+        },
+      },
+      tags: [...extensionTags, ...DEFAULT_OPERATOR_TAGS],
+    },
+  };
+};
 
 module.exports = { createSwaggerConfig };

--- a/servers/credentialinghub/src/controllers/operator/autohooks.js
+++ b/servers/credentialinghub/src/controllers/operator/autohooks.js
@@ -31,5 +31,5 @@ module.exports = async (fastify) => {
   fastify
     .register(kmsPlugin)
     .register(responseRequestIdPlugin)
-    .autoSchemaPreset({ security: [{ operatorBearer: [] }] });
+    .autoSchemaPreset({ security: [{ operatorAuth: [] }] });
 };

--- a/servers/credentialinghub/src/controllers/operator/autohooks.js
+++ b/servers/credentialinghub/src/controllers/operator/autohooks.js
@@ -15,7 +15,6 @@
  *
  */
 const { responseRequestIdPlugin } = require('@verii/fastify-plugins');
-const fastifyBearerAuth = require('@fastify/bearer-auth');
 const { kmsPlugin } = require('../../entities/keys');
 const {
   setDocumentationAudience,
@@ -23,11 +22,9 @@ const {
 
 module.exports = async (fastify) => {
   setDocumentationAudience(fastify, 'operator');
-  if (!fastify.config.isTest) {
-    fastify.register(fastifyBearerAuth, {
-      keys: new Set([fastify.config.operatorApiToken]),
-    });
-  }
+  fastify.addHook('onRequest', async (request, reply) => {
+    await fastify.authenticateOperator(request, reply);
+  });
   fastify
     .register(kmsPlugin)
     .register(responseRequestIdPlugin)

--- a/servers/credentialinghub/src/entities/tenants/domain/operator-tenant-scope.js
+++ b/servers/credentialinghub/src/entities/tenants/domain/operator-tenant-scope.js
@@ -19,7 +19,8 @@ const newError = require('http-errors');
 const CAO_DID_MISMATCH = 'cao_did_mismatch';
 
 const getOperatorCaoDid = (context) =>
-  context.server.operatorTenantIsolation === 'cao'
+  context.server.operatorTenantIsolation === 'cao' &&
+  context.operatorPrincipal != null
     ? context.operatorPrincipal.caoDid
     : null;
 

--- a/servers/credentialinghub/src/entities/tenants/domain/operator-tenant-scope.js
+++ b/servers/credentialinghub/src/entities/tenants/domain/operator-tenant-scope.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Velocity Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const newError = require('http-errors');
+
+const CAO_DID_MISMATCH = 'cao_did_mismatch';
+
+const getOperatorCaoDid = (context) =>
+  context.server.operatorTenantIsolation === 'cao'
+    ? context.operatorPrincipal.caoDid
+    : null;
+
+const scopeTenantFilter = (filter, context) => {
+  const caoDid = getOperatorCaoDid(context);
+  return caoDid == null ? filter : { ...filter, caoDid };
+};
+
+const applyOperatorCaoDid = (newTenant, context) => {
+  const caoDid = getOperatorCaoDid(context);
+  if (
+    caoDid != null &&
+    newTenant.caoDid != null &&
+    newTenant.caoDid !== caoDid
+  ) {
+    throw newError(400, CAO_DID_MISMATCH, {
+      errorCode: CAO_DID_MISMATCH,
+    });
+  }
+  return caoDid == null ? { ...newTenant } : { ...newTenant, caoDid };
+};
+
+module.exports = {
+  applyOperatorCaoDid,
+  getOperatorCaoDid,
+  scopeTenantFilter,
+};

--- a/servers/credentialinghub/src/entities/tenants/index.js
+++ b/servers/credentialinghub/src/entities/tenants/index.js
@@ -17,6 +17,7 @@
 module.exports = {
   ...require('./adapters'),
   ...require('./domain'),
+  ...require('./domain/operator-tenant-scope'),
   ...require('./factories'),
   ...require('./orchestrators'),
   ...require('./plugins'),

--- a/servers/credentialinghub/src/entities/tenants/orchestrators/create-tenant.js
+++ b/servers/credentialinghub/src/entities/tenants/orchestrators/create-tenant.js
@@ -28,29 +28,31 @@ const {
 } = require('../../keys');
 const { loadTenantDidDoc, loadTenantProfile } = require('../adapters');
 const { validateNewTenant } = require('../domain');
+const { applyOperatorCaoDid } = require('../domain/operator-tenant-scope');
 
 const createTenant = async (newTenant, tenantKeys, context) => {
   const { repos, kms } = context;
+  const scopedNewTenant = applyOperatorCaoDid(newTenant, context);
 
   const [didDoc, orgProfile] = await Promise.all([
-    loadTenantDidDoc(newTenant.did, context),
-    loadTenantProfile(newTenant.did, context),
+    loadTenantDidDoc(scopedNewTenant.did, context),
+    loadTenantProfile(scopedNewTenant.did, context),
   ]);
 
-  validateNewTenant(newTenant, orgProfile, context);
+  validateNewTenant(scopedNewTenant, orgProfile, context);
 
   validateTenantKeys(tenantKeys, didDoc);
   const normalizedKeys = [
     generateAccessTokenSecret(CihKeyPurposes.HOLDER_ACCESS_TOKENS),
   ].concat(map(normalizeTenantKey, tenantKeys));
   const primaryAccount = await resolvePrimaryAccount(
-    newTenant,
+    scopedNewTenant,
     normalizedKeys,
     context,
   );
 
   const preparedTenant = await prepareTenant(
-    newTenant,
+    scopedNewTenant,
     normalizedKeys,
     primaryAccount,
     context,

--- a/servers/credentialinghub/src/entities/tenants/orchestrators/delete-tenant.js
+++ b/servers/credentialinghub/src/entities/tenants/orchestrators/delete-tenant.js
@@ -18,10 +18,23 @@ const { ObjectId } = require('mongodb');
 const { isEmpty, map } = require('lodash/fp');
 const newError = require('http-errors');
 const { TenantErrors } = require('../domain');
+const {
+  getOperatorCaoDid,
+  scopeTenantFilter,
+} = require('../domain/operator-tenant-scope');
 
-const deleteTenant = async (tenantId, { repos }) => {
-  const filter = { tenantId: new ObjectId(tenantId) };
-  const issuerServices = await repos.issuerServices.find({ filter });
+const deleteTenant = async (tenantId, context) => {
+  const { repos } = context;
+  const boxedTenantId = new ObjectId(tenantId);
+  const tenantFilter = scopeTenantFilter({ _id: boxedTenantId }, context);
+  const tenant = await repos.tenants.findOne({ filter: tenantFilter });
+  if (tenant == null) {
+    throwTenantNotFound(tenantId, context);
+  }
+
+  const issuerServices = await repos.issuerServices.find({
+    filter: { tenantId: boxedTenantId },
+  });
 
   if (!isEmpty(issuerServices)) {
     throw newError(
@@ -36,10 +49,21 @@ const deleteTenant = async (tenantId, { repos }) => {
   }
   return Promise.all([
     repos.keys.delUsingFilter({
-      filter: { tenantId: new ObjectId(tenantId) },
+      filter: { tenantId: boxedTenantId },
     }),
-    repos.tenants.del(tenantId),
+    repos.tenants.delUsingFilter({
+      filter: tenantFilter,
+    }),
   ]);
+};
+
+const throwTenantNotFound = (tenantId, context) => {
+  if (getOperatorCaoDid(context) == null) {
+    throw new newError.NotFound(`tenant ${tenantId} not found`);
+  }
+  throw newError(404, 'Tenant not found', {
+    errorCode: 'tenant_not_found',
+  });
 };
 
 module.exports = { deleteTenant };

--- a/servers/credentialinghub/src/entities/tenants/orchestrators/find-tenants.js
+++ b/servers/credentialinghub/src/entities/tenants/orchestrators/find-tenants.js
@@ -14,9 +14,12 @@
  * limitations under the License.
  *
  */
-const findTenants = (tenantIds, { repos }) => {
-  const filter = tenantIds == null ? {} : { _id: { $in: tenantIds } };
-  return repos.tenants.find({ filter });
+const { scopeTenantFilter } = require('../domain/operator-tenant-scope');
+
+const findTenants = (tenantIds, context) => {
+  const identifierFilter = tenantIds == null ? {} : { _id: { $in: tenantIds } };
+  const filter = scopeTenantFilter(identifierFilter, context);
+  return context.repos.tenants.find({ filter });
 };
 
 module.exports = { findTenants };

--- a/servers/credentialinghub/src/entities/tenants/plugins/tenant-loader-plugin.js
+++ b/servers/credentialinghub/src/entities/tenants/plugins/tenant-loader-plugin.js
@@ -16,6 +16,7 @@
 
 const fp = require('fastify-plugin');
 const newError = require('http-errors');
+const { scopeTenantFilter } = require('../domain/operator-tenant-scope');
 
 const extractTenantId = (req) => {
   if (req.params.tenantId != null) {
@@ -36,7 +37,10 @@ const loadTenant = async (options, req) => {
     throwTenantNotFound(options);
   }
 
-  const filter = options.useDID ? { did: tenantId } : { _id: tenantId };
+  const identifierFilter = options.useDID
+    ? { did: tenantId }
+    : { _id: tenantId };
+  const filter = scopeTenantFilter(identifierFilter, req);
   const tenant = await req.repos.tenants.findOne({ filter });
   if (tenant == null) {
     throwTenantNotFound(options);

--- a/servers/credentialinghub/src/entities/tenants/repo/repo.js
+++ b/servers/credentialinghub/src/entities/tenants/repo/repo.js
@@ -26,6 +26,7 @@ module.exports = (app, options, next = () => {}) => {
     await mongoDb()
       .collection('tenants')
       .createIndex({ did: 1 }, { unique: true });
+    await mongoDb().collection('tenants').createIndex({ caoDid: 1, _id: 1 });
   });
   next();
   return repoFactory(

--- a/servers/credentialinghub/src/index.js
+++ b/servers/credentialinghub/src/index.js
@@ -1,3 +1,4 @@
 module.exports = {
   ...require('./start-app-server'),
+  ...require('./plugins/operator-auth'),
 };

--- a/servers/credentialinghub/src/init-server.js
+++ b/servers/credentialinghub/src/init-server.js
@@ -27,8 +27,11 @@ const { openid4vpPlugin } = require('./entities/openid4vp');
 const {
   notificationEnqueueAdapterPlugin,
 } = require('./entities/notifications');
+const { registerOperatorAuth } = require('./plugins/operator-auth');
 
-const initServer = (server) => {
+const initServer = (server, { operatorAuthExtension } = {}) => {
+  registerOperatorAuth(server, operatorAuthExtension);
+
   if (!server.config.isTest) {
     server.register(authenticateVnfClientPlugin);
   }

--- a/servers/credentialinghub/src/plugins/operator-auth/default-operator-auth-plugin.js
+++ b/servers/credentialinghub/src/plugins/operator-auth/default-operator-auth-plugin.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Velocity Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fastifyBearerAuth = require('@fastify/bearer-auth');
+const fp = require('fastify-plugin');
+
+const assertNonEmpty = (value, name) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new TypeError(`${name} must be a non-empty string`);
+  }
+};
+
+const defaultOperatorAuthPlugin = fp(async (fastify) => {
+  if (!fastify.config.isTest) {
+    assertNonEmpty(fastify.config.operatorApiToken, 'OPERATOR_API_TOKEN');
+    await fastify.register(fastifyBearerAuth, {
+      keys: new Set([fastify.config.operatorApiToken]),
+      addHook: false,
+    });
+  }
+
+  fastify.decorate('authenticateOperator', async (request, reply) => {
+    if (!fastify.config.isTest) {
+      await new Promise((resolve, reject) => {
+        fastify.verifyBearerAuth(request, reply, (error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    }
+    request.operatorPrincipal = {
+      caoDid: fastify.config.defaultCaoDid ?? null,
+      subject: 'legacy-operator-token',
+      subjectType: 'client',
+      authenticationMethod: 'static_bearer',
+    };
+  });
+});
+
+module.exports = { defaultOperatorAuthPlugin };

--- a/servers/credentialinghub/src/plugins/operator-auth/index.js
+++ b/servers/credentialinghub/src/plugins/operator-auth/index.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Velocity Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  ...require('./register-operator-auth'),
+};

--- a/servers/credentialinghub/src/plugins/operator-auth/register-operator-auth.js
+++ b/servers/credentialinghub/src/plugins/operator-auth/register-operator-auth.js
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Velocity Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fp = require('fastify-plugin');
+const { defaultOperatorAuthPlugin } = require('./default-operator-auth-plugin');
+
+const TENANT_ISOLATION_MODES = new Set(['legacy', 'cao']);
+const PRINCIPAL_STRING_FIELDS = [
+  'subject',
+  'subjectType',
+  'authenticationMethod',
+];
+
+const isObject = (value) =>
+  value != null && typeof value === 'object' && !Array.isArray(value);
+
+const validateExtension = (extension) => {
+  if (!isObject(extension)) {
+    throw new TypeError('operatorAuthExtension must be an object');
+  }
+  if (typeof extension.plugin !== 'function') {
+    throw new TypeError('operatorAuthExtension.plugin must be a function');
+  }
+  if (!TENANT_ISOLATION_MODES.has(extension.tenantIsolation)) {
+    throw new TypeError(
+      "operatorAuthExtension.tenantIsolation must be 'legacy' or 'cao'",
+    );
+  }
+  if (extension.documentation != null && !isObject(extension.documentation)) {
+    throw new TypeError(
+      'operatorAuthExtension.documentation must be an object',
+    );
+  }
+};
+
+const assertNonEmptyPrincipalField = (principal, field) => {
+  if (typeof principal[field] !== 'string' || principal[field].length === 0) {
+    throw new TypeError(
+      `operatorPrincipal.${field} must be a non-empty string`,
+    );
+  }
+};
+
+const isNonEmptyString = (value) =>
+  typeof value === 'string' && value.length > 0;
+
+const normalizeCaoDid = (caoDid, tenantIsolation) => {
+  if (tenantIsolation === 'cao') {
+    if (!isNonEmptyString(caoDid)) {
+      throw new TypeError(
+        'operatorPrincipal.caoDid must be a non-empty string for CAO isolation',
+      );
+    }
+    return caoDid;
+  }
+  if (caoDid == null) {
+    return null;
+  }
+  if (!isNonEmptyString(caoDid)) {
+    throw new TypeError(
+      'operatorPrincipal.caoDid must be null or a non-empty string',
+    );
+  }
+  return caoDid;
+};
+
+const normalizePrincipal = (principal, tenantIsolation) => {
+  if (!isObject(principal)) {
+    throw new TypeError('operatorPrincipal must be an object');
+  }
+
+  for (const field of PRINCIPAL_STRING_FIELDS) {
+    assertNonEmptyPrincipalField(principal, field);
+  }
+
+  return {
+    caoDid: normalizeCaoDid(principal.caoDid, tenantIsolation),
+    subject: principal.subject,
+    subjectType: principal.subjectType,
+    authenticationMethod: principal.authenticationMethod,
+  };
+};
+
+const installOperatorAuthPlugin = fp(
+  async (fastify, { extension }) => {
+    const resolvedExtension =
+      extension == null
+        ? {
+            plugin: defaultOperatorAuthPlugin,
+            tenantIsolation: 'legacy',
+          }
+        : extension;
+    validateExtension(resolvedExtension);
+
+    fastify
+      .decorateRequest('operatorPrincipal', null)
+      .decorate('operatorTenantIsolation', resolvedExtension.tenantIsolation);
+
+    await fastify.register(resolvedExtension.plugin);
+
+    if (
+      !fastify.hasDecorator('authenticateOperator') ||
+      typeof fastify.authenticateOperator !== 'function'
+    ) {
+      throw new TypeError(
+        'operator authentication plugin must decorate authenticateOperator',
+      );
+    }
+
+    const { authenticateOperator } = fastify;
+    // Replace the capability implementation with the stable, validating seam.
+    // eslint-disable-next-line better-mutation/no-mutation
+    fastify.authenticateOperator = async (request, reply) => {
+      await authenticateOperator(request, reply);
+      if (!reply.sent) {
+        // eslint-disable-next-line better-mutation/no-mutation
+        request.operatorPrincipal = normalizePrincipal(
+          request.operatorPrincipal,
+          resolvedExtension.tenantIsolation,
+        );
+      }
+    };
+  },
+  { name: 'credentialingHubOperatorAuth' },
+);
+
+const registerOperatorAuth = (server, extension) =>
+  server.register(installOperatorAuthPlugin, { extension });
+
+module.exports = { registerOperatorAuth };

--- a/servers/credentialinghub/src/plugins/operator-auth/register-operator-auth.js
+++ b/servers/credentialinghub/src/plugins/operator-auth/register-operator-auth.js
@@ -123,8 +123,11 @@ const installOperatorAuthPlugin = fp(
     const { authenticateOperator } = fastify;
     // Replace the capability implementation with the stable, validating seam.
     // eslint-disable-next-line better-mutation/no-mutation
-    fastify.authenticateOperator = async (request, reply) => {
-      await authenticateOperator(request, reply);
+    fastify.authenticateOperator = async function authenticateAndNormalize(
+      request,
+      reply,
+    ) {
+      await authenticateOperator.call(this, request, reply);
       if (!reply.sent) {
         // eslint-disable-next-line better-mutation/no-mutation
         request.operatorPrincipal = normalizePrincipal(

--- a/servers/credentialinghub/src/start-app-server.js
+++ b/servers/credentialinghub/src/start-app-server.js
@@ -15,20 +15,40 @@
  */
 
 const { createServer, listenServer } = require('@verii/server-provider');
-const { flow } = require('lodash/fp');
 const config = require('./config');
+const { createSwaggerConfig } = require('./config/swagger-config');
 const { initServer } = require('./init-server');
 const {
   startEmbeddedNotificationWorker,
 } = require('./start-embedded-notification-worker');
 
-const startAppServer = () => {
-  const server = flow(createServer, initServer)(config);
+const createAppServer = ({
+  operatorAuthExtension,
+  configOverrides = {},
+} = {}) => {
+  const baseConfig = {
+    ...config,
+    ...configOverrides,
+  };
+  const serverConfig = {
+    ...baseConfig,
+    ...createSwaggerConfig(
+      baseConfig.version,
+      operatorAuthExtension?.documentation,
+    ),
+  };
+  const server = createServer(serverConfig);
+  return initServer(server, { operatorAuthExtension });
+};
+
+const startAppServer = (options = {}) => {
+  const server = createAppServer(options);
   startEmbeddedNotificationWorker(server);
   listenServer(server);
   return server;
 };
 
 module.exports = {
+  createAppServer,
   startAppServer,
 };

--- a/servers/credentialinghub/test/config/swagger-config.test.js
+++ b/servers/credentialinghub/test/config/swagger-config.test.js
@@ -1,0 +1,151 @@
+const { describe, it } = require('node:test');
+const { expect } = require('expect');
+const buildFastify = require('../helpers/create-test-fastify');
+const { createSwaggerConfig } = require('../../src/config/swagger-config');
+
+const OPERATOR_DOCUMENTATION = {
+  operatorSecurityScheme: {
+    type: 'oauth2',
+    flows: {
+      clientCredentials: {
+        tokenUrl: '/operator/oauth/token',
+        scopes: {},
+      },
+    },
+  },
+  securitySchemes: {
+    operatorClientBasic: { type: 'http', scheme: 'basic' },
+  },
+  tags: [{ name: 'Operator Authentication', description: 'M2M auth.' }],
+};
+
+const getDocuments = async (operatorDocumentation) => {
+  const fastify = buildFastify(
+    createSwaggerConfig('1.0.0', operatorDocumentation),
+  );
+
+  try {
+    const responses = await Promise.all(
+      [
+        ['operator', '/documentation/json'],
+        ['openid4vc', '/documentation/openid4vc.json'],
+        ['vnApi', '/documentation/vn-api.json'],
+      ].map(async ([name, url]) => {
+        const result = await fastify.injectJson({ method: 'GET', url });
+        expect(result.statusCode).toEqual(200);
+        return [name, result.json];
+      }),
+    );
+
+    return Object.fromEntries(responses);
+  } finally {
+    await fastify.close();
+  }
+};
+
+describe('createSwaggerConfig', () => {
+  it('emits static operator authentication with the reserved scheme name', async () => {
+    const { operator } = await getDocuments();
+
+    expect(operator.components.securitySchemes).toEqual({
+      operatorAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        description: 'Operator API token',
+      },
+    });
+  });
+
+  it('emits an extension operator scheme in the reserved slot', async () => {
+    const { operator } = await getDocuments({
+      operatorSecurityScheme: OPERATOR_DOCUMENTATION.operatorSecurityScheme,
+    });
+
+    expect(operator.components.securitySchemes).toEqual({
+      operatorAuth: OPERATOR_DOCUMENTATION.operatorSecurityScheme,
+    });
+  });
+
+  it('emits additional operator security schemes', async () => {
+    const { operator } = await getDocuments({
+      securitySchemes: OPERATOR_DOCUMENTATION.securitySchemes,
+    });
+
+    expect(operator.components.securitySchemes).toEqual({
+      operatorAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        description: 'Operator API token',
+      },
+      operatorClientBasic: { type: 'http', scheme: 'basic' },
+    });
+  });
+
+  it('prepends extension tags without exposing them to wallet documents', async () => {
+    const { operator, openid4vc, vnApi } = await getDocuments(
+      OPERATOR_DOCUMENTATION,
+    );
+
+    expect(operator.tags.map(({ name }) => name)).toEqual([
+      'Operator Authentication',
+      'Tenants',
+      'Issuer Services',
+      'Relying Party Services',
+      'Depots',
+      'Credentials',
+      'Presentations',
+      'Issue Links',
+      'Presentation Links',
+      'Exchanges',
+      'Utilities',
+    ]);
+    expect(openid4vc.components.securitySchemes).toEqual({
+      openid4vciAccessToken: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description: 'OpenID4VCI access token',
+      },
+    });
+    expect(openid4vc.tags.map(({ name }) => name)).toEqual([
+      'OpenID4VCI',
+      'OpenID4VP',
+    ]);
+    expect(vnApi.components.securitySchemes).toEqual({
+      vnApiAccessToken: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description: 'VN-API access token',
+      },
+    });
+    expect(vnApi.tags.map(({ name }) => name)).toEqual([
+      'Issuing',
+      'Presentation',
+    ]);
+  });
+
+  it('rejects extensions that reuse the reserved operator scheme name', () => {
+    expect(() =>
+      createSwaggerConfig('1.0.0', {
+        securitySchemes: { operatorAuth: { type: 'http', scheme: 'basic' } },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects extensions that reuse an operator tag name', () => {
+    expect(() =>
+      createSwaggerConfig('1.0.0', {
+        tags: [
+          { name: 'Operator Authentication', description: 'M2M auth.' },
+          { name: 'Operator Authentication', description: 'Duplicate.' },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      createSwaggerConfig('1.0.0', {
+        tags: [{ name: 'Tenants', description: 'Duplicate default tag.' }],
+      }),
+    ).toThrow();
+  });
+});

--- a/servers/credentialinghub/test/helpers/create-test-fastify.js
+++ b/servers/credentialinghub/test/helpers/create-test-fastify.js
@@ -26,8 +26,9 @@ const config = require('../../src/config');
 
 const mongoConnection = buildMongoConnection('test-credentialing-hub');
 
-module.exports = (configOverrides = {}) =>
-  flow(
-    createTestServer,
-    initServer,
-  )({ ...config, ...configOverrides, mongoConnection });
+module.exports = (configOverrides = {}, serverOptions = {}) =>
+  flow(createTestServer, (server) => initServer(server, serverOptions))({
+    ...config,
+    ...configOverrides,
+    mongoConnection,
+  });

--- a/servers/credentialinghub/test/operator/operator-auth-extension.test.js
+++ b/servers/credentialinghub/test/operator/operator-auth-extension.test.js
@@ -1,0 +1,334 @@
+const { spawnSync } = require('node:child_process');
+const { afterEach, describe, it } = require('node:test');
+const { expect } = require('expect');
+const Fastify = require('fastify');
+const fp = require('fastify-plugin');
+const { buildMongoConnection } = require('@verii/tests-helpers');
+const buildFastify = require('../helpers/create-test-fastify');
+const { createAppServer, registerOperatorAuth } = require('../../src');
+
+const TEST_PRINCIPAL = {
+  caoDid: 'did:example:operator',
+  subject: 'test-client',
+  subjectType: 'client',
+  authenticationMethod: 'test',
+};
+
+const createTestOperatorAuthPlugin = ({
+  principal = TEST_PRINCIPAL,
+  resolveVnfClientCredentials,
+} = {}) =>
+  fp(async (fastify) => {
+    fastify.decorate('authenticateOperator', async (request) => {
+      request.operatorPrincipal = {
+        ...principal,
+        privateClaim: 'must-not-leak',
+      };
+    });
+    if (resolveVnfClientCredentials != null) {
+      fastify.decorate(
+        'resolveVnfClientCredentials',
+        resolveVnfClientCredentials,
+      );
+    }
+  });
+
+const createExtension = (overrides = {}) => ({
+  plugin: createTestOperatorAuthPlugin(),
+  tenantIsolation: 'cao',
+  documentation: {},
+  ...overrides,
+});
+
+const activeServers = new Set();
+
+const trackServer = (server) => {
+  activeServers.add(server);
+  return server;
+};
+
+afterEach(async () => {
+  await Promise.all([...activeServers].map(async (server) => server.close()));
+  activeServers.clear();
+});
+
+const createAuthenticationBoundary = (extension, config = {}) => {
+  const fastify = trackServer(Fastify());
+  fastify.decorate('config', {
+    isTest: true,
+    defaultCaoDid: undefined,
+    ...config,
+  });
+  registerOperatorAuth(fastify, extension);
+  fastify.get(
+    '/principal',
+    {
+      onRequest: async (request, reply) =>
+        fastify.authenticateOperator(request, reply),
+    },
+    async (request) => request.operatorPrincipal,
+  );
+  return fastify;
+};
+
+describe('operator authentication extension', () => {
+  it('authenticates core Operator routes through the extension', async () => {
+    const fastify = trackServer(
+      buildFastify(
+        {},
+        {
+          operatorAuthExtension: createExtension({
+            plugin: fp(async (server) => {
+              server.decorate(
+                'authenticateOperator',
+                async (request, reply) => {
+                  await reply.code(401).send({
+                    error: 'extension-authenticator-ran',
+                  });
+                },
+              );
+            }),
+          }),
+        },
+      ),
+    );
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/operator/tenants/get',
+    });
+
+    expect(response.statusCode).toEqual(401);
+    expect(response.json()).toEqual(
+      expect.objectContaining({
+        error: 'extension-authenticator-ran',
+      }),
+    );
+  });
+
+  it('exposes only the normalized principal after authentication', async () => {
+    const fastify = createAuthenticationBoundary(createExtension());
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/principal',
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json()).toEqual(TEST_PRINCIPAL);
+  });
+
+  it('rejects a missing or empty CAO DID in CAO isolation mode', async () => {
+    await Promise.all(
+      [undefined, ''].map(async (caoDid) => {
+        const fastify = createAuthenticationBoundary(
+          createExtension({
+            plugin: createTestOperatorAuthPlugin({
+              principal: { ...TEST_PRINCIPAL, caoDid },
+            }),
+          }),
+        );
+
+        const response = await fastify.inject({
+          method: 'GET',
+          url: '/principal',
+        });
+
+        expect(response.statusCode).toEqual(500);
+        expect(response.json().message).toEqual(
+          'operatorPrincipal.caoDid must be a non-empty string for CAO isolation',
+        );
+      }),
+    );
+  });
+
+  it('allows a null CAO DID in legacy isolation mode', async () => {
+    const fastify = createAuthenticationBoundary(
+      createExtension({
+        tenantIsolation: 'legacy',
+        plugin: createTestOperatorAuthPlugin({
+          principal: { ...TEST_PRINCIPAL, caoDid: undefined },
+        }),
+      }),
+    );
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/principal',
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json()).toEqual({
+      ...TEST_PRINCIPAL,
+      caoDid: null,
+    });
+  });
+
+  it('fails startup when the extension omits authenticateOperator', async () => {
+    const fastify = createAuthenticationBoundary(
+      createExtension({ plugin: fp(async () => {}) }),
+    );
+
+    await expect(fastify.ready()).rejects.toThrow(
+      'operator authentication plugin must decorate authenticateOperator',
+    );
+  });
+
+  it('fails startup when the extension shape is invalid', async () => {
+    const invalidExtensions = [
+      {
+        extension: { tenantIsolation: 'cao', documentation: {} },
+        message: 'operatorAuthExtension.plugin must be a function',
+      },
+      {
+        extension: createExtension({ tenantIsolation: 'organization' }),
+        message:
+          "operatorAuthExtension.tenantIsolation must be 'legacy' or 'cao'",
+      },
+      {
+        extension: createExtension({ documentation: 'oauth2' }),
+        message: 'operatorAuthExtension.documentation must be an object',
+      },
+    ];
+
+    await Promise.all(
+      invalidExtensions.map(async ({ extension, message }) => {
+        const fastify = createAuthenticationBoundary(extension);
+        await expect(fastify.ready()).rejects.toThrow(message);
+        activeServers.delete(fastify);
+      }),
+    );
+  });
+});
+
+describe('default static Operator authentication', () => {
+  it('accepts only the configured static bearer token', async () => {
+    const fastify = createAuthenticationBoundary(undefined, {
+      isTest: false,
+      operatorApiToken: 'operator-secret',
+      defaultCaoDid: 'did:example:default-cao',
+    });
+
+    const unauthorizedResponse = await fastify.inject({
+      method: 'GET',
+      url: '/principal',
+    });
+    const authenticatedResponse = await fastify.inject({
+      method: 'GET',
+      url: '/principal',
+      headers: { authorization: 'Bearer operator-secret' },
+    });
+
+    expect(unauthorizedResponse.statusCode).toEqual(401);
+    expect(authenticatedResponse.statusCode).toEqual(200);
+    expect(authenticatedResponse.json()).toEqual({
+      caoDid: 'did:example:default-cao',
+      subject: 'legacy-operator-token',
+      subjectType: 'client',
+      authenticationMethod: 'static_bearer',
+    });
+  });
+
+  it('requires the static token only when no extension is supplied', async () => {
+    const staticFastify = createAuthenticationBoundary(undefined, {
+      isTest: false,
+      operatorApiToken: undefined,
+    });
+    await expect(staticFastify.ready()).rejects.toThrow(
+      'OPERATOR_API_TOKEN must be a non-empty string',
+    );
+    activeServers.delete(staticFastify);
+
+    const extensionFastify = createAuthenticationBoundary(createExtension(), {
+      isTest: false,
+      operatorApiToken: undefined,
+    });
+    await extensionFastify.ready();
+  });
+});
+
+describe('VNF credential resolver registration', () => {
+  const createProductionServer = (operatorAuthExtension) =>
+    trackServer(
+      createAppServer({
+        operatorAuthExtension,
+        configOverrides: {
+          isTest: false,
+          logSeverity: 'silent',
+          mongoConnection: buildMongoConnection('test-credentialing-hub'),
+          operatorApiToken: undefined,
+          vnfClientId: undefined,
+          vnfClientSecret: undefined,
+        },
+      }),
+    );
+
+  it('installs an extension resolver before VNF authentication starts', async () => {
+    const fastify = createProductionServer(
+      createExtension({
+        plugin: createTestOperatorAuthPlugin({
+          resolveVnfClientCredentials: async () => ({
+            cacheKey: 'test-cao:1',
+            loadCredentials: async () => ({
+              clientId: 'test-vnf-client',
+              clientSecret: 'test-vnf-secret',
+            }),
+          }),
+        }),
+      }),
+    );
+
+    await fastify.ready();
+  });
+
+  it('uses the default resolver and requires both config values when no custom resolver is installed', async () => {
+    const cases = [
+      {
+        config: { vnfClientId: undefined, vnfClientSecret: 'secret' },
+        message: 'fastify.config.vnfClientId is required',
+      },
+      {
+        config: { vnfClientId: 'client-id', vnfClientSecret: undefined },
+        message: 'fastify.config.vnfClientSecret is required',
+      },
+    ];
+
+    for (const { config, message } of cases) {
+      const startup = spawnSync(
+        process.execPath,
+        [
+          '-e',
+          `
+          const Fastify = require('fastify');
+          const fp = require('fastify-plugin');
+          const { authenticateVnfClientPlugin } =
+            require('@verii/base-contract-io');
+          const { registerOperatorAuth } =
+            require('./src/plugins/operator-auth');
+          const fastify = Fastify();
+          fastify.decorate('config', ${JSON.stringify(config)});
+          registerOperatorAuth(fastify, {
+            plugin: fp(async (server) => {
+              server.decorate('authenticateOperator', async () => {});
+            }, { name: 'testOperatorAuth' }),
+            tenantIsolation: 'cao',
+            documentation: {},
+          });
+          fastify.register(authenticateVnfClientPlugin);
+          fastify.ready((error) => {
+            process.stderr.write(error?.message ?? 'ready');
+            process.exit(error == null ? 0 : 1);
+          });
+        `,
+        ],
+        {
+          cwd: require('node:path').resolve(__dirname, '../..'),
+          encoding: 'utf8',
+        },
+      );
+
+      expect(startup.status).toEqual(1);
+      expect(startup.stderr).toContain(message);
+    }
+  });
+});

--- a/servers/credentialinghub/test/operator/operator-auth-extension.test.js
+++ b/servers/credentialinghub/test/operator/operator-auth-extension.test.js
@@ -106,6 +106,34 @@ describe('operator authentication extension', () => {
     );
   });
 
+  it('preserves the authenticator Fastify receiver through the HTTP boundary', async () => {
+    const fastify = createAuthenticationBoundary(
+      createExtension({
+        plugin: fp(async (server) => {
+          server
+            .decorate('operatorCaoDid', TEST_PRINCIPAL.caoDid)
+            .decorate(
+              'authenticateOperator',
+              async function authenticateOperator(request) {
+                request.operatorPrincipal = {
+                  ...TEST_PRINCIPAL,
+                  caoDid: this.operatorCaoDid,
+                };
+              },
+            );
+        }),
+      }),
+    );
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/principal',
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json()).toEqual(TEST_PRINCIPAL);
+  });
+
   it('exposes only the normalized principal after authentication', async () => {
     const fastify = createAuthenticationBoundary(createExtension());
 

--- a/servers/credentialinghub/test/operator/operator-tenant-loader-registration.test.js
+++ b/servers/credentialinghub/test/operator/operator-tenant-loader-registration.test.js
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Velocity Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { after, before, beforeEach, describe, it } = require('node:test');
+const { expect } = require('expect');
+const fp = require('fastify-plugin');
+const { omit } = require('lodash/fp');
+const { ObjectId } = require('mongodb');
+const { mongoDb } = require('@spencejs/spence-mongo-repos');
+const createTestFastify = require('../helpers/create-test-fastify');
+const { initTenantFactory } = require('../../src/entities/tenants');
+
+const CAO_A_DID = 'did:example:cao-a';
+const CAO_B_DID = 'did:example:cao-b';
+
+const operatorAuthExtension = {
+  plugin: fp(async (fastify) => {
+    fastify.decorate('authenticateOperator', async (request) => {
+      request.operatorPrincipal = {
+        caoDid: CAO_A_DID,
+        subject: 'test-operator',
+        subjectType: 'client',
+        authenticationMethod: 'test',
+      };
+    });
+  }),
+  tenantIsolation: 'cao',
+  documentation: {},
+};
+
+const requestCases = [
+  {
+    controller: 'credentials',
+    buildRequest: (tenantId) => ({
+      method: 'GET',
+      url: `/operator/credentials/get?tenantId=${tenantId}`,
+    }),
+  },
+  {
+    controller: 'depots',
+    buildRequest: (tenantId) => ({
+      method: 'POST',
+      url: '/operator/depots/delete',
+      payload: {
+        tenantId,
+        serviceId: new ObjectId(),
+        depotId: new ObjectId(),
+      },
+    }),
+  },
+  {
+    controller: 'exchanges',
+    buildRequest: (tenantId) => ({
+      method: 'GET',
+      url: `/operator/exchanges/get?tenantId=${tenantId}&exchangeId=${new ObjectId()}`,
+    }),
+  },
+  {
+    controller: 'issue-links',
+    buildRequest: (tenantId) => ({
+      method: 'POST',
+      url: '/operator/issue-links/refresh',
+      payload: { tenantId, serviceId: new ObjectId() },
+    }),
+  },
+  {
+    controller: 'issuer-services',
+    buildRequest: (tenantId) => ({
+      method: 'GET',
+      url: `/operator/issuer-services/get?tenantId=${tenantId}`,
+    }),
+  },
+  {
+    controller: 'presentation-links',
+    buildRequest: (tenantId) => ({
+      method: 'POST',
+      url: '/operator/presentation-links/refresh',
+      payload: { tenantId, serviceId: new ObjectId() },
+    }),
+  },
+  {
+    controller: 'presentations',
+    buildRequest: (tenantId) => ({
+      method: 'GET',
+      url: `/operator/presentations/get?tenantId=${tenantId}`,
+    }),
+  },
+  {
+    controller: 'relying-party-services',
+    buildRequest: (tenantId) => ({
+      method: 'GET',
+      url: `/operator/relying-party-services/get?tenantId=${tenantId}`,
+    }),
+  },
+];
+
+const comparableResponse = (response) => ({
+  statusCode: response.statusCode,
+  body: omit(['requestId'], response.json),
+});
+
+describe('operator controller tenant-loader registration', () => {
+  let fastify;
+  let persistTenant;
+  let foreignTenant;
+
+  before(async () => {
+    fastify = createTestFastify(
+      { logSeverity: 'fatal' },
+      { operatorAuthExtension },
+    );
+    await fastify.ready();
+    ({ persistTenant } = initTenantFactory(fastify));
+  });
+
+  beforeEach(async () => {
+    await mongoDb().collection('tenants').deleteMany({});
+    foreignTenant = await persistTenant({ caoDid: CAO_B_DID });
+  });
+
+  after(async () => {
+    await fastify.close();
+  });
+
+  requestCases.forEach(({ controller, buildRequest }) => {
+    it(`${controller} conceals a tenant owned by another CAO`, async () => {
+      const unknownResponse = await fastify.injectJson(
+        buildRequest(new ObjectId()),
+      );
+      const foreignResponse = await fastify.injectJson(
+        buildRequest(foreignTenant._id),
+      );
+
+      expect(comparableResponse(foreignResponse)).toEqual(
+        comparableResponse(unknownResponse),
+      );
+      expect(foreignResponse.json.errorCode).toEqual('tenant_not_found');
+    });
+  });
+});

--- a/servers/credentialinghub/test/operator/tenant-loader-cao-isolation.test.js
+++ b/servers/credentialinghub/test/operator/tenant-loader-cao-isolation.test.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Velocity Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { after, before, beforeEach, describe, it } = require('node:test');
+const { expect } = require('expect');
+const fp = require('fastify-plugin');
+const { omit } = require('lodash/fp');
+const { mongoDb } = require('@spencejs/spence-mongo-repos');
+const createTestFastify = require('../helpers/create-test-fastify');
+const {
+  initTenantFactory,
+  tenantLoaderPlugin,
+} = require('../../src/entities/tenants');
+
+const CAO_A_DID = 'did:example:cao-a';
+const CAO_B_DID = 'did:example:cao-b';
+
+const createOperatorAuthExtension = (tenantIsolation) => ({
+  plugin: fp(async (fastify) => {
+    fastify.decorate('authenticateOperator', async (request) => {
+      request.operatorPrincipal = {
+        caoDid: tenantIsolation === 'cao' ? CAO_A_DID : null,
+        subject: 'test-operator',
+        subjectType: 'client',
+        authenticationMethod: 'test',
+      };
+    });
+  }),
+  tenantIsolation,
+  documentation: {},
+});
+
+const createTenantLoaderServer = async (tenantIsolation) => {
+  const fastify = createTestFastify(
+    { logSeverity: 'fatal' },
+    {
+      operatorAuthExtension: createOperatorAuthExtension(tenantIsolation),
+    },
+  );
+  fastify.register(async (server) => {
+    server.addHook('onRequest', server.authenticateOperator);
+    await server.register(tenantLoaderPlugin);
+    server.get('/test/operator-tenants/:tenantId', async (request) => ({
+      tenantId: request.tenant._id,
+    }));
+  });
+  await fastify.ready();
+  return fastify;
+};
+
+const comparableResponse = (response) => ({
+  statusCode: response.statusCode,
+  body: omit(['requestId'], response.json),
+});
+
+describe('tenant loader CAO isolation', () => {
+  let fastify;
+  let persistTenant;
+  let ownTenant;
+  let foreignTenant;
+
+  before(async () => {
+    fastify = await createTenantLoaderServer('cao');
+    ({ persistTenant } = initTenantFactory(fastify));
+  });
+
+  beforeEach(async () => {
+    await mongoDb().collection('tenants').deleteMany({});
+    [ownTenant, foreignTenant] = await Promise.all([
+      persistTenant({ caoDid: CAO_A_DID }),
+      persistTenant({ caoDid: CAO_B_DID }),
+    ]);
+  });
+
+  after(async () => {
+    await fastify.close();
+  });
+
+  it("loads the authenticated CAO's tenant", async () => {
+    const response = await fastify.injectJson({
+      method: 'GET',
+      url: `/test/operator-tenants/${ownTenant._id}`,
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json).toEqual({ tenantId: ownTenant._id });
+  });
+
+  it('conceals a tenant owned by another CAO as an unknown tenant', async () => {
+    const unknownResponse = await fastify.injectJson({
+      method: 'GET',
+      url: '/test/operator-tenants/000000000000000000000000',
+    });
+    const foreignResponse = await fastify.injectJson({
+      method: 'GET',
+      url: `/test/operator-tenants/${foreignTenant._id}`,
+    });
+
+    expect(comparableResponse(foreignResponse)).toEqual(
+      comparableResponse(unknownResponse),
+    );
+  });
+});
+
+describe('tenant loader legacy isolation', () => {
+  let fastify;
+  let persistTenant;
+
+  before(async () => {
+    fastify = await createTenantLoaderServer('legacy');
+    ({ persistTenant } = initTenantFactory(fastify));
+  });
+
+  beforeEach(async () => {
+    await mongoDb().collection('tenants').deleteMany({});
+  });
+
+  after(async () => {
+    await fastify.close();
+  });
+
+  it('loads a tenant by ID without applying a CAO filter', async () => {
+    const tenant = await persistTenant({ caoDid: CAO_B_DID });
+
+    const response = await fastify.injectJson({
+      method: 'GET',
+      url: `/test/operator-tenants/${tenant._id}`,
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json).toEqual({ tenantId: tenant._id });
+  });
+});

--- a/servers/credentialinghub/test/operator/tenants-controller.test.js
+++ b/servers/credentialinghub/test/operator/tenants-controller.test.js
@@ -17,6 +17,7 @@
 
 const { after, before, beforeEach, describe, it, mock } = require('node:test');
 const { expect } = require('expect');
+const fp = require('fastify-plugin');
 
 const mockLookupPrimary = mock.fn();
 const mockContractPermissionsModule = {
@@ -60,6 +61,24 @@ const { CihKeyPurposes, initKeyFactory } = require('../../src/entities/keys');
 const {
   TenantErrors,
 } = require('../../src/entities/tenants/domain/tenant-errors');
+
+const OPERATOR_CAO_DID = 'did:example:operator-cao';
+const OTHER_CAO_DID = 'did:example:other-cao';
+
+const operatorAuthExtension = {
+  plugin: fp(async (fastify) => {
+    fastify.decorate('authenticateOperator', async (request) => {
+      request.operatorPrincipal = {
+        caoDid: OPERATOR_CAO_DID,
+        subject: 'test-operator',
+        subjectType: 'client',
+        authenticationMethod: 'test',
+      };
+    });
+  }),
+  tenantIsolation: 'cao',
+  documentation: {},
+};
 
 describe('Tenants management test suite', () => {
   let fastify;
@@ -996,6 +1015,206 @@ describe('Tenants management test suite', () => {
         tenantId: new ObjectId(tenantId),
       })
       .toArray();
+});
+
+describe('CAO-isolated tenant management', () => {
+  let fastify;
+  let newTenant;
+  let persistTenant;
+  let persistKey;
+  let persistIssuerService;
+
+  before(async () => {
+    fastify = createTestFastify(
+      { logSeverity: 'fatal' },
+      { operatorAuthExtension },
+    );
+    await fastify.ready();
+    ({ persistTenant, newTenant } = initTenantFactory(fastify));
+    ({ persistKey } = initKeyFactory(fastify));
+    ({ persistIssuerService } = initIssuerServiceFactory(fastify));
+  });
+
+  beforeEach(async () => {
+    fastify.resetOverrides();
+    await Promise.all([
+      mongoDb().collection('tenants').deleteMany({}),
+      mongoDb().collection('keys').deleteMany({}),
+      mongoDb().collection('issuerServices').deleteMany({}),
+    ]);
+  });
+
+  after(async () => {
+    await fastify.close();
+  });
+
+  const buildCreatePayload = async (caoDid) => {
+    const { didDoc, keys } = buildIssuerDidDoc();
+    setupCreateTenantRegistrarMocks(didDoc.id, didDoc);
+    const tenant = await newTenant({ did: didDoc.id });
+    return {
+      tenant: {
+        ...pick(['did', 'name', 'logo', 'primaryAccount'], tenant),
+        ...(caoDid == null ? {} : { caoDid }),
+      },
+      keys,
+    };
+  };
+
+  const comparableResponse = (response) => ({
+    statusCode: response.statusCode,
+    body: omit(['requestId'], response.json),
+  });
+
+  const loadTenant = (tenantId) =>
+    mongoDb()
+      .collection('tenants')
+      .findOne({ _id: new ObjectId(tenantId) });
+
+  const loadKeys = (tenantId) =>
+    mongoDb()
+      .collection('keys')
+      .find({ tenantId: new ObjectId(tenantId) })
+      .toArray();
+
+  it('assigns the authenticated CAO when create omits caoDid', async () => {
+    const payload = await buildCreatePayload();
+
+    const response = await fastify.injectJson({
+      method: 'POST',
+      url: '/operator/tenants/create',
+      payload,
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json.tenant.caoDid).toEqual(OPERATOR_CAO_DID);
+    await expect(loadTenant(response.json.tenant.id)).resolves.toEqual(
+      expect.objectContaining({ caoDid: OPERATOR_CAO_DID }),
+    );
+  });
+
+  it('accepts create when the supplied caoDid matches the authenticated CAO', async () => {
+    const payload = await buildCreatePayload(OPERATOR_CAO_DID);
+
+    const response = await fastify.injectJson({
+      method: 'POST',
+      url: '/operator/tenants/create',
+      payload,
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json.tenant.caoDid).toEqual(OPERATOR_CAO_DID);
+  });
+
+  it('rejects create when the supplied caoDid conflicts with the authenticated CAO', async () => {
+    const payload = await buildCreatePayload(OTHER_CAO_DID);
+
+    const response = await fastify.injectJson({
+      method: 'POST',
+      url: '/operator/tenants/create',
+      payload,
+    });
+
+    expect(response.statusCode).toEqual(400);
+    expect(response.json).toEqual(
+      errorResponseMatcher({
+        statusCode: 400,
+        error: 'Bad Request',
+        message: 'cao_did_mismatch',
+        errorCode: 'cao_did_mismatch',
+      }),
+    );
+    await expect(
+      mongoDb().collection('tenants').countDocuments(),
+    ).resolves.toEqual(0);
+    await expect(
+      mongoDb().collection('keys').countDocuments(),
+    ).resolves.toEqual(0);
+  });
+
+  it("lists only the authenticated CAO's tenants", async () => {
+    const [ownTenantA, ownTenantB] = await Promise.all([
+      persistTenant({ caoDid: OPERATOR_CAO_DID }),
+      persistTenant({ caoDid: OPERATOR_CAO_DID }),
+      persistTenant({ caoDid: OTHER_CAO_DID }),
+    ]);
+
+    const response = await fastify.injectJson({
+      method: 'GET',
+      url: '/operator/tenants/get',
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(map('id', response.json.tenants).sort()).toEqual(
+      [ownTenantA._id, ownTenantB._id].sort(),
+    );
+  });
+
+  it("filters explicit tenant IDs to the authenticated CAO's tenants", async () => {
+    const [ownTenant, foreignTenant] = await Promise.all([
+      persistTenant({ caoDid: OPERATOR_CAO_DID }),
+      persistTenant({ caoDid: OTHER_CAO_DID }),
+    ]);
+
+    const response = await fastify.injectJson({
+      method: 'GET',
+      url: `/operator/tenants/get?tenantId=${ownTenant._id}&tenantId=${foreignTenant._id}`,
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(map('id', response.json.tenants)).toEqual([ownTenant._id]);
+  });
+
+  it('deletes a tenant owned by the authenticated CAO and its keys', async () => {
+    const tenant = await persistTenant({ caoDid: OPERATOR_CAO_DID });
+    await persistKey({ tenant });
+
+    const response = await fastify.injectJson({
+      method: 'POST',
+      url: '/operator/tenants/delete',
+      payload: { tenantId: tenant._id },
+    });
+
+    expect(response.statusCode).toEqual(200);
+    await expect(loadTenant(tenant._id)).resolves.toBeNull();
+    await expect(loadKeys(tenant._id)).resolves.toEqual([]);
+  });
+
+  it('conceals a foreign tenant before checking or removing related records', async () => {
+    const foreignTenant = await persistTenant({ caoDid: OTHER_CAO_DID });
+    const foreignKey = await persistKey({ tenant: foreignTenant });
+    const foreignService = await persistIssuerService({
+      tenant: foreignTenant,
+    });
+    const unknownResponse = await fastify.injectJson({
+      method: 'POST',
+      url: '/operator/tenants/delete',
+      payload: { tenantId: new ObjectId() },
+    });
+
+    const foreignResponse = await fastify.injectJson({
+      method: 'POST',
+      url: '/operator/tenants/delete',
+      payload: { tenantId: foreignTenant._id },
+    });
+
+    expect(comparableResponse(foreignResponse)).toEqual(
+      comparableResponse(unknownResponse),
+    );
+    await expect(loadTenant(foreignTenant._id)).resolves.toEqual(
+      expect.objectContaining({ caoDid: OTHER_CAO_DID }),
+    );
+    await expect(loadKeys(foreignTenant._id)).resolves.toEqual([
+      expect.objectContaining({ _id: new ObjectId(foreignKey._id) }),
+    ]);
+    await expect(
+      mongoDb()
+        .collection('issuerServices')
+        .findOne({ _id: new ObjectId(foreignService._id) }),
+    ).resolves.toEqual(
+      expect.objectContaining({ _id: new ObjectId(foreignService._id) }),
+    );
+  });
 });
 
 const expectedTenant = (tenant, overrides) =>

--- a/servers/credentialinghub/test/swagger.test.js
+++ b/servers/credentialinghub/test/swagger.test.js
@@ -1,7 +1,10 @@
 const { after, before, describe, it } = require('node:test');
 const { expect } = require('expect');
+const fp = require('fastify-plugin');
+const { buildMongoConnection } = require('@verii/tests-helpers');
 const packageJson = require('../package.json');
 const buildFastify = require('./helpers/create-test-fastify');
+const { createAppServer } = require('../src');
 
 const DOCUMENTS = {
   operator: '/documentation/json',
@@ -471,5 +474,65 @@ describe('swagger documents', () => {
     expect(result.body).toContain('ui.initOAuth({})');
     expect(result.body).not.toContain('persistAuthorization');
     expect(result.body).not.toContain('clientId');
+  });
+});
+
+describe('operator authentication extension documentation', () => {
+  it('includes extension metadata supplied while constructing the server', async () => {
+    const operatorSecurityScheme = {
+      type: 'oauth2',
+      flows: {
+        clientCredentials: {
+          tokenUrl: '/operator/oauth/token',
+          scopes: {},
+        },
+      },
+    };
+    const fastify = createAppServer({
+      operatorAuthExtension: {
+        plugin: fp(async (server) => {
+          server.decorate('authenticateOperator', async (request) => {
+            request.operatorPrincipal = {
+              caoDid: 'did:example:operator',
+              subject: 'operator-client',
+              subjectType: 'client',
+              authenticationMethod: 'test',
+            };
+          });
+        }),
+        tenantIsolation: 'cao',
+        documentation: {
+          operatorSecurityScheme,
+          tags: [
+            {
+              name: 'Operator Authentication',
+              description: 'Machine authentication.',
+            },
+          ],
+        },
+      },
+      configOverrides: {
+        isTest: false,
+        mongoConnection: buildMongoConnection('test-credentialing-hub'),
+      },
+    });
+
+    try {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: DOCUMENTS.operator,
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.json().components.securitySchemes.operatorAuth).toEqual(
+        operatorSecurityScheme,
+      );
+      expect(response.json().tags[0]).toEqual({
+        name: 'Operator Authentication',
+        description: 'Machine authentication.',
+      });
+    } finally {
+      await fastify.close();
+    }
   });
 });

--- a/servers/credentialinghub/test/swagger.test.js
+++ b/servers/credentialinghub/test/swagger.test.js
@@ -9,7 +9,7 @@ const DOCUMENTS = {
   vnApi: '/documentation/vn-api.json',
 };
 
-const OPERATOR_SECURITY = [{ operatorBearer: [] }];
+const OPERATOR_SECURITY = [{ operatorAuth: [] }];
 const OPENID4VCI_SECURITY = [{ openid4vciAccessToken: [] }];
 const VN_API_SECURITY = [{ vnApiAccessToken: [] }];
 
@@ -193,7 +193,7 @@ const EXPECTED_OPERATION_METADATA = {
 const EXPECTED_DOCUMENTS = {
   operator: {
     title: 'Velocity Credentialing Hub — Operator API',
-    securitySchemes: ['operatorBearer'],
+    securitySchemes: ['operatorAuth'],
     tags: [
       'Tenants',
       'Issuer Services',
@@ -454,7 +454,7 @@ describe('swagger documents', () => {
     }
   });
 
-  it('offers all documents in Swagger UI with Operator API selected', async () => {
+  it('offers all documents in Swagger UI without preconfigured OAuth credentials', async () => {
     const result = await fastify.inject({
       method: 'GET',
       url: '/documentation/static/swagger-initializer.js',
@@ -468,5 +468,8 @@ describe('swagger documents', () => {
     expect(result.body).toContain('VN-API Wallet API');
     expect(result.body).toContain(DOCUMENTS.vnApi);
     expect(result.body).toContain('"urls.primaryName":"Operator API"');
+    expect(result.body).toContain('ui.initOAuth({})');
+    expect(result.body).not.toContain('persistAuthorization');
+    expect(result.body).not.toContain('clientId');
   });
 });

--- a/servers/credentialinghub/test/vn-api/vn-issuing-controller-get-credential-manifest.test.js
+++ b/servers/credentialinghub/test/vn-api/vn-issuing-controller-get-credential-manifest.test.js
@@ -17,6 +17,7 @@
 
 const { after, before, beforeEach, describe, it, mock } = require('node:test');
 const { expect } = require('expect');
+const fp = require('fastify-plugin');
 const {
   mockHttpClientJsonResponse,
   mockHttpClient,
@@ -48,6 +49,22 @@ const createTestFastify = require('../helpers/create-test-fastify');
 const { constructTenant } = require('../helpers/construct-tenant');
 
 const agentUrl = 'https://localhost.test';
+const OPERATOR_CAO_DID = 'did:example:operator-cao';
+
+const operatorAuthExtension = {
+  plugin: fp(async (fastify) => {
+    fastify.decorate('authenticateOperator', async (request) => {
+      request.operatorPrincipal = {
+        caoDid: OPERATOR_CAO_DID,
+        subject: 'test-operator',
+        subjectType: 'client',
+        authenticationMethod: 'test',
+      };
+    });
+  }),
+  tenantIsolation: 'cao',
+  documentation: {},
+};
 
 const vnUrl = ({ did }) => `/vn-api/r/${did}`;
 
@@ -468,6 +485,58 @@ describe('vn-api > get credential manifests', () => {
         },
       ]);
     });
+  });
+});
+
+describe('VN API tenant loading with CAO-isolated operator routes', () => {
+  let fastify;
+  let tenant;
+  let persistIssuerService;
+
+  before(async () => {
+    fastify = createTestFastify(
+      { logSeverity: 'fatal' },
+      { operatorAuthExtension },
+    );
+    await fastify.ready();
+    const { persistTenant } = initTenantFactory(fastify);
+    const { persistKey } = initKeyFactory(fastify);
+    ({ persistIssuerService } = initIssuerServiceFactory(fastify));
+
+    await Promise.all([
+      mongoDb().collection('tenants').deleteMany({}),
+      mongoDb().collection('keys').deleteMany({}),
+      mongoDb().collection('issuerServices').deleteMany({}),
+      mongoDb().collection('exchanges').deleteMany({}),
+    ]);
+    ({ tenant } = await constructTenant(persistTenant, persistKey));
+  });
+
+  after(async () => {
+    await fastify.close();
+  });
+
+  it('loads a public VN API tenant without an operator principal', async () => {
+    const issuerService = await persistIssuerService({
+      tenant,
+      description: 'Credential Issuance Disclosure',
+      authMethods: ['preauth'],
+    });
+
+    const response = await fastify.injectJson({
+      method: 'GET',
+      url: testUrl(tenant, {
+        id: issuerService._id,
+        format: 'json',
+      }),
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.json.issuing_request).toEqual(
+      expect.objectContaining({
+        issuer: { id: tenant.did },
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
## What changed

- add unconditional credential/KMS redaction and sensitive-route body suppression
- expose generic KMS key/secret deletion
- add injectable lazy VNF credential resolution with audience/version-aware token caching
- make Operator OpenAPI authentication metadata extensible without leaking it into wallet documents
- add a Fastify operator-auth capability seam, normalized principal, and construction API while preserving static bearer mode
- enforce CAO-scoped tenant create/list/load/delete behavior across Operator endpoints while preserving public VN/OpenID tenant loading

## Why

This provides the generic open-source extension points needed for a private Credentialing Hub wrapper to supply CAO-scoped machine-to-machine authentication and per-CAO blockchain credentials without embedding private credential policy in the Hub.

## Compatibility

- no extension continues to use the existing static Operator bearer token
- the default VNF resolver continues to use process configuration
- public VN/OpenID routes remain unscoped by Operator principal
- existing Operator Swagger behavior remains bearer-based under the generic `operatorAuth` scheme name

## Validation

- Logger: 34 passed
- DB KMS: 16 passed
- Server provider: 14 passed
- VNF resolver contract: 13 passed
- Credentialing Hub: 495 passed
- ESLint across all touched packages: clean
- branch diff/whitespace checks: clean
- task-level reviews, a broad cross-task review, and scoped fix re-reviews completed
