### PR TITLE
fix(server): protect sensitive authentication logs

### DIFF
--- a/packages/logger/src/log.js
+++ b/packages/logger/src/log.js
@@ -98,15 +98,12 @@ const SECURITY_PATHS = [
   'operatorApiToken',
   'clientSecret',
   'client_secret',
-  'vnfClientId',
-  'vnfClientSecret',
   'blockchainCredentials.secretId',
   'cao.blockchainCredentials.secretId',
   'provisioningCode',
   "headers['x-provisioning-code']",
   'body.clientSecret',
   'body.client_secret',
-  'body.vnfClientId',
   'body.vnfClientSecret',
   'body.blockchainCredentials.secretId',
   'body.provisioningCode',
@@ -158,11 +155,7 @@ const loggerProvider = ({
     }),
   };
   const redact = {};
-  const verbosePayloadPaths =
-    /^debug$/i.test(logSeverity) && nodeEnv === 'development'
-      ? []
-      : JSON_VC_PATHS;
-  redact.paths = [...SPAM_PATHS, ...SECURITY_PATHS, ...verbosePayloadPaths];
+  redact.paths = [...SPAM_PATHS, ...SECURITY_PATHS, ...JSON_VC_PATHS];
   redact.censor = (value, path) => {
     if (last(path) === 'file') {
       return '...large file...';

--- a/packages/logger/src/log.js
+++ b/packages/logger/src/log.js
@@ -95,6 +95,21 @@ const SECURITY_PATHS = [
   'vnfBrokerClientSecret',
   'vnfClientSecret',
   'yotiSecret',
+  'operatorApiToken',
+  'clientSecret',
+  'client_secret',
+  'vnfClientId',
+  'vnfClientSecret',
+  'blockchainCredentials.secretId',
+  'cao.blockchainCredentials.secretId',
+  'provisioningCode',
+  "headers['x-provisioning-code']",
+  'body.clientSecret',
+  'body.client_secret',
+  'body.vnfClientId',
+  'body.vnfClientSecret',
+  'body.blockchainCredentials.secretId',
+  'body.provisioningCode',
 ];
 
 const prettyPrint = (nodeEnv) =>
@@ -143,10 +158,11 @@ const loggerProvider = ({
     }),
   };
   const redact = {};
-  redact.paths =
-    /^debug$/i.test(logSeverity) && nodeEnv === 'dev'
-      ? SPAM_PATHS
-      : [...SPAM_PATHS, ...SECURITY_PATHS, ...JSON_VC_PATHS];
+  const verbosePayloadPaths =
+    /^debug$/i.test(logSeverity) && nodeEnv === 'development'
+      ? []
+      : JSON_VC_PATHS;
+  redact.paths = [...SPAM_PATHS, ...SECURITY_PATHS, ...verbosePayloadPaths];
   redact.censor = (value, path) => {
     if (last(path) === 'file') {
       return '...large file...';

--- a/packages/logger/test/log.test.js
+++ b/packages/logger/test/log.test.js
@@ -21,6 +21,104 @@ const { Writable } = require('node:stream');
 const { loggerProvider } = require('../index');
 
 const store = {};
+const CENSOR = '...shhh...';
+const sensitiveDataForLog = () => ({
+  operatorApiToken: 'static-token',
+  clientSecret: 'client-secret',
+  client_secret: 'oauth-client-secret',
+  vnfClientId: 'vnf-client-id',
+  vnfClientSecret: 'vnf-client-secret',
+  blockchainCredentials: {
+    secretId: 'kms-secret-id',
+  },
+  provisioningCode: 'provisioning-code',
+  headers: {
+    authorization: 'Basic Y2xpZW50OnNlY3JldA==',
+    'x-provisioning-code': 'provisioning-code',
+  },
+  body: {
+    access_token: 'jwt',
+    clientSecret: 'returned-secret',
+    vnfClientId: 'submitted-vnf-client-id',
+    vnfClientSecret: 'submitted-vnf-secret',
+    blockchainCredentials: {
+      secretId: 'submitted-kms-secret-id',
+    },
+  },
+});
+
+const additionalSensitiveDataForLog = () => ({
+  cao: {
+    blockchainCredentials: {
+      secretId: 'cao-kms-secret-id',
+    },
+  },
+  body: {
+    client_secret: 'submitted-oauth-client-secret',
+    provisioningCode: 'submitted-provisioning-code',
+  },
+});
+
+const expectSensitiveDataToBeRedacted = (output) => {
+  for (const secret of [
+    'static-token',
+    'client-secret',
+    'oauth-client-secret',
+    'vnf-client-id',
+    'vnf-client-secret',
+    'kms-secret-id',
+    'Basic Y2xpZW50OnNlY3JldA==',
+    'jwt',
+    'returned-secret',
+    'submitted-vnf-client-id',
+    'submitted-vnf-secret',
+    'submitted-kms-secret-id',
+  ]) {
+    expect(output).not.toContain(secret);
+  }
+  expect(output).not.toContain('"provisioningCode":"provisioning-code"');
+  expect(output).not.toContain('"x-provisioning-code":"provisioning-code"');
+
+  expect(JSON.parse(output)).toMatchObject({
+    operatorApiToken: CENSOR,
+    clientSecret: CENSOR,
+    client_secret: CENSOR,
+    vnfClientId: CENSOR,
+    vnfClientSecret: CENSOR,
+    blockchainCredentials: { secretId: CENSOR },
+    provisioningCode: CENSOR,
+    headers: {
+      authorization: CENSOR,
+      'x-provisioning-code': CENSOR,
+    },
+    body: {
+      access_token: CENSOR,
+      clientSecret: CENSOR,
+      vnfClientId: CENSOR,
+      vnfClientSecret: CENSOR,
+      blockchainCredentials: { secretId: CENSOR },
+    },
+  });
+};
+
+const expectAdditionalSensitiveDataToBeRedacted = (output) => {
+  for (const secret of [
+    'cao-kms-secret-id',
+    'submitted-oauth-client-secret',
+    'submitted-provisioning-code',
+  ]) {
+    expect(output).not.toContain(secret);
+  }
+
+  expect(JSON.parse(output)).toMatchObject({
+    cao: { blockchainCredentials: { secretId: CENSOR } },
+    body: {
+      client_secret: CENSOR,
+      provisioningCode: CENSOR,
+    },
+  });
+};
+
 class MemoryStream extends Writable {
   constructor(key, options) {
     super(options);
@@ -620,5 +718,65 @@ describe('Test pino logger provider with redaction', () => {
     const logInfo = '"body":{"file":"...large file..."}';
 
     expect(logStream.toString()).toMatch(logInfo);
+  });
+
+  it('redacts operator credentials in debug logs for dev', () => {
+    const stream = new MemoryStream('dev-debug-log');
+    const debugLog = loggerProvider({
+      nodeEnv: 'dev',
+      logSeverity: 'debug',
+      version: '1.0',
+      traceIdHeader: 'x-trace-id',
+      destination: stream,
+    });
+
+    debugLog.debug(sensitiveDataForLog());
+
+    expectSensitiveDataToBeRedacted(stream.toString());
+  });
+
+  it('redacts operator credentials in debug logs for development', () => {
+    const stream = new MemoryStream('development-debug-log');
+    const debugLog = loggerProvider({
+      nodeEnv: 'development',
+      logSeverity: 'debug',
+      version: '1.0',
+      traceIdHeader: 'x-trace-id',
+      destination: stream,
+    });
+
+    debugLog.debug(sensitiveDataForLog());
+
+    expectSensitiveDataToBeRedacted(stream.toString());
+  });
+
+  it('redacts additional operator credentials in debug logs for dev', () => {
+    const stream = new MemoryStream('additional-dev-debug-log');
+    const debugLog = loggerProvider({
+      nodeEnv: 'dev',
+      logSeverity: 'debug',
+      version: '1.0',
+      traceIdHeader: 'x-trace-id',
+      destination: stream,
+    });
+
+    debugLog.debug(additionalSensitiveDataForLog());
+
+    expectAdditionalSensitiveDataToBeRedacted(stream.toString());
+  });
+
+  it('redacts additional operator credentials in debug logs for development', () => {
+    const stream = new MemoryStream('additional-development-debug-log');
+    const debugLog = loggerProvider({
+      nodeEnv: 'development',
+      logSeverity: 'debug',
+      version: '1.0',
+      traceIdHeader: 'x-trace-id',
+      destination: stream,
+    });
+
+    debugLog.debug(additionalSensitiveDataForLog());
+
+    expectAdditionalSensitiveDataToBeRedacted(stream.toString());
   });
 });

--- a/packages/logger/test/log.test.js
+++ b/packages/logger/test/log.test.js
@@ -64,13 +64,11 @@ const expectSensitiveDataToBeRedacted = (output) => {
     'static-token',
     'client-secret',
     'oauth-client-secret',
-    'vnf-client-id',
     'vnf-client-secret',
     'kms-secret-id',
     'Basic Y2xpZW50OnNlY3JldA==',
     'jwt',
     'returned-secret',
-    'submitted-vnf-client-id',
     'submitted-vnf-secret',
     'submitted-kms-secret-id',
   ]) {
@@ -83,7 +81,7 @@ const expectSensitiveDataToBeRedacted = (output) => {
     operatorApiToken: CENSOR,
     clientSecret: CENSOR,
     client_secret: CENSOR,
-    vnfClientId: CENSOR,
+    vnfClientId: 'vnf-client-id',
     vnfClientSecret: CENSOR,
     blockchainCredentials: { secretId: CENSOR },
     provisioningCode: CENSOR,
@@ -94,7 +92,7 @@ const expectSensitiveDataToBeRedacted = (output) => {
     body: {
       access_token: CENSOR,
       clientSecret: CENSOR,
-      vnfClientId: CENSOR,
+      vnfClientId: 'submitted-vnf-client-id',
       vnfClientSecret: CENSOR,
       blockchainCredentials: { secretId: CENSOR },
     },
@@ -748,6 +746,27 @@ describe('Test pino logger provider with redaction', () => {
     debugLog.debug(sensitiveDataForLog());
 
     expectSensitiveDataToBeRedacted(stream.toString());
+  });
+
+  it('redacts credential payloads in development debug logs', () => {
+    const stream = new MemoryStream('development-debug-credential-log');
+    const debugLog = loggerProvider({
+      nodeEnv: 'development',
+      logSeverity: 'debug',
+      version: '1.0',
+      traceIdHeader: 'x-trace-id',
+      destination: stream,
+    });
+
+    debugLog.debug({
+      credentialSubject: { givenName: 'Ada' },
+      relatedResource: { id: 'https://example.com/private-resource' },
+    });
+
+    expect(JSON.parse(stream.toString())).toMatchObject({
+      credentialSubject: CENSOR,
+      relatedResource: { id: CENSOR },
+    });
   });
 
   it('redacts additional operator credentials in debug logs for dev', () => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -55,6 +55,7 @@
     "globals": "17.7.0",
     "h2url": "0.2.0",
     "mongodb": "^7.5.0",
+    "pino-test": "^2.0.0",
     "prettier": "3.9.6"
   },
   "nx": {

--- a/packages/server/src/common-create-server.js
+++ b/packages/server/src/common-create-server.js
@@ -237,4 +237,4 @@ const createCommonLog = (config) => {
   return loggerProvider({ nodeEnv, logSeverity, version });
 };
 
-module.exports = { commonCreateServer, createCommonLog };
+module.exports = { commonCreateServer, createCommonLog, isSensitiveRoute };

--- a/packages/server/src/common-create-server.js
+++ b/packages/server/src/common-create-server.js
@@ -48,6 +48,9 @@ const velocityFavicon = readFileSync(
   resolve(__dirname, 'assets/velocity-favicon.png'),
 );
 
+const isSensitiveRoute = (req) =>
+  req.routeOptions?.config?.sensitiveLogging === true;
+
 const commonCreateServer = (config, log) => {
   const { customFastifyOptions, traceIdHeader } = config;
 
@@ -121,17 +124,14 @@ const commonCreateServer = (config, log) => {
     })
     .addHook('onError', async (req, reply, error) => {
       const { body } = req;
+      const errorLog = isSensitiveRoute(req)
+        ? { req: req.raw, err: error }
+        : { req: req.raw, body, res: reply.raw, err: error };
 
       if (error.validation) {
-        req.log.warn(
-          { req: req.raw, body, res: reply.raw, err: error },
-          error && error.message,
-        );
+        req.log.warn(errorLog, error && error.message);
       } else {
-        req.log.error(
-          { req: req.raw, body, res: reply.raw, err: error },
-          error && error.message,
-        );
+        req.log.error(errorLog, error && error.message);
       }
     })
     // request cache

--- a/packages/server/src/create-server.js
+++ b/packages/server/src/create-server.js
@@ -22,6 +22,9 @@ const {
   createCommonLog,
 } = require('./common-create-server');
 
+const isSensitiveRoute = (req) =>
+  req.routeOptions?.config?.sensitiveLogging === true;
+
 const createServer = (config) => {
   const log = createCommonLog(config);
   log.info(config, 'Server Configured');
@@ -36,12 +39,12 @@ const createServer = (config) => {
       })
       // logging
       .addHook('preValidation', async (req) => {
-        if (req.body) {
+        if (req.body && !isSensitiveRoute(req)) {
           req.log.debug({ headers: req.headers, body: req.body }, 'request');
         }
       })
       .addHook('preSerialization', async (req, reply, payload) => {
-        if (payload) {
+        if (payload && !isSensitiveRoute(req)) {
           req.log.debug({ body: payload }, 'response body');
         }
         return payload;

--- a/packages/server/src/create-server.js
+++ b/packages/server/src/create-server.js
@@ -25,8 +25,7 @@ const {
 const isSensitiveRoute = (req) =>
   req.routeOptions?.config?.sensitiveLogging === true;
 
-const createServer = (config) => {
-  const log = createCommonLog(config);
+const createServer = (config, log = createCommonLog(config)) => {
   log.info(config, 'Server Configured');
 
   const server = commonCreateServer(config, log);

--- a/packages/server/src/create-server.js
+++ b/packages/server/src/create-server.js
@@ -20,10 +20,8 @@ const fastifySensible = require('@fastify/sensible');
 const {
   commonCreateServer,
   createCommonLog,
+  isSensitiveRoute,
 } = require('./common-create-server');
-
-const isSensitiveRoute = (req) =>
-  req.routeOptions?.config?.sensitiveLogging === true;
 
 const createServer = (config, log = createCommonLog(config)) => {
   log.info(config, 'Server Configured');

--- a/packages/server/test/server.test.js
+++ b/packages/server/test/server.test.js
@@ -16,8 +16,10 @@
 const { createHash } = require('node:crypto');
 const { afterEach, beforeEach, describe, it } = require('node:test');
 const { expect } = require('expect');
+const pinoTest = require('pino-test');
 
 const { loadTestEnv, buildMongoConnection } = require('@verii/tests-helpers');
+const { loggerProvider } = require('@verii/logger');
 
 loadTestEnv();
 const { genericConfig } = require('@verii/config');
@@ -34,32 +36,6 @@ const sha256 = (value) => createHash('sha256').update(value).digest('hex');
 const listenTestServer = async (server) => {
   const { appPort, appHost } = server.config;
   await server.listen({ port: appPort, host: appHost });
-};
-
-const captureLogs = async (server, callback) => {
-  const writes = [];
-  let logger = server.log;
-  let streamSymbol;
-  while (logger && !streamSymbol) {
-    streamSymbol = Object.getOwnPropertySymbols(logger).find(
-      (symbol) => symbol.toString() === 'Symbol(pino.stream)',
-    );
-    logger = Object.getPrototypeOf(logger);
-  }
-  const stream = server.log[streamSymbol];
-  server.log[streamSymbol] = {
-    write: (chunk) => {
-      writes.push(chunk.toString());
-    },
-  };
-
-  try {
-    await callback();
-  } finally {
-    server.log[streamSymbol] = stream;
-  }
-
-  return writes.join('');
 };
 
 describe('Server package variant tests ', () => {
@@ -141,11 +117,16 @@ describe('Server package variant tests ', () => {
 
   it('omits sensitive route payloads from logs while retaining normal debug payload logs', async () => {
     await server.close();
-    server = createServer({
+    const config = {
       ...genericConfig,
       logSeverity: 'debug',
       mongoConnection,
-    });
+    };
+    const logEntries = [];
+    const logSink = pinoTest.sink();
+    logSink.on('data', (entry) => logEntries.push(entry));
+    const log = loggerProvider({ ...config, destination: logSink });
+    server = createServer(config, log);
     server.post(
       '/sensitive',
       { config: { sensitiveLogging: true } },
@@ -165,42 +146,41 @@ describe('Server package variant tests ', () => {
       result: 'public-response-body',
     }));
 
-    const logs = await captureLogs(server, async () => {
-      const sensitiveResponse = await server.inject({
-        method: 'post',
-        url: '/sensitive',
-        headers: {
-          authorization: 'Basic c2Vuc2l0aXZlOnNlY3JldA==',
-          'x-provisioning-code': 'sensitive-provisioning-code',
-        },
-        payload: {
-          request: 'sensitive-request-body',
-          clientSecret: 'submitted-secret',
-        },
-      });
-      const sensitiveErrorResponse = await server.inject({
-        method: 'post',
-        url: '/sensitive-error',
-        headers: {
-          authorization: 'Basic ZmFpbHVyZTpzZWNyZXQ=',
-          'x-provisioning-code': 'failure-provisioning-code',
-        },
-        payload: {
-          request: 'sensitive-error-request-body',
-          clientSecret: 'failure-submitted-secret',
-        },
-      });
-      const normalResponse = await server.inject({
-        method: 'post',
-        url: '/not-sensitive',
-        payload: { request: 'public-request-body' },
-      });
-
-      expect(sensitiveResponse.statusCode).toEqual(200);
-      expect(sensitiveErrorResponse.statusCode).toEqual(500);
-      expect(normalResponse.statusCode).toEqual(200);
+    const sensitiveResponse = await server.inject({
+      method: 'post',
+      url: '/sensitive',
+      headers: {
+        authorization: 'Basic c2Vuc2l0aXZlOnNlY3JldA==',
+        'x-provisioning-code': 'sensitive-provisioning-code',
+      },
+      payload: {
+        request: 'sensitive-request-body',
+        clientSecret: 'submitted-secret',
+      },
+    });
+    const sensitiveErrorResponse = await server.inject({
+      method: 'post',
+      url: '/sensitive-error',
+      headers: {
+        authorization: 'Basic ZmFpbHVyZTpzZWNyZXQ=',
+        'x-provisioning-code': 'failure-provisioning-code',
+      },
+      payload: {
+        request: 'sensitive-error-request-body',
+        clientSecret: 'failure-submitted-secret',
+      },
+    });
+    const normalResponse = await server.inject({
+      method: 'post',
+      url: '/not-sensitive',
+      payload: { request: 'public-request-body' },
     });
 
+    expect(sensitiveResponse.statusCode).toEqual(200);
+    expect(sensitiveErrorResponse.statusCode).toEqual(500);
+    expect(normalResponse.statusCode).toEqual(200);
+
+    const logs = JSON.stringify(logEntries);
     for (const sensitiveValue of [
       'sensitive-request-body',
       'sensitive-response-body',
@@ -216,7 +196,7 @@ describe('Server package variant tests ', () => {
       expect(logs).not.toContain(sensitiveValue);
     }
 
-    const logEntries = logs.trim().split('\n').map(JSON.parse);
+    expect(logEntries).not.toHaveLength(0);
     const logEntriesForRoute = (url) => {
       const requestLog = logEntries.find(
         (entry) => entry.req?.url === url && entry.msg === 'incoming request',

--- a/packages/server/test/server.test.js
+++ b/packages/server/test/server.test.js
@@ -36,6 +36,32 @@ const listenTestServer = async (server) => {
   await server.listen({ port: appPort, host: appHost });
 };
 
+const captureLogs = async (server, callback) => {
+  const writes = [];
+  let logger = server.log;
+  let streamSymbol;
+  while (logger && !streamSymbol) {
+    streamSymbol = Object.getOwnPropertySymbols(logger).find(
+      (symbol) => symbol.toString() === 'Symbol(pino.stream)',
+    );
+    logger = Object.getPrototypeOf(logger);
+  }
+  const stream = server.log[streamSymbol];
+  server.log[streamSymbol] = {
+    write: (chunk) => {
+      writes.push(chunk.toString());
+    },
+  };
+
+  try {
+    await callback();
+  } finally {
+    server.log[streamSymbol] = stream;
+  }
+
+  return writes.join('');
+};
+
 describe('Server package variant tests ', () => {
   let server;
 
@@ -111,6 +137,112 @@ describe('Server package variant tests ', () => {
     } catch (e) {
       expect(e.response.statusCode).toEqual(500);
     }
+  });
+
+  it('omits sensitive route payloads from logs while retaining normal debug payload logs', async () => {
+    await server.close();
+    server = createServer({
+      ...genericConfig,
+      logSeverity: 'debug',
+      mongoConnection,
+    });
+    server.post(
+      '/sensitive',
+      { config: { sensitiveLogging: true } },
+      async () => ({
+        result: 'sensitive-response-body',
+        clientSecret: 'returned-secret',
+      }),
+    );
+    server.post(
+      '/sensitive-error',
+      { config: { sensitiveLogging: true } },
+      async () => {
+        throw new Error('safe failure');
+      },
+    );
+    server.post('/not-sensitive', async () => ({
+      result: 'public-response-body',
+    }));
+
+    const logs = await captureLogs(server, async () => {
+      const sensitiveResponse = await server.inject({
+        method: 'post',
+        url: '/sensitive',
+        headers: {
+          authorization: 'Basic c2Vuc2l0aXZlOnNlY3JldA==',
+          'x-provisioning-code': 'sensitive-provisioning-code',
+        },
+        payload: {
+          request: 'sensitive-request-body',
+          clientSecret: 'submitted-secret',
+        },
+      });
+      const sensitiveErrorResponse = await server.inject({
+        method: 'post',
+        url: '/sensitive-error',
+        headers: {
+          authorization: 'Basic ZmFpbHVyZTpzZWNyZXQ=',
+          'x-provisioning-code': 'failure-provisioning-code',
+        },
+        payload: {
+          request: 'sensitive-error-request-body',
+          clientSecret: 'failure-submitted-secret',
+        },
+      });
+      const normalResponse = await server.inject({
+        method: 'post',
+        url: '/not-sensitive',
+        payload: { request: 'public-request-body' },
+      });
+
+      expect(sensitiveResponse.statusCode).toEqual(200);
+      expect(sensitiveErrorResponse.statusCode).toEqual(500);
+      expect(normalResponse.statusCode).toEqual(200);
+    });
+
+    for (const sensitiveValue of [
+      'sensitive-request-body',
+      'sensitive-response-body',
+      'submitted-secret',
+      'returned-secret',
+      'sensitive-error-request-body',
+      'failure-submitted-secret',
+      'Basic c2Vuc2l0aXZlOnNlY3JldA==',
+      'Basic ZmFpbHVyZTpzZWNyZXQ=',
+      'sensitive-provisioning-code',
+      'failure-provisioning-code',
+    ]) {
+      expect(logs).not.toContain(sensitiveValue);
+    }
+
+    const logEntries = logs.trim().split('\n').map(JSON.parse);
+    const logEntriesForRoute = (url) => {
+      const requestLog = logEntries.find(
+        (entry) => entry.req?.url === url && entry.msg === 'incoming request',
+      );
+      return logEntries.filter((entry) => entry.reqId === requestLog.reqId);
+    };
+    const sensitiveLogs = logEntriesForRoute('/sensitive');
+    const sensitiveErrorLogs = logEntriesForRoute('/sensitive-error');
+    const publicLogs = logEntriesForRoute('/not-sensitive');
+
+    for (const logEntry of [...sensitiveLogs, ...sensitiveErrorLogs]) {
+      expect(logEntry).not.toHaveProperty('body');
+      expect(logEntry).not.toHaveProperty('headers');
+    }
+    expect(publicLogs).toContainEqual(
+      expect.objectContaining({
+        body: { request: 'public-request-body' },
+        msg: 'request',
+      }),
+    );
+    expect(publicLogs).toContainEqual(
+      expect.objectContaining({
+        body: { result: 'public-response-body' },
+        msg: 'response body',
+      }),
+    );
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2079,6 +2079,9 @@ importers:
       mongodb:
         specifier: ^7.5.0
         version: 7.5.0
+      pino-test:
+        specifier: ^2.0.0
+        version: 2.0.0
       prettier:
         specifier: 3.9.6
         version: 3.9.6
@@ -9862,6 +9865,9 @@ packages:
 
   pino-std-serializers@7.1.0:
     resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino-test@2.0.0:
+    resolution: {integrity: sha512-quHvIgAFMzm1Jx05xaHYRk2fdE/UQifabYzwGkbp8nbr34zxKcFPZqP5foGvk0EoqtepctrRTiDELvESOiwgIg==}
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
@@ -18317,6 +18323,10 @@ snapshots:
       strip-json-comments: 5.0.3
 
   pino-std-serializers@7.1.0: {}
+
+  pino-test@2.0.0:
+    dependencies:
+      split2: 4.2.0
 
   pino@10.3.1:
     dependencies:


### PR DESCRIPTION
## Stack

PR 1 of 6. This is the base of the Credentialing Hub operator-auth extension stack.

## Scope

- keep credential, provisioning-code, token, and KMS identifier redaction active at every log level
- suppress request/response bodies for routes marked `sensitiveLogging`, including error paths
- retain ordinary debug body logging for non-sensitive routes

## Why

Later M2M endpoints return and accept credentials. This establishes the reusable logging safety boundary before those extension points are introduced.

## Review size

5 files; 323 additions, 14 deletions. Tests remain with the implementation; planning/spec documents are excluded.

## Validation

- `@verii/logger`: 34 passed
- `@verii/server-provider`: 14 passed
- ESLint and diff checks: clean
