### PR TITLE
feat(base-contract-io): resolve VNF client OAuth creds

### DIFF
--- a/packages/base-contract-io/README.md
+++ b/packages/base-contract-io/README.md
@@ -1,11 +1,11 @@
 # `@verii/base-contract-io`
 
-## VNF client credential resolution
+## VNF client OAuth creds resolution
 
 The VNF authentication plugin decorates Fastify with
-`resolveVnfClientCredentials(request)`. Applications can install this
+`resolveVnfClientOAuthCreds(request)`. Applications can install this
 decorator before registering `authenticateVnfClientPlugin` to select VNF
-credentials for each request.
+OAuth creds for each request.
 
 Register the custom decorator before `authenticateVnfClientPlugin`. When the
 decorator is installed from another Fastify plugin, wrap that plugin with
@@ -14,22 +14,24 @@ Registering it later causes the authentication plugin to install its default
 decorator first, and the custom registration will fail because the decorator
 already exists.
 
-A resolver returns credential metadata and a lazy credential loader:
+A resolver returns OAuth client metadata and a lazy OAuth creds loader:
 
 ```js
-fastify.decorate('resolveVnfClientCredentials', async (request) => ({
-  cacheKey: `tenant:${request.tenantId}:version:2`,
-  loadCredentials: async () => ({
+fastify.decorate('resolveVnfClientOAuthCreds', async (request) => ({
+  cacheKey: request.tenantId,
+  loadOAuthCreds: async () => ({
     clientId: await readClientId(request.tenantId),
     clientSecret: await readClientSecret(request.tenantId),
   }),
 }));
 ```
 
-`cacheKey` must be a non-empty, stable, non-secret string that changes whenever
-the selected credential pair changes. Do not include a client secret, a digest
-of a client secret, or any value derived from a client secret. Tokens are
-cached by both their audience and this resolver cache key.
+`cacheKey` must be a non-empty, stable, non-secret string. Use the identity that
+owns the OAuth creds, such as a tenant or CAO DID. Do not include a client
+secret, a digest of a client secret, or any value derived from a client secret.
+Tokens are cached by both their audience and this resolver cache key, so an
+existing token remains usable until its normal expiry after the stored OAuth
+creds change.
 
 The plugin calls the resolver once per incoming Fastify request so that an
 application can select the current credential version. Blockchain operations
@@ -37,7 +39,7 @@ may make multiple JSON-RPC calls during that request; all of them reuse the
 same resolver result. A resolver rejection is likewise retained for the
 remainder of that request.
 
-The plugin invokes `loadCredentials` only when there is no live token for the
+The plugin invokes `loadOAuthCreds` only when there is no live token for the
 resulting audience and cache key. It must resolve to non-empty string
 `clientId` and `clientSecret` values. This allows credential stores such as KMS
 to remain untouched on token-cache hits.

--- a/packages/base-contract-io/README.md
+++ b/packages/base-contract-io/README.md
@@ -7,6 +7,13 @@ The VNF authentication plugin decorates Fastify with
 decorator before registering `authenticateVnfClientPlugin` to select VNF
 credentials for each request.
 
