### PR TITLE
feat(db-kms): delete keys and secrets

### DIFF
--- a/packages/db-kms/src/db-kms.js
+++ b/packages/db-kms/src/db-kms.js
@@ -101,6 +101,23 @@ const initDbKms = (fastify, kmsOptions = {}) => {
     };
 
     /**
+     * Deletes a key or secret
+     * @param {Id} keyId the key or secret id to delete
+     * @returns {Promise<boolean>} whether a key or secret was deleted
+     */
+    const deleteKeyOrSecret = async (keyId) => {
+      const existing = await repo.findOne(
+        { filter: { _id: keyId } },
+        { _id: 1 },
+      );
+      if (existing == null) {
+        return false;
+      }
+      await repo.del(existing._id);
+      return true;
+    };
+
+    /**
      * The key to load internally
      * @param {Id} keyId the key id to load
      * @returns {Promise<KeySpec & { _id: Id, privateJwk: JsonWebKey, secret: string }>} the key returned
@@ -202,6 +219,7 @@ const initDbKms = (fastify, kmsOptions = {}) => {
       createKey,
       importKey,
       importSecret,
+      deleteKeyOrSecret,
       exportKeyOrSecret,
       signJwt,
       verifyJwt,

--- a/packages/db-kms/test/db-kms.test.js
+++ b/packages/db-kms/test/db-kms.test.js
@@ -208,6 +208,7 @@ describe('db kms', () => {
 
       await expect(kms.deleteKeyOrSecret(key.id)).resolves.toBe(true);
       await expect(kms.exportKeyOrSecret(key.id)).resolves.toBeNull();
+      await expect(kms.deleteKeyOrSecret(key.id)).resolves.toBe(false);
     });
   });
 

--- a/packages/db-kms/test/db-kms.test.js
+++ b/packages/db-kms/test/db-kms.test.js
@@ -196,6 +196,21 @@ describe('db kms', () => {
     });
   });
 
+  describe('deleting keys & secrets', () => {
+    it('should delete imported secrets and generated asymmetric keys', async () => {
+      const imported = await kms.importSecret({ secret: 'vnf-secret' });
+
+      await expect(kms.deleteKeyOrSecret(imported.id)).resolves.toBe(true);
+      await expect(kms.exportKeyOrSecret(imported.id)).resolves.toBeNull();
+      await expect(kms.deleteKeyOrSecret(imported.id)).resolves.toBe(false);
+
+      const key = await kms.createKey(keySpecs.es256);
+
+      await expect(kms.deleteKeyOrSecret(key.id)).resolves.toBe(true);
+      await expect(kms.exportKeyOrSecret(key.id)).resolves.toBeNull();
+    });
+  });
+
   describe('jwt operations', () => {
     let keys;
     let alternativeKeys;

--- a/packages/db-kms/types/types.d.ts
+++ b/packages/db-kms/types/types.d.ts
@@ -58,6 +58,7 @@ export interface KMS {
   createKey: (kmsSpec: KeySpec) => Promise<KmsKey>;
   importKey: (importableKey: ImportableKey) => Promise<KmsKey>;
   importSecret: (importableSecret: ImportableSecret) => Promise<KmsSecret>;
+  deleteKeyOrSecret: (keyId: Id) => Promise<boolean>;
   exportKeyOrSecret: (keyId: Id) => Promise<ExportedKey>;
   signJwt: (
     payload: Record<string, unknown>,


### PR DESCRIPTION
## Dependencies

Standalone. Base: `main`.

## Scope

- expose `deleteKeyOrSecret(keyId)` through the initialized KMS API
- return `true` when an existing key/secret is deleted and `false` when absent
- support imported secrets and generated asymmetric keys
- update the public TypeScript contract

## Why

Per-CAO blockchain credential replacement needs a generic way to delete superseded or unattached KMS material without adding CAO policy to `db-kms`.

## Review size

3 files; 35 additions. Tests remain with the implementation; planning/spec documents are excluded.

## Validation

- `@verii/db-kms`: 16 passed
- ESLint and diff checks: clean