+Register the custom decorator before `authenticateVnfClientPlugin`. When the
+decorator is installed from another Fastify plugin, wrap that plugin with
+`fastify-plugin` so the decorator is visible to the authentication plugin.
+Registering it later causes the authentication plugin to install its default
+decorator first, and the custom registration will fail because the decorator
+already exists.
+
 A resolver returns credential metadata and a lazy credential loader:
 
 ```js
@@ -24,10 +31,16 @@ the selected credential pair changes. Do not include a client secret, a digest
 of a client secret, or any value derived from a client secret. Tokens are
 cached by both their audience and this resolver cache key.
 
-The plugin calls the resolver on every authentication so that an application
-can select the current credential version. It invokes `loadCredentials` only
-when there is no live token for the resulting audience and cache key. This
-allows credential stores such as KMS to remain untouched on token-cache hits.
+The plugin calls the resolver once per incoming Fastify request so that an
+application can select the current credential version. Blockchain operations
+may make multiple JSON-RPC calls during that request; all of them reuse the
+same resolver result. A resolver rejection is likewise retained for the
+remainder of that request.
+
+The plugin invokes `loadCredentials` only when there is no live token for the
+resulting audience and cache key. It must resolve to non-empty string
+`clientId` and `clientSecret` values. This allows credential stores such as KMS
+to remain untouched on token-cache hits.
 
 If an application does not install a resolver, the plugin installs a default
 one backed by `fastify.config.vnfClientId` and
@@ -35,3 +48,7 @@ one backed by `fastify.config.vnfClientId` and
 starts in this mode. A custom resolver is preserved as-is: if it rejects, the
 authentication rejects and the plugin does not fall back to the configured
 credentials.
+
+The published low-level `initAuthenticateVnfClient` function also continues to
+accept its original `{ audience, clientId, clientSecret }` input. New
+applications should prefer the resolver contract.

--- a/packages/base-contract-io/README.md
+++ b/packages/base-contract-io/README.md
@@ -1,1 +1,37 @@
-hi
+# `@verii/base-contract-io`
+
+## VNF client credential resolution
+
+The VNF authentication plugin decorates Fastify with
+`resolveVnfClientCredentials(request)`. Applications can install this
+decorator before registering `authenticateVnfClientPlugin` to select VNF
+credentials for each request.
+
+A resolver returns credential metadata and a lazy credential loader:
+
+```js
+fastify.decorate('resolveVnfClientCredentials', async (request) => ({
+  cacheKey: `tenant:${request.tenantId}:version:2`,
+  loadCredentials: async () => ({
+    clientId: await readClientId(request.tenantId),
+    clientSecret: await readClientSecret(request.tenantId),
+  }),
+}));
+```
+
+`cacheKey` must be a non-empty, stable, non-secret string that changes whenever
+the selected credential pair changes. Do not include a client secret, a digest
+of a client secret, or any value derived from a client secret. Tokens are
+cached by both their audience and this resolver cache key.
+
+The plugin calls the resolver on every authentication so that an application
+can select the current credential version. It invokes `loadCredentials` only
+when there is no live token for the resulting audience and cache key. This
+allows credential stores such as KMS to remain untouched on token-cache hits.
+
+If an application does not install a resolver, the plugin installs a default
+one backed by `fastify.config.vnfClientId` and
+`fastify.config.vnfClientSecret`. Both values are required when the plugin
+starts in this mode. A custom resolver is preserved as-is: if it rejects, the
+authentication rejects and the plugin does not fall back to the configured
+credentials.

--- a/packages/base-contract-io/src/authenticate-vnf-client.js
+++ b/packages/base-contract-io/src/authenticate-vnf-client.js
@@ -18,11 +18,38 @@
 const fp = require('fastify-plugin');
 const { addSeconds } = require('date-fns/fp');
 const { initHttpClient } = require('@verii/http-client');
+const once = require('lodash/once');
 
 const TOKEN_EXPIRATION_SAFE_BUFFER = 5;
 
 const buildTokenCacheKey = (audience, resolverCacheKey) =>
   JSON.stringify([audience, resolverCacheKey]);
+
+const isNonEmptyString = (value) =>
+  typeof value === 'string' && value.length > 0;
+
+const assertNonEmptyString = (value, field) => {
+  if (!isNonEmptyString(value)) {
+    throw new TypeError(`VNF credential resolver ${field} must be non-empty`);
+  }
+};
+
+const normalizeCredentialSource = ({
+  cacheKey,
+  loadCredentials,
+  clientId,
+  clientSecret,
+}) => {
+  const usesPublishedCredentials =
+    loadCredentials == null && (clientId != null || clientSecret != null);
+
+  return usesPublishedCredentials
+    ? {
+        cacheKey: `client:${clientId}`,
+        loadCredentials: async () => ({ clientId, clientSecret }),
+      }
+    : { cacheKey, loadCredentials };
+};
 
 const pruneExpiredTokens = (tokensCache) => {
   const now = new Date();
@@ -34,32 +61,34 @@ const pruneExpiredTokens = (tokensCache) => {
 };
 
 const initAuthenticateVnfClient = (fastify) => {
-  return async ({ audience, cacheKey, loadCredentials }, req) => {
-    if (typeof cacheKey !== 'string' || cacheKey.length === 0) {
-      throw new TypeError('VNF credential resolver cacheKey must be non-empty');
-    }
+  return async ({ audience, ...credentialSource }, req) => {
+    const { cacheKey, loadCredentials } =
+      normalizeCredentialSource(credentialSource);
+    assertNonEmptyString(cacheKey, 'cacheKey');
     if (typeof loadCredentials !== 'function') {
       throw new TypeError(
         'VNF credential resolver loadCredentials must be a function',
       );
     }
 
-    pruneExpiredTokens(fastify.vnfAuthTokensCache);
     const tokenCacheKey = buildTokenCacheKey(audience, cacheKey);
     const cachedToken = fastify.vnfAuthTokensCache.get(tokenCacheKey);
 
-    if (cachedToken) {
+    if (cachedToken?.expiresAt > new Date()) {
       return cachedToken.accessToken;
     }
 
-    const { clientId, clientSecret } = await loadCredentials();
+    pruneExpiredTokens(fastify.vnfAuthTokensCache);
+    const resolvedCredentials = await loadCredentials();
+    assertNonEmptyString(resolvedCredentials?.clientId, 'clientId');
+    assertNonEmptyString(resolvedCredentials?.clientSecret, 'clientSecret');
     const httpClient = initHttpClient(fastify.config)(req);
     const response = await httpClient.post(
       fastify.config.vnfOAuthTokensEndpoint,
       {
         grant_type: 'client_credentials',
-        client_id: clientId,
-        client_secret: clientSecret,
+        client_id: resolvedCredentials.clientId,
+        client_secret: resolvedCredentials.clientSecret,
         audience,
       },
     );
@@ -88,13 +117,18 @@ const initDefaultVnfClientCredentialsResolver = (fastify) => async () => ({
 
 const initAuthenticateVnfBlockchainClient = (fastify, req) => {
   const authenticateVnfClient = initAuthenticateVnfClient(fastify);
+  const resolveVnfClientCredentials = once(() =>
+    fastify.resolveVnfClientCredentials(req),
+  );
   return async () => {
-    const resolution = await fastify.resolveVnfClientCredentials(req);
+    const { cacheKey, loadCredentials } =
+      (await resolveVnfClientCredentials()) ?? {};
 
     return authenticateVnfClient(
       {
         audience: fastify.config.blockchainApiAudience,
-        ...resolution,
+        cacheKey,
+        loadCredentials,
       },
       req,
     );

--- a/packages/base-contract-io/src/authenticate-vnf-client.js
+++ b/packages/base-contract-io/src/authenticate-vnf-client.js
@@ -16,43 +16,23 @@
  */
 
 const fp = require('fastify-plugin');
-const { addSeconds } = require('date-fns/fp');
 const { initHttpClient } = require('@verii/http-client');
+const { isEmpty, isString } = require('lodash/fp');
 const once = require('lodash/once');
 
-const TOKEN_EXPIRATION_SAFE_BUFFER = 5;
+const TOKEN_EXPIRATION_SAFE_BUFFER_MS = 5000;
+const DEFAULT_OAUTH_CREDS_CACHE_KEY = 'default';
 
 const buildTokenCacheKey = (audience, resolverCacheKey) =>
   JSON.stringify([audience, resolverCacheKey]);
 
-const isNonEmptyString = (value) =>
-  typeof value === 'string' && value.length > 0;
-
 const assertNonEmptyString = (value, field) => {
-  if (!isNonEmptyString(value)) {
-    throw new TypeError(`VNF credential resolver ${field} must be non-empty`);
+  if (!isString(value) || isEmpty(value)) {
+    throw new TypeError(`VNF OAuth creds resolver ${field} must be non-empty`);
   }
 };
 
-const normalizeCredentialSource = ({
-  cacheKey,
-  loadCredentials,
-  clientId,
-  clientSecret,
-}) => {
-  const usesPublishedCredentials =
-    loadCredentials == null && (clientId != null || clientSecret != null);
-
-  return usesPublishedCredentials
-    ? {
-        cacheKey: `client:${clientId}`,
-        loadCredentials: async () => ({ clientId, clientSecret }),
-      }
-    : { cacheKey, loadCredentials };
-};
-
-const pruneExpiredTokens = (tokensCache) => {
-  const now = new Date();
+const pruneExpiredTokens = (tokensCache, now) => {
   for (const [key, token] of tokensCache) {
     if (!(token.expiresAt > now)) {
       tokensCache.delete(key);
@@ -61,44 +41,49 @@ const pruneExpiredTokens = (tokensCache) => {
 };
 
 const initAuthenticateVnfClient = (fastify) => {
-  return async ({ audience, ...credentialSource }, req) => {
-    const { cacheKey, loadCredentials } =
-      normalizeCredentialSource(credentialSource);
+  return async (
+    {
+      audience,
+      cacheKey = DEFAULT_OAUTH_CREDS_CACHE_KEY,
+      clientId,
+      clientSecret,
+      loadOAuthCreds = async () => ({ clientId, clientSecret }),
+    },
+    req,
+  ) => {
     assertNonEmptyString(cacheKey, 'cacheKey');
-    if (typeof loadCredentials !== 'function') {
-      throw new TypeError(
-        'VNF credential resolver loadCredentials must be a function',
-      );
-    }
 
     const tokenCacheKey = buildTokenCacheKey(audience, cacheKey);
     const cachedToken = fastify.vnfAuthTokensCache.get(tokenCacheKey);
+    const now = Date.now();
 
-    if (cachedToken?.expiresAt > new Date()) {
+    if (cachedToken?.expiresAt > now) {
       return cachedToken.accessToken;
     }
 
-    pruneExpiredTokens(fastify.vnfAuthTokensCache);
-    const resolvedCredentials = await loadCredentials();
-    assertNonEmptyString(resolvedCredentials?.clientId, 'clientId');
-    assertNonEmptyString(resolvedCredentials?.clientSecret, 'clientSecret');
+    pruneExpiredTokens(fastify.vnfAuthTokensCache, now);
+    const oauthCreds = await loadOAuthCreds();
+    const { clientId: oauthClientId, clientSecret: oauthClientSecret } =
+      oauthCreds ?? {};
+    assertNonEmptyString(oauthClientId, 'clientId');
+    assertNonEmptyString(oauthClientSecret, 'clientSecret');
     const httpClient = initHttpClient(fastify.config)(req);
     const response = await httpClient.post(
       fastify.config.vnfOAuthTokensEndpoint,
       {
         grant_type: 'client_credentials',
-        client_id: resolvedCredentials.clientId,
-        client_secret: resolvedCredentials.clientSecret,
+        client_id: oauthClientId,
+        client_secret: oauthClientSecret,
         audience,
       },
     );
     const authResult = await response.json();
     const token = {
       accessToken: authResult.access_token,
-      expiresAt: addSeconds(
-        authResult.expires_in - TOKEN_EXPIRATION_SAFE_BUFFER,
-        new Date(),
-      ),
+      expiresAt:
+        Date.now() +
+        authResult.expires_in * 1000 -
+        TOKEN_EXPIRATION_SAFE_BUFFER_MS,
     };
 
     fastify.vnfAuthTokensCache.set(tokenCacheKey, token);
@@ -107,9 +92,26 @@ const initAuthenticateVnfClient = (fastify) => {
   };
 };
 
-const initDefaultVnfClientCredentialsResolver = (fastify) => async () => ({
-  cacheKey: `config:${fastify.config.vnfClientId}`,
-  loadCredentials: async () => ({
+/**
+ * @typedef {object} OAuthCreds
+ * @property {string} clientId
+ * @property {string} clientSecret
+ */
+
+/**
+ * @typedef {object} OAuthCredsResolution
+ * @property {string} cacheKey A stable, non-secret token cache identity
+ * @property {() => Promise<OAuthCreds>} loadOAuthCreds Lazy OAuth creds loader
+ */
+
+/**
+ * @param {*} fastify Fastify instance
+ * @returns {() => Promise<OAuthCredsResolution>} the default OAuth creds
+ * resolver
+ */
+const initDefaultVnfClientOAuthCredsResolver = (fastify) => async () => ({
+  cacheKey: DEFAULT_OAUTH_CREDS_CACHE_KEY,
+  loadOAuthCreds: async () => ({
     clientId: fastify.config.vnfClientId,
     clientSecret: fastify.config.vnfClientSecret,
   }),
@@ -117,18 +119,18 @@ const initDefaultVnfClientCredentialsResolver = (fastify) => async () => ({
 
 const initAuthenticateVnfBlockchainClient = (fastify, req) => {
   const authenticateVnfClient = initAuthenticateVnfClient(fastify);
-  const resolveVnfClientCredentials = once(() =>
-    fastify.resolveVnfClientCredentials(req),
+  const resolveVnfClientOAuthCreds = once(() =>
+    fastify.resolveVnfClientOAuthCreds(req),
   );
   return async () => {
-    const { cacheKey, loadCredentials } =
-      (await resolveVnfClientCredentials()) ?? {};
+    const { cacheKey, loadOAuthCreds } =
+      (await resolveVnfClientOAuthCreds()) ?? {};
 
     return authenticateVnfClient(
       {
         audience: fastify.config.blockchainApiAudience,
         cacheKey,
-        loadCredentials,
+        loadOAuthCreds,
       },
       req,
     );
@@ -136,7 +138,7 @@ const initAuthenticateVnfBlockchainClient = (fastify, req) => {
 };
 
 const initAuthenticateVnfClientPlugin = (fastify, options, next) => {
-  if (!fastify.hasDecorator('resolveVnfClientCredentials')) {
+  if (!fastify.hasDecorator('resolveVnfClientOAuthCreds')) {
     if (!fastify.config.vnfClientId) {
       throw new Error('fastify.config.vnfClientId is required');
     }
@@ -145,8 +147,8 @@ const initAuthenticateVnfClientPlugin = (fastify, options, next) => {
     }
 
     fastify.decorate(
-      'resolveVnfClientCredentials',
-      initDefaultVnfClientCredentialsResolver(fastify),
+      'resolveVnfClientOAuthCreds',
+      initDefaultVnfClientOAuthCredsResolver(fastify),
     );
   }
 

--- a/packages/base-contract-io/src/authenticate-vnf-client.js
+++ b/packages/base-contract-io/src/authenticate-vnf-client.js
@@ -21,52 +21,101 @@ const { initHttpClient } = require('@verii/http-client');
 
 const TOKEN_EXPIRATION_SAFE_BUFFER = 5;
 
-const isTokenCached = (tokensCache, audience) =>
-  tokensCache.get(audience) && tokensCache.get(audience).expiresAt > new Date();
+const buildTokenCacheKey = (audience, resolverCacheKey) =>
+  JSON.stringify([audience, resolverCacheKey]);
+
+const pruneExpiredTokens = (tokensCache) => {
+  const now = new Date();
+  for (const [key, token] of tokensCache) {
+    if (!(token.expiresAt > now)) {
+      tokensCache.delete(key);
+    }
+  }
+};
 
 const initAuthenticateVnfClient = (fastify) => {
-  return async ({ audience, clientId, clientSecret }, req) => {
-    const httpClient = initHttpClient(fastify.config)(req);
-
-    if (!isTokenCached(fastify.vnfAuthTokensCache, audience)) {
-      const response = await httpClient.post(
-        fastify.config.vnfOAuthTokensEndpoint,
-        {
-          grant_type: 'client_credentials',
-          client_id: clientId,
-          client_secret: clientSecret,
-          audience,
-        },
+  return async ({ audience, cacheKey, loadCredentials }, req) => {
+    if (typeof cacheKey !== 'string' || cacheKey.length === 0) {
+      throw new TypeError('VNF credential resolver cacheKey must be non-empty');
+    }
+    if (typeof loadCredentials !== 'function') {
+      throw new TypeError(
+        'VNF credential resolver loadCredentials must be a function',
       );
-
-      const authResult = await response.json();
-
-      fastify.vnfAuthTokensCache.set(audience, {
-        accessToken: authResult.access_token,
-        expiresAt: addSeconds(
-          authResult.expires_in - TOKEN_EXPIRATION_SAFE_BUFFER,
-          new Date(),
-        ),
-      });
     }
 
-    return fastify.vnfAuthTokensCache.get(audience).accessToken;
+    pruneExpiredTokens(fastify.vnfAuthTokensCache);
+    const tokenCacheKey = buildTokenCacheKey(audience, cacheKey);
+    const cachedToken = fastify.vnfAuthTokensCache.get(tokenCacheKey);
+
+    if (cachedToken) {
+      return cachedToken.accessToken;
+    }
+
+    const { clientId, clientSecret } = await loadCredentials();
+    const httpClient = initHttpClient(fastify.config)(req);
+    const response = await httpClient.post(
+      fastify.config.vnfOAuthTokensEndpoint,
+      {
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: clientSecret,
+        audience,
+      },
+    );
+    const authResult = await response.json();
+    const token = {
+      accessToken: authResult.access_token,
+      expiresAt: addSeconds(
+        authResult.expires_in - TOKEN_EXPIRATION_SAFE_BUFFER,
+        new Date(),
+      ),
+    };
+
+    fastify.vnfAuthTokensCache.set(tokenCacheKey, token);
+
+    return token.accessToken;
   };
 };
+
+const initDefaultVnfClientCredentialsResolver = (fastify) => async () => ({
+  cacheKey: `config:${fastify.config.vnfClientId}`,
+  loadCredentials: async () => ({
+    clientId: fastify.config.vnfClientId,
+    clientSecret: fastify.config.vnfClientSecret,
+  }),
+});
+
 const initAuthenticateVnfBlockchainClient = (fastify, req) => {
   const authenticateVnfClient = initAuthenticateVnfClient(fastify);
-  return () =>
-    authenticateVnfClient(
+  return async () => {
+    const resolution = await fastify.resolveVnfClientCredentials(req);
+
+    return authenticateVnfClient(
       {
         audience: fastify.config.blockchainApiAudience,
-        clientId: fastify.config.vnfClientId,
-        clientSecret: fastify.config.vnfClientSecret,
+        ...resolution,
       },
       req,
     );
+  };
 };
 
 const initAuthenticateVnfClientPlugin = (fastify, options, next) => {
+  if (!fastify.hasDecorator('resolveVnfClientCredentials')) {
+    if (!fastify.config.vnfClientId) {
+      throw new Error('fastify.config.vnfClientId is required');
+    }
+    if (!fastify.config.vnfClientSecret) {
+      throw new Error('fastify.config.vnfClientSecret is required');
+    }
+
+    fastify.decorate(
+      'resolveVnfClientCredentials',
+      initDefaultVnfClientCredentialsResolver(fastify),
+    );
+  }
+
   fastify
     .decorate('vnfAuthTokensCache', new Map())
     .decorateRequest('vnfBlockchainAuthenticate', null)

--- a/packages/base-contract-io/test/authenticate-vnf-client.test.js
+++ b/packages/base-contract-io/test/authenticate-vnf-client.test.js
@@ -105,7 +105,7 @@ describe('VNF Identity Provider Authentication', () => {
   describe('VNF authenticate', () => {
     it('loads credentials lazily and posts the client credentials grant', async () => {
       tokenResponses.push({ access_token: 'TOKEN', expires_in: 60 });
-      const loadCredentials = mock.fn(async () => ({
+      const loadOAuthCreds = mock.fn(async () => ({
         clientId: 'cao-a-client',
         clientSecret: 'cao-a-secret',
       }));
@@ -114,13 +114,13 @@ describe('VNF Identity Provider Authentication', () => {
         {
           audience: BLOCKCHAIN_AUDIENCE,
           cacheKey: 'did:velocity:cao-a:3',
-          loadCredentials,
+          loadOAuthCreds,
         },
         {},
       );
 
       expect(result).toEqual('TOKEN');
-      expect(loadCredentials.mock.callCount()).toEqual(1);
+      expect(loadOAuthCreds.mock.callCount()).toEqual(1);
       expect(post.mock.calls[0].arguments).toEqual([
         TOKEN_ENDPOINT,
         {
@@ -153,23 +153,50 @@ describe('VNF Identity Provider Authentication', () => {
       });
     });
 
+    it('reuses the legacy token cache without deriving its key from the client ID', async () => {
+      tokenResponses.push({ access_token: 'LEGACY_TOKEN', expires_in: 60 });
+
+      const firstToken = await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          clientId: 'legacy-client-a',
+          clientSecret: 'legacy-secret-a',
+        },
+        {},
+      );
+      const secondToken = await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          clientId: 'legacy-client-b',
+          clientSecret: 'legacy-secret-b',
+        },
+        {},
+      );
+
+      expect([firstToken, secondToken]).toEqual([
+        'LEGACY_TOKEN',
+        'LEGACY_TOKEN',
+      ]);
+      expect(post.mock.callCount()).toEqual(1);
+    });
+
     it('reuses a token for the same audience and resolver cache key', async () => {
       tokenResponses.push({ access_token: 'TOKEN', expires_in: 60 });
-      const loadCredentials = mock.fn(async () => ({
+      const loadOAuthCreds = mock.fn(async () => ({
         clientId: 'cao-a-client',
         clientSecret: 'cao-a-secret',
       }));
       const authentication = {
         audience: BLOCKCHAIN_AUDIENCE,
         cacheKey: 'did:velocity:cao-a:3',
-        loadCredentials,
+        loadOAuthCreds,
       };
 
       const firstToken = await authenticateVnfClient(authentication, {});
       const secondToken = await authenticateVnfClient(authentication, {});
 
       expect([firstToken, secondToken]).toEqual(['TOKEN', 'TOKEN']);
-      expect(loadCredentials.mock.callCount()).toEqual(1);
+      expect(loadOAuthCreds.mock.callCount()).toEqual(1);
       expect(post.mock.callCount()).toEqual(1);
     });
 
@@ -185,7 +212,7 @@ describe('VNF Identity Provider Authentication', () => {
         JSON.stringify([BLOCKCHAIN_AUDIENCE, 'did:velocity:cao-a:3']),
         {
           accessToken: 'CACHED_TOKEN',
-          expiresAt: new Date(Date.now() + 60000),
+          expiresAt: Date.now() + 60000,
         },
       );
 
@@ -193,7 +220,7 @@ describe('VNF Identity Provider Authentication', () => {
         {
           audience: BLOCKCHAIN_AUDIENCE,
           cacheKey: 'did:velocity:cao-a:3',
-          loadCredentials: async () => {
+          loadOAuthCreds: async () => {
             throw new Error('credentials should not be loaded');
           },
         },
@@ -209,11 +236,11 @@ describe('VNF Identity Provider Authentication', () => {
         { access_token: 'CAO_A_TOKEN', expires_in: 60 },
         { access_token: 'CAO_B_TOKEN', expires_in: 60 },
       );
-      const loadCaoACredentials = mock.fn(async () => ({
+      const loadCaoAOAuthCreds = mock.fn(async () => ({
         clientId: 'cao-a-client',
         clientSecret: 'cao-a-secret',
       }));
-      const loadCaoBCredentials = mock.fn(async () => ({
+      const loadCaoBOAuthCreds = mock.fn(async () => ({
         clientId: 'cao-b-client',
         clientSecret: 'cao-b-secret',
       }));
@@ -222,7 +249,7 @@ describe('VNF Identity Provider Authentication', () => {
         {
           audience: BLOCKCHAIN_AUDIENCE,
           cacheKey: 'did:velocity:cao-a:3',
-          loadCredentials: loadCaoACredentials,
+          loadOAuthCreds: loadCaoAOAuthCreds,
         },
         {},
       );
@@ -230,7 +257,7 @@ describe('VNF Identity Provider Authentication', () => {
         {
           audience: BLOCKCHAIN_AUDIENCE,
           cacheKey: 'did:velocity:cao-b:7',
-          loadCredentials: loadCaoBCredentials,
+          loadOAuthCreds: loadCaoBOAuthCreds,
         },
         {},
       );
@@ -244,21 +271,21 @@ describe('VNF Identity Provider Authentication', () => {
         { access_token: 'EXPIRED_TOKEN', expires_in: 0 },
         { access_token: 'FRESH_TOKEN', expires_in: 60 },
       );
-      const loadCredentials = mock.fn(async () => ({
+      const loadOAuthCreds = mock.fn(async () => ({
         clientId: 'cao-a-client',
         clientSecret: 'cao-a-secret',
       }));
       const authentication = {
         audience: BLOCKCHAIN_AUDIENCE,
         cacheKey: 'did:velocity:cao-a:3',
-        loadCredentials,
+        loadOAuthCreds,
       };
 
       await authenticateVnfClient(authentication, {});
       const result = await authenticateVnfClient(authentication, {});
 
       expect(result).toEqual('FRESH_TOKEN');
-      expect(loadCredentials.mock.callCount()).toEqual(2);
+      expect(loadOAuthCreds.mock.callCount()).toEqual(2);
       expect(post.mock.callCount()).toEqual(2);
     });
 
@@ -266,18 +293,18 @@ describe('VNF Identity Provider Authentication', () => {
       tokenResponses.push({ access_token: 'NEW_TOKEN', expires_in: 60 });
       fastify.vnfAuthTokensCache.set('legacy-unreachable-entry', {
         accessToken: 'EXPIRED_TOKEN',
-        expiresAt: new Date(0),
+        expiresAt: 0,
       });
       fastify.vnfAuthTokensCache.set('live-entry', {
         accessToken: 'LIVE_TOKEN',
-        expiresAt: new Date(Date.now() + 60000),
+        expiresAt: Date.now() + 60000,
       });
 
       await authenticateVnfClient(
         {
           audience: BLOCKCHAIN_AUDIENCE,
           cacheKey: 'did:velocity:cao-a:3',
-          loadCredentials: async () => ({
+          loadOAuthCreds: async () => ({
             clientId: 'cao-a-client',
             clientSecret: 'cao-a-secret',
           }),
@@ -293,7 +320,7 @@ describe('VNF Identity Provider Authentication', () => {
     });
 
     it('rejects an empty resolver cache key before loading credentials', async () => {
-      const loadCredentials = mock.fn(async () => ({
+      const loadOAuthCreds = mock.fn(async () => ({
         clientId: 'cao-a-client',
         clientSecret: 'cao-a-secret',
       }));
@@ -303,26 +330,12 @@ describe('VNF Identity Provider Authentication', () => {
           {
             audience: BLOCKCHAIN_AUDIENCE,
             cacheKey: '',
-            loadCredentials,
+            loadOAuthCreds,
           },
           {},
         ),
       ).rejects.toThrow('cacheKey');
-      expect(loadCredentials.mock.callCount()).toEqual(0);
-      expect(post.mock.callCount()).toEqual(0);
-    });
-
-    it('rejects a non-function credential loader before requesting a token', async () => {
-      await expect(
-        authenticateVnfClient(
-          {
-            audience: BLOCKCHAIN_AUDIENCE,
-            cacheKey: 'did:velocity:cao-a:3',
-            loadCredentials: null,
-          },
-          {},
-        ),
-      ).rejects.toThrow('loadCredentials');
+      expect(loadOAuthCreds.mock.callCount()).toEqual(0);
       expect(post.mock.callCount()).toEqual(0);
     });
 
@@ -332,7 +345,7 @@ describe('VNF Identity Provider Authentication', () => {
           {
             audience: BLOCKCHAIN_AUDIENCE,
             cacheKey: 'did:velocity:cao-a:3',
-            loadCredentials: async () => ({
+            loadOAuthCreds: async () => ({
               clientSecret: 'cao-a-secret',
             }),
           },
@@ -348,7 +361,7 @@ describe('VNF Identity Provider Authentication', () => {
           {
             audience: BLOCKCHAIN_AUDIENCE,
             cacheKey: 'did:velocity:cao-a:3',
-            loadCredentials: async () => ({
+            loadOAuthCreds: async () => ({
               clientId: 'cao-a-client',
             }),
           },
@@ -368,11 +381,11 @@ describe('VNF Identity Provider Authentication', () => {
       });
 
       await registerPlugin(fastify);
-      const resolution = await fastify.resolveVnfClientCredentials({});
+      const resolution = await fastify.resolveVnfClientOAuthCreds({});
       const result = await invokeRequestAuthentication(fastify);
 
-      expect(resolution.cacheKey).toEqual('config:configured-client');
-      await expect(resolution.loadCredentials()).resolves.toEqual({
+      expect(resolution.cacheKey).toEqual('default');
+      await expect(resolution.loadOAuthCreds()).resolves.toEqual({
         clientId: 'configured-client',
         clientSecret: 'configured-secret',
       });
@@ -387,19 +400,19 @@ describe('VNF Identity Provider Authentication', () => {
 
     it('resolves metadata for every request but loads credentials only on a cache miss', async () => {
       tokenResponses.push({ access_token: 'CUSTOM_TOKEN', expires_in: 60 });
-      const loadCredentials = mock.fn(async () => ({
+      const loadOAuthCreds = mock.fn(async () => ({
         clientId: 'cao-a-client',
         clientSecret: 'cao-a-secret',
       }));
-      const resolveVnfClientCredentials = mock.fn(async () => ({
+      const resolveVnfClientOAuthCreds = mock.fn(async () => ({
         cacheKey: 'did:velocity:cao-a:3',
-        loadCredentials,
+        loadOAuthCreds,
       }));
       fastify = createFastify({
         vnfClientId: undefined,
         vnfClientSecret: undefined,
       });
-      fastify.resolveVnfClientCredentials = resolveVnfClientCredentials;
+      fastify.resolveVnfClientOAuthCreds = resolveVnfClientOAuthCreds;
 
       await registerPlugin(fastify);
       const firstToken = await invokeRequestAuthentication(fastify, {
@@ -413,16 +426,16 @@ describe('VNF Identity Provider Authentication', () => {
         'CUSTOM_TOKEN',
         'CUSTOM_TOKEN',
       ]);
-      expect(resolveVnfClientCredentials.mock.callCount()).toEqual(2);
-      expect(loadCredentials.mock.callCount()).toEqual(1);
+      expect(resolveVnfClientOAuthCreds.mock.callCount()).toEqual(2);
+      expect(loadOAuthCreds.mock.callCount()).toEqual(1);
       expect(post.mock.callCount()).toEqual(1);
     });
 
     it('resolves credential metadata once when a request makes multiple RPC calls', async () => {
       tokenResponses.push({ access_token: 'CUSTOM_TOKEN', expires_in: 60 });
-      const resolveVnfClientCredentials = mock.fn(async () => ({
+      const resolveVnfClientOAuthCreds = mock.fn(async () => ({
         cacheKey: 'did:velocity:cao-a:3',
-        loadCredentials: async () => ({
+        loadOAuthCreds: async () => ({
           clientId: 'cao-a-client',
           clientSecret: 'cao-a-secret',
         }),
@@ -431,7 +444,7 @@ describe('VNF Identity Provider Authentication', () => {
         vnfClientId: undefined,
         vnfClientSecret: undefined,
       });
-      fastify.resolveVnfClientCredentials = resolveVnfClientCredentials;
+      fastify.resolveVnfClientOAuthCreds = resolveVnfClientOAuthCreds;
       const request = { id: 'request-1' };
 
       await registerPlugin(fastify);
@@ -443,7 +456,7 @@ describe('VNF Identity Provider Authentication', () => {
         'CUSTOM_TOKEN',
         'CUSTOM_TOKEN',
       ]);
-      expect(resolveVnfClientCredentials.mock.callCount()).toEqual(1);
+      expect(resolveVnfClientOAuthCreds.mock.callCount()).toEqual(1);
       expect(post.mock.callCount()).toEqual(1);
     });
 
@@ -451,7 +464,7 @@ describe('VNF Identity Provider Authentication', () => {
       tokenResponses.push({ access_token: 'CUSTOM_TOKEN', expires_in: 60 });
       const customResolver = async () => ({
         cacheKey: 'did:velocity:cao-a:3',
-        loadCredentials: async () => ({
+        loadOAuthCreds: async () => ({
           clientId: 'custom-client',
           clientSecret: 'custom-secret',
         }),
@@ -460,13 +473,13 @@ describe('VNF Identity Provider Authentication', () => {
         vnfClientId: undefined,
         vnfClientSecret: undefined,
       });
-      fastify.resolveVnfClientCredentials = customResolver;
+      fastify.resolveVnfClientOAuthCreds = customResolver;
 
       await registerPlugin(fastify);
       const result = await invokeRequestAuthentication(fastify);
 
       expect(result).toEqual('CUSTOM_TOKEN');
-      expect(fastify.resolveVnfClientCredentials).toBe(customResolver);
+      expect(fastify.resolveVnfClientOAuthCreds).toBe(customResolver);
       expect(post.mock.calls[0].arguments[1]).toEqual({
         grant_type: 'client_credentials',
         client_id: 'custom-client',
@@ -481,10 +494,10 @@ describe('VNF Identity Provider Authentication', () => {
         vnfClientId: undefined,
         vnfClientSecret: undefined,
       });
-      fastify.resolveVnfClientCredentials = async () => ({
+      fastify.resolveVnfClientOAuthCreds = async () => ({
         audience: 'https://unexpected-audience.test',
         cacheKey: 'did:velocity:cao-a:3',
-        loadCredentials: async () => ({
+        loadOAuthCreds: async () => ({
           clientId: 'custom-client',
           clientSecret: 'custom-secret',
         }),
@@ -520,7 +533,7 @@ describe('VNF Identity Provider Authentication', () => {
       });
       fastify = createFastify();
       fastify.config = config;
-      fastify.resolveVnfClientCredentials = async () => {
+      fastify.resolveVnfClientOAuthCreds = async () => {
         throw customError;
       };
 

--- a/packages/base-contract-io/test/authenticate-vnf-client.test.js
+++ b/packages/base-contract-io/test/authenticate-vnf-client.test.js
@@ -132,6 +132,27 @@ describe('VNF Identity Provider Authentication', () => {
       ]);
     });
 
+    it('accepts the published client ID and secret input shape', async () => {
+      tokenResponses.push({ access_token: 'LEGACY_TOKEN', expires_in: 60 });
+
+      const result = await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          clientId: 'legacy-client',
+          clientSecret: 'legacy-secret',
+        },
+        {},
+      );
+
+      expect(result).toEqual('LEGACY_TOKEN');
+      expect(post.mock.calls[0].arguments[1]).toEqual({
+        grant_type: 'client_credentials',
+        client_id: 'legacy-client',
+        client_secret: 'legacy-secret',
+        audience: BLOCKCHAIN_AUDIENCE,
+      });
+    });
+
     it('reuses a token for the same audience and resolver cache key', async () => {
       tokenResponses.push({ access_token: 'TOKEN', expires_in: 60 });
       const loadCredentials = mock.fn(async () => ({
@@ -150,6 +171,37 @@ describe('VNF Identity Provider Authentication', () => {
       expect([firstToken, secondToken]).toEqual(['TOKEN', 'TOKEN']);
       expect(loadCredentials.mock.callCount()).toEqual(1);
       expect(post.mock.callCount()).toEqual(1);
+    });
+
+    it('returns a live cached token without examining unrelated cache entries', async () => {
+      const unrelatedToken = { accessToken: 'UNRELATED_TOKEN' };
+      Object.defineProperty(unrelatedToken, 'expiresAt', {
+        get: () => {
+          throw new Error('unrelated cache entry was examined');
+        },
+      });
+      fastify.vnfAuthTokensCache.set('unrelated-entry', unrelatedToken);
+      fastify.vnfAuthTokensCache.set(
+        JSON.stringify([BLOCKCHAIN_AUDIENCE, 'did:velocity:cao-a:3']),
+        {
+          accessToken: 'CACHED_TOKEN',
+          expiresAt: new Date(Date.now() + 60000),
+        },
+      );
+
+      const result = await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          cacheKey: 'did:velocity:cao-a:3',
+          loadCredentials: async () => {
+            throw new Error('credentials should not be loaded');
+          },
+        },
+        {},
+      );
+
+      expect(result).toEqual('CACHED_TOKEN');
+      expect(post.mock.callCount()).toEqual(0);
     });
 
     it('requests separate tokens for two resolver cache keys', async () => {
@@ -273,6 +325,38 @@ describe('VNF Identity Provider Authentication', () => {
       ).rejects.toThrow('loadCredentials');
       expect(post.mock.callCount()).toEqual(0);
     });
+
+    it('rejects a missing loaded client ID before requesting a token', async () => {
+      await expect(
+        authenticateVnfClient(
+          {
+            audience: BLOCKCHAIN_AUDIENCE,
+            cacheKey: 'did:velocity:cao-a:3',
+            loadCredentials: async () => ({
+              clientSecret: 'cao-a-secret',
+            }),
+          },
+          {},
+        ),
+      ).rejects.toThrow('clientId');
+      expect(post.mock.callCount()).toEqual(0);
+    });
+
+    it('rejects a missing loaded client secret before requesting a token', async () => {
+      await expect(
+        authenticateVnfClient(
+          {
+            audience: BLOCKCHAIN_AUDIENCE,
+            cacheKey: 'did:velocity:cao-a:3',
+            loadCredentials: async () => ({
+              clientId: 'cao-a-client',
+            }),
+          },
+          {},
+        ),
+      ).rejects.toThrow('clientSecret');
+      expect(post.mock.callCount()).toEqual(0);
+    });
   });
 
   describe('VNF authentication plugin', () => {
@@ -334,6 +418,35 @@ describe('VNF Identity Provider Authentication', () => {
       expect(post.mock.callCount()).toEqual(1);
     });
 
+    it('resolves credential metadata once when a request makes multiple RPC calls', async () => {
+      tokenResponses.push({ access_token: 'CUSTOM_TOKEN', expires_in: 60 });
+      const resolveVnfClientCredentials = mock.fn(async () => ({
+        cacheKey: 'did:velocity:cao-a:3',
+        loadCredentials: async () => ({
+          clientId: 'cao-a-client',
+          clientSecret: 'cao-a-secret',
+        }),
+      }));
+      fastify = createFastify({
+        vnfClientId: undefined,
+        vnfClientSecret: undefined,
+      });
+      fastify.resolveVnfClientCredentials = resolveVnfClientCredentials;
+      const request = { id: 'request-1' };
+
+      await registerPlugin(fastify);
+      await fastify.runPreValidation(request);
+      const firstToken = await request.vnfBlockchainAuthenticate();
+      const secondToken = await request.vnfBlockchainAuthenticate();
+
+      expect([firstToken, secondToken]).toEqual([
+        'CUSTOM_TOKEN',
+        'CUSTOM_TOKEN',
+      ]);
+      expect(resolveVnfClientCredentials.mock.callCount()).toEqual(1);
+      expect(post.mock.callCount()).toEqual(1);
+    });
+
     it('preserves a pre-existing custom credential resolver', async () => {
       tokenResponses.push({ access_token: 'CUSTOM_TOKEN', expires_in: 60 });
       const customResolver = async () => ({
@@ -360,6 +473,29 @@ describe('VNF Identity Provider Authentication', () => {
         client_secret: 'custom-secret',
         audience: BLOCKCHAIN_AUDIENCE,
       });
+    });
+
+    it('ignores an audience returned by a custom credential resolver', async () => {
+      tokenResponses.push({ access_token: 'CUSTOM_TOKEN', expires_in: 60 });
+      fastify = createFastify({
+        vnfClientId: undefined,
+        vnfClientSecret: undefined,
+      });
+      fastify.resolveVnfClientCredentials = async () => ({
+        audience: 'https://unexpected-audience.test',
+        cacheKey: 'did:velocity:cao-a:3',
+        loadCredentials: async () => ({
+          clientId: 'custom-client',
+          clientSecret: 'custom-secret',
+        }),
+      });
+
+      await registerPlugin(fastify);
+      await invokeRequestAuthentication(fastify);
+
+      expect(post.mock.calls[0].arguments[1].audience).toEqual(
+        BLOCKCHAIN_AUDIENCE,
+      );
     });
 
     it('returns a custom resolver rejection without falling back to config', async () => {

--- a/packages/base-contract-io/test/authenticate-vnf-client.test.js
+++ b/packages/base-contract-io/test/authenticate-vnf-client.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-const { mock, beforeEach, describe, it, after } = require('node:test');
+const { after, beforeEach, describe, it, mock } = require('node:test');
 const { expect } = require('expect');
 
 const initHttpClient = mock.fn();
@@ -22,128 +22,390 @@ mock.module('@verii/http-client', { namedExports: { initHttpClient } });
 
 const {
   initAuthenticateVnfClient,
-  initAuthenticateVnfBlockchainClient,
   initAuthenticateVnfClientPlugin,
 } = require('../src/authenticate-vnf-client');
 
-describe('VNF Identity Provider Authentication', () => {
-  const addHook2 = mock.fn(() => {});
-  const decorateRequest2 = mock.fn(() => ({ addHook: addHook2 }));
-  const addHook = mock.fn(() => ({ decorateRequest: decorateRequest2 }));
-  const decorateRequest = mock.fn(() => ({ addHook }));
-  const decorate = mock.fn(() => ({ decorateRequest }));
-  const createFastify = () => ({
-    config: {},
-    vnfAuthTokensCache: new Map(),
-    decorate,
-  });
-  const tokenResult = {
-    access_token: 'TOKEN',
-    expires_in: 60,
+const TOKEN_ENDPOINT = 'https://auth.velocitynetwork.test/oauth/token';
+const BLOCKCHAIN_AUDIENCE = 'https://velocitynetwork.node';
+
+const createFastify = (config = {}) => {
+  const hooks = new Map();
+  const fastify = {
+    config: {
+      vnfClientId: 'config-client',
+      vnfClientSecret: 'config-secret',
+      vnfOAuthTokensEndpoint: TOKEN_ENDPOINT,
+      blockchainApiAudience: BLOCKCHAIN_AUDIENCE,
+      ...config,
+    },
+    decorate(name, value) {
+      this[name] = value;
+      return this;
+    },
+    hasDecorator(name) {
+      return Object.hasOwn(this, name);
+    },
+    decorateRequest() {
+      return this;
+    },
+    addHook(name, hook) {
+      hooks.set(name, hook);
+      return this;
+    },
+    runPreValidation: async (request) => {
+      await hooks.get('preValidation')(request);
+    },
   };
-  const undiciMockPost = mock.fn((result) => ({
-    json: () => Promise.resolve(result),
-  }));
-  const undiciMock = (result) => () => ({
-    post: () => undiciMockPost(result),
+
+  return fastify;
+};
+
+const registerPlugin = async (fastify) =>
+  new Promise((resolve, reject) => {
+    try {
+      initAuthenticateVnfClientPlugin(fastify, {}, (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    } catch (error) {
+      reject(error);
+    }
   });
+
+const invokeRequestAuthentication = async (fastify, request = {}) => {
+  await fastify.runPreValidation(request);
+  return request.vnfBlockchainAuthenticate();
+};
+
+describe('VNF Identity Provider Authentication', () => {
+  const tokenResponses = [];
+  const post = mock.fn(async () => ({
+    json: async () => tokenResponses.shift(),
+  }));
   let fastify;
-  let vnfAuthenticate;
+  let authenticateVnfClient;
 
   beforeEach(() => {
     initHttpClient.mock.resetCalls();
-    undiciMockPost.mock.resetCalls();
+    post.mock.resetCalls();
+    tokenResponses.length = 0;
+    initHttpClient.mock.mockImplementation(() => () => ({ post }));
     fastify = createFastify();
-    vnfAuthenticate = initAuthenticateVnfClient(fastify);
+    fastify.vnfAuthTokensCache = new Map();
+    authenticateVnfClient = initAuthenticateVnfClient(fastify);
   });
 
   after(() => {
     mock.reset();
   });
 
-  describe('VNF Authenticate', () => {
-    it('Base VNF authenticate call', async () => {
-      initHttpClient.mock.mockImplementationOnce(() => undiciMock(tokenResult));
+  describe('VNF authenticate', () => {
+    it('loads credentials lazily and posts the client credentials grant', async () => {
+      tokenResponses.push({ access_token: 'TOKEN', expires_in: 60 });
+      const loadCredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
 
-      const result = await vnfAuthenticate('API-IDENTIFIER');
+      const result = await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          cacheKey: 'did:velocity:cao-a:3',
+          loadCredentials,
+        },
+        {},
+      );
 
-      expect(result).toEqual(tokenResult.access_token);
+      expect(result).toEqual('TOKEN');
+      expect(loadCredentials.mock.callCount()).toEqual(1);
+      expect(post.mock.calls[0].arguments).toEqual([
+        TOKEN_ENDPOINT,
+        {
+          grant_type: 'client_credentials',
+          client_id: 'cao-a-client',
+          client_secret: 'cao-a-secret',
+          audience: BLOCKCHAIN_AUDIENCE,
+        },
+      ]);
     });
 
-    it('Get cached token', async () => {
-      initHttpClient.mock.mockImplementationOnce(() => undiciMock(tokenResult));
-
-      await vnfAuthenticate('API-IDENTIFIER');
-
-      const otherTokenResult = {
-        ...tokenResult,
-        access_token: 'OTHER_TOKEN',
+    it('reuses a token for the same audience and resolver cache key', async () => {
+      tokenResponses.push({ access_token: 'TOKEN', expires_in: 60 });
+      const loadCredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
+      const authentication = {
+        audience: BLOCKCHAIN_AUDIENCE,
+        cacheKey: 'did:velocity:cao-a:3',
+        loadCredentials,
       };
 
-      initHttpClient.mock.mockImplementationOnce(() =>
-        undiciMock(otherTokenResult),
-      );
+      const firstToken = await authenticateVnfClient(authentication, {});
+      const secondToken = await authenticateVnfClient(authentication, {});
 
-      const result = await vnfAuthenticate('API-IDENTIFIER');
-
-      expect(result).toEqual(tokenResult.access_token);
+      expect([firstToken, secondToken]).toEqual(['TOKEN', 'TOKEN']);
+      expect(loadCredentials.mock.callCount()).toEqual(1);
+      expect(post.mock.callCount()).toEqual(1);
     });
 
-    it('Get new token when cached expired', async () => {
-      initHttpClient.mock.mockImplementationOnce(() =>
-        undiciMock({
-          ...tokenResult,
-          expires_in: 0,
-        }),
+    it('requests separate tokens for two resolver cache keys', async () => {
+      tokenResponses.push(
+        { access_token: 'CAO_A_TOKEN', expires_in: 60 },
+        { access_token: 'CAO_B_TOKEN', expires_in: 60 },
+      );
+      const loadCaoACredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
+      const loadCaoBCredentials = mock.fn(async () => ({
+        clientId: 'cao-b-client',
+        clientSecret: 'cao-b-secret',
+      }));
+
+      const caoAToken = await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          cacheKey: 'did:velocity:cao-a:3',
+          loadCredentials: loadCaoACredentials,
+        },
+        {},
+      );
+      const caoBToken = await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          cacheKey: 'did:velocity:cao-b:7',
+          loadCredentials: loadCaoBCredentials,
+        },
+        {},
       );
 
-      await vnfAuthenticate('API-IDENTIFIER');
+      expect([caoAToken, caoBToken]).toEqual(['CAO_A_TOKEN', 'CAO_B_TOKEN']);
+      expect(post.mock.callCount()).toEqual(2);
+    });
 
-      const otherTokenResult = {
-        ...tokenResult,
-        access_token: 'OTHER_TOKEN',
+    it('reloads credentials and requests a token after expiry', async () => {
+      tokenResponses.push(
+        { access_token: 'EXPIRED_TOKEN', expires_in: 0 },
+        { access_token: 'FRESH_TOKEN', expires_in: 60 },
+      );
+      const loadCredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
+      const authentication = {
+        audience: BLOCKCHAIN_AUDIENCE,
+        cacheKey: 'did:velocity:cao-a:3',
+        loadCredentials,
       };
 
-      initHttpClient.mock.mockImplementationOnce(() =>
-        undiciMock(otherTokenResult),
-      );
+      await authenticateVnfClient(authentication, {});
+      const result = await authenticateVnfClient(authentication, {});
 
-      const result = await vnfAuthenticate('API-IDENTIFIER');
-
-      expect(result).toEqual(otherTokenResult.access_token);
+      expect(result).toEqual('FRESH_TOKEN');
+      expect(loadCredentials.mock.callCount()).toEqual(2);
+      expect(post.mock.callCount()).toEqual(2);
     });
-  });
 
-  describe('VNF Blockchain Authenticate', () => {
-    it('Blockchain VNF authenticate call should make network request and then use cache', async () => {
-      initHttpClient.mock.mockImplementation(() => undiciMock(tokenResult));
-      const authenticate = initAuthenticateVnfBlockchainClient(fastify, {});
-      const result1 = await authenticate();
-      expect(result1).toEqual(tokenResult.access_token);
-      expect(undiciMockPost.mock.callCount()).toEqual(1);
-      const result2 = await authenticate();
-      expect(result2).toEqual(tokenResult.access_token);
-      expect(undiciMockPost.mock.callCount()).toEqual(1);
-    });
-  });
-
-  describe('VNF Authentication Plugin', () => {
-    it('Register VNF authentication functions', async () => {
-      initAuthenticateVnfClientPlugin(fastify, {}, () => {});
-
-      const req = {};
-      await addHook.mock.calls[0].arguments[1](req);
-      expect(req).toEqual({
-        vnfBlockchainAuthenticate: expect.any(Function),
+    it('prunes expired entries while preserving live cached tokens', async () => {
+      tokenResponses.push({ access_token: 'NEW_TOKEN', expires_in: 60 });
+      fastify.vnfAuthTokensCache.set('legacy-unreachable-entry', {
+        accessToken: 'EXPIRED_TOKEN',
+        expiresAt: new Date(0),
+      });
+      fastify.vnfAuthTokensCache.set('live-entry', {
+        accessToken: 'LIVE_TOKEN',
+        expiresAt: new Date(Date.now() + 60000),
       });
 
-      expect(
-        decorateRequest.mock.calls.map((call) => call.arguments),
-      ).toContainEqual(['vnfBlockchainAuthenticate', null]);
-      expect(addHook.mock.calls.map((call) => call.arguments)).toContainEqual([
-        'preValidation',
-        expect.anything(),
+      await authenticateVnfClient(
+        {
+          audience: BLOCKCHAIN_AUDIENCE,
+          cacheKey: 'did:velocity:cao-a:3',
+          loadCredentials: async () => ({
+            clientId: 'cao-a-client',
+            clientSecret: 'cao-a-secret',
+          }),
+        },
+        {},
+      );
+
+      expect(fastify.vnfAuthTokensCache.has('legacy-unreachable-entry')).toBe(
+        false,
+      );
+      expect(fastify.vnfAuthTokensCache.has('live-entry')).toBe(true);
+      expect(fastify.vnfAuthTokensCache.size).toEqual(2);
+    });
+
+    it('rejects an empty resolver cache key before loading credentials', async () => {
+      const loadCredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
+
+      await expect(
+        authenticateVnfClient(
+          {
+            audience: BLOCKCHAIN_AUDIENCE,
+            cacheKey: '',
+            loadCredentials,
+          },
+          {},
+        ),
+      ).rejects.toThrow('cacheKey');
+      expect(loadCredentials.mock.callCount()).toEqual(0);
+      expect(post.mock.callCount()).toEqual(0);
+    });
+
+    it('rejects a non-function credential loader before requesting a token', async () => {
+      await expect(
+        authenticateVnfClient(
+          {
+            audience: BLOCKCHAIN_AUDIENCE,
+            cacheKey: 'did:velocity:cao-a:3',
+            loadCredentials: null,
+          },
+          {},
+        ),
+      ).rejects.toThrow('loadCredentials');
+      expect(post.mock.callCount()).toEqual(0);
+    });
+  });
+
+  describe('VNF authentication plugin', () => {
+    it('uses config credentials through the default resolver', async () => {
+      tokenResponses.push({ access_token: 'CONFIG_TOKEN', expires_in: 60 });
+      fastify = createFastify({
+        vnfClientId: 'configured-client',
+        vnfClientSecret: 'configured-secret',
+      });
+
+      await registerPlugin(fastify);
+      const resolution = await fastify.resolveVnfClientCredentials({});
+      const result = await invokeRequestAuthentication(fastify);
+
+      expect(resolution.cacheKey).toEqual('config:configured-client');
+      await expect(resolution.loadCredentials()).resolves.toEqual({
+        clientId: 'configured-client',
+        clientSecret: 'configured-secret',
+      });
+      expect(result).toEqual('CONFIG_TOKEN');
+      expect(post.mock.calls[0].arguments[1]).toEqual({
+        grant_type: 'client_credentials',
+        client_id: 'configured-client',
+        client_secret: 'configured-secret',
+        audience: BLOCKCHAIN_AUDIENCE,
+      });
+    });
+
+    it('resolves metadata for every request but loads credentials only on a cache miss', async () => {
+      tokenResponses.push({ access_token: 'CUSTOM_TOKEN', expires_in: 60 });
+      const loadCredentials = mock.fn(async () => ({
+        clientId: 'cao-a-client',
+        clientSecret: 'cao-a-secret',
+      }));
+      const resolveVnfClientCredentials = mock.fn(async () => ({
+        cacheKey: 'did:velocity:cao-a:3',
+        loadCredentials,
+      }));
+      fastify = createFastify({
+        vnfClientId: undefined,
+        vnfClientSecret: undefined,
+      });
+      fastify.resolveVnfClientCredentials = resolveVnfClientCredentials;
+
+      await registerPlugin(fastify);
+      const firstToken = await invokeRequestAuthentication(fastify, {
+        id: 'request-1',
+      });
+      const secondToken = await invokeRequestAuthentication(fastify, {
+        id: 'request-2',
+      });
+
+      expect([firstToken, secondToken]).toEqual([
+        'CUSTOM_TOKEN',
+        'CUSTOM_TOKEN',
       ]);
+      expect(resolveVnfClientCredentials.mock.callCount()).toEqual(2);
+      expect(loadCredentials.mock.callCount()).toEqual(1);
+      expect(post.mock.callCount()).toEqual(1);
+    });
+
+    it('preserves a pre-existing custom credential resolver', async () => {
+      tokenResponses.push({ access_token: 'CUSTOM_TOKEN', expires_in: 60 });
+      const customResolver = async () => ({
+        cacheKey: 'did:velocity:cao-a:3',
+        loadCredentials: async () => ({
+          clientId: 'custom-client',
+          clientSecret: 'custom-secret',
+        }),
+      });
+      fastify = createFastify({
+        vnfClientId: undefined,
+        vnfClientSecret: undefined,
+      });
+      fastify.resolveVnfClientCredentials = customResolver;
+
+      await registerPlugin(fastify);
+      const result = await invokeRequestAuthentication(fastify);
+
+      expect(result).toEqual('CUSTOM_TOKEN');
+      expect(fastify.resolveVnfClientCredentials).toBe(customResolver);
+      expect(post.mock.calls[0].arguments[1]).toEqual({
+        grant_type: 'client_credentials',
+        client_id: 'custom-client',
+        client_secret: 'custom-secret',
+        audience: BLOCKCHAIN_AUDIENCE,
+      });
+    });
+
+    it('returns a custom resolver rejection without falling back to config', async () => {
+      const customError = new Error('custom resolver failed');
+      const config = {
+        vnfOAuthTokensEndpoint: TOKEN_ENDPOINT,
+        blockchainApiAudience: BLOCKCHAIN_AUDIENCE,
+      };
+      Object.defineProperties(config, {
+        vnfClientId: {
+          enumerable: true,
+          get: () => {
+            throw new Error('default client ID was accessed');
+          },
+        },
+        vnfClientSecret: {
+          enumerable: true,
+          get: () => {
+            throw new Error('default client secret was accessed');
+          },
+        },
+      });
+      fastify = createFastify();
+      fastify.config = config;
+      fastify.resolveVnfClientCredentials = async () => {
+        throw customError;
+      };
+
+      await registerPlugin(fastify);
+
+      await expect(invokeRequestAuthentication(fastify)).rejects.toBe(
+        customError,
+      );
+      expect(post.mock.callCount()).toEqual(0);
+    });
+
+    it('fails plugin startup when the default client ID is missing', async () => {
+      fastify = createFastify({ vnfClientId: undefined });
+
+      await expect(registerPlugin(fastify)).rejects.toThrow('vnfClientId');
+    });
+
+    it('fails plugin startup when the default client secret is missing', async () => {
+      fastify = createFastify({ vnfClientSecret: undefined });
+
+      await expect(registerPlugin(fastify)).rejects.toThrow('vnfClientSecret');
     });
   });
 });


### PR DESCRIPTION
## Dependencies

Standalone. Base: `main`.

## Scope

- add injectable `resolveVnfClientOAuthCreds(request)` support
- keep the existing config-based OAuth creds resolver as the default
- resolve cache metadata once per Fastify request while loading OAuth creds only on token-cache misses
- key cached VNF tokens by audience plus a stable, non-secret resolver key
- use one fixed cache identity for the config and published low-level paths, without loading or exposing the client ID
- preserve the published low-level `{ audience, clientId, clientSecret }` input shape
- validate resolved OAuth client IDs and secrets and propagate custom resolver failures without falling back to shared config
- store and compare token expiry as epoch milliseconds

## Why

The private Hub needs to choose CAO-specific blockchain OAuth creds per request while retaining the open-source static configuration path.

An existing access token intentionally remains usable until its normal expiry after the stored OAuth creds change. The private Hub therefore uses the CAO DID itself as the resolver cache key.

## Review size

3 files; 659 additions, 108 deletions. The README documents the public resolver contract; no planning/spec files are included.

## Validation

- focused resolver contract: 19 passed
- dependent Hub authentication: 11 passed
- dependent Swagger integration: 12 passed
- dependent tenant-isolation endpoints: 58 passed
- package ESLint and diff checks: clean
