### PR TITLE
feat(credentialinghub): support relying party depots

### DIFF
--- a/servers/credentialinghub/src/entities/depots/domain/validate-depot.js
+++ b/servers/credentialinghub/src/entities/depots/domain/validate-depot.js
@@ -16,10 +16,11 @@
  */
 const newError = require('http-errors');
 const { isEmpty } = require('lodash/fp');
+const { isBefore } = require('date-fns/fp');
 const { DepotErrors } = require('./depot-errors');
 
 const validateDepot = (depot, service) => {
-  if (service == null) {
+  if (isMissingOrDeactivated(service)) {
     throw newError(400, DepotErrors.REFERENCED_SERVICE_NOT_FOUND, {
       errorCode: DepotErrors.REFERENCED_SERVICE_NOT_FOUND,
     });
@@ -34,5 +35,10 @@ const validateDepot = (depot, service) => {
     });
   }
 };
+
+const isMissingOrDeactivated = (service) =>
+  service == null ||
+  (service.deactivationDate != null &&
+    isBefore(new Date(), service.deactivationDate));
 
 module.exports = { validateDepot };

--- a/servers/credentialinghub/src/entities/depots/orchestrators/create-depot.js
+++ b/servers/credentialinghub/src/entities/depots/orchestrators/create-depot.js
@@ -15,25 +15,16 @@
  *
  */
 const { ObjectId } = require('mongodb');
-const {
-  validateReferencedService,
-} = require('../../exchanges/domain/validate-referenced-service');
 const { validateDepot } = require('../domain');
 
 const createDepot = async (newDepot, serviceId, { repos }) => {
-  const issuerService = await repos.issuerServices.findOne({
-    filter: { _id: serviceId },
-  });
-  const relyingPartyService =
-    issuerService == null
-      ? await repos.relyingPartyServices.findOne({
-          filter: { _id: serviceId },
-        })
-      : undefined;
-  if (relyingPartyService != null) {
-    validateReferencedService(relyingPartyService);
-  }
-  const service = issuerService ?? relyingPartyService;
+  const service =
+    (await repos.issuerServices.findOne({
+      filter: { _id: serviceId },
+    })) ??
+    (await repos.relyingPartyServices.findOne({
+      filter: { _id: serviceId },
+    }));
   validateDepot(newDepot, service);
   return repos.depots.insert({
     ...newDepot,

--- a/servers/credentialinghub/src/entities/depots/orchestrators/create-depot.js
+++ b/servers/credentialinghub/src/entities/depots/orchestrators/create-depot.js
@@ -15,12 +15,25 @@
  *
  */
 const { ObjectId } = require('mongodb');
+const {
+  validateReferencedService,
+} = require('../../exchanges/domain/validate-referenced-service');
 const { validateDepot } = require('../domain');
 
 const createDepot = async (newDepot, serviceId, { repos }) => {
-  const service = await repos.issuerServices.findOne({
+  const issuerService = await repos.issuerServices.findOne({
     filter: { _id: serviceId },
   });
+  const relyingPartyService =
+    issuerService == null
+      ? await repos.relyingPartyServices.findOne({
+          filter: { _id: serviceId },
+        })
+      : undefined;
+  if (relyingPartyService != null) {
+    validateReferencedService(relyingPartyService);
+  }
+  const service = issuerService ?? relyingPartyService;
   validateDepot(newDepot, service);
   return repos.depots.insert({
     ...newDepot,

--- a/servers/credentialinghub/test/operator/depots-controller.test.js
+++ b/servers/credentialinghub/test/operator/depots-controller.test.js
@@ -31,6 +31,9 @@ const { initTenantFactory } = require('../../src/entities/tenants');
 const {
   initIssuerServiceFactory,
 } = require('../../src/entities/issuer-services');
+const {
+  initRelyingPartyServiceFactory,
+} = require('../../src/entities/relying-party-services');
 const { initDepotFactory } = require('../../src/entities/depots');
 const { initCredentialFactory } = require('../../src/entities/credentials');
 
@@ -39,6 +42,7 @@ describe('Depots Test suite', () => {
   let fastify;
   let persistTenant;
   let persistIssuerService;
+  let persistRelyingPartyService;
   let persistDepot;
   let persistCredential;
 
@@ -51,6 +55,7 @@ describe('Depots Test suite', () => {
 
     ({ persistTenant } = initTenantFactory(fastify));
     ({ persistIssuerService } = initIssuerServiceFactory(fastify));
+    ({ persistRelyingPartyService } = initRelyingPartyServiceFactory(fastify));
     ({ persistDepot } = initDepotFactory(fastify));
     ({ persistCredential } = initCredentialFactory(fastify));
   });
@@ -59,6 +64,7 @@ describe('Depots Test suite', () => {
     await mongoDb().collection('tenants').deleteMany({});
     await mongoDb().collection('keys').deleteMany({});
     await mongoDb().collection('issuerServices').deleteMany({});
+    await mongoDb().collection('relyingPartyServices').deleteMany({});
     await mongoDb().collection('depots').deleteMany({});
     tenant = await persistTenant();
     issuerService = await persistIssuerService({
@@ -96,6 +102,29 @@ describe('Depots Test suite', () => {
           depot: { userReference: 'ABC123' },
         },
       });
+      expect(response.json).toEqual(
+        errorResponseMatcher({
+          statusCode: 400,
+          message: 'referenced_service_not_found',
+          errorCode: 'referenced_service_not_found',
+        }),
+      );
+    });
+    it('should 400 if referenced relying party service is deactivated', async () => {
+      const relyingPartyService = await persistRelyingPartyService({
+        tenant,
+        deactivationDate: new Date(),
+      });
+      const response = await fastify.injectJson({
+        method: 'POST',
+        url: `${testUrl}/create`,
+        payload: {
+          tenantId: tenant._id,
+          serviceId: relyingPartyService._id,
+          depot: { userReference: 'RP-USER-123' },
+        },
+      });
+
       expect(response.json).toEqual(
         errorResponseMatcher({
           statusCode: 400,
@@ -191,6 +220,36 @@ describe('Depots Test suite', () => {
         requestId: expect.any(String),
       });
 
+      await expect(
+        mongoDb().collection('depots').find({}).toArray(),
+      ).resolves.toEqual([expectedDbDepot(response.json.depot, tenant)]);
+    });
+
+    it('should 200 for a relying party service depot', async () => {
+      const relyingPartyService = await persistRelyingPartyService({ tenant });
+      const payload = {
+        tenantId: tenant._id,
+        serviceId: relyingPartyService._id,
+        depot: { userReference: 'RP-USER-123' },
+      };
+
+      const response = await fastify.injectJson({
+        method: 'POST',
+        url: `${testUrl}/create`,
+        payload,
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.json).toEqual({
+        depot: {
+          ...payload.depot,
+          serviceId: payload.serviceId,
+          id: expect.stringMatching(OBJECT_ID_FORMAT),
+          createdAt: expect.stringMatching(ISO_DATETIME_FORMAT),
+          updatedAt: expect.stringMatching(ISO_DATETIME_FORMAT),
+        },
+        requestId: expect.any(String),
+      });
       await expect(
         mongoDb().collection('depots').find({}).toArray(),
       ).resolves.toEqual([expectedDbDepot(response.json.depot, tenant)]);

--- a/servers/credentialinghub/test/operator/depots-controller.test.js
+++ b/servers/credentialinghub/test/operator/depots-controller.test.js
@@ -110,6 +110,30 @@ describe('Depots Test suite', () => {
         }),
       );
     });
+    it('should 400 if referenced issuer service is deactivated', async () => {
+      const deactivatedIssuerService = await persistIssuerService({
+        tenant,
+        authMethods: ['preauth'],
+        deactivationDate: new Date(),
+      });
+      const response = await fastify.injectJson({
+        method: 'POST',
+        url: `${testUrl}/create`,
+        payload: {
+          tenantId: tenant._id,
+          serviceId: deactivatedIssuerService._id,
+          depot: { userReference: 'ABC123' },
+        },
+      });
+
+      expect(response.json).toEqual(
+        errorResponseMatcher({
+          statusCode: 400,
+          message: 'referenced_service_not_found',
+          errorCode: 'referenced_service_not_found',
+        }),
+      );
+    });
     it('should 400 if referenced relying party service is deactivated', async () => {
       const relyingPartyService = await persistRelyingPartyService({
         tenant,


### PR DESCRIPTION
## Summary

- allow the operator depot endpoint to create depots for relying-party services
- reject deactivated relying-party services through the established service validator
- preserve existing issuer-service depot validation

## Root cause

Relying-party presentation links already support an optional depot ID, but `POST /operator/depots/create` resolved service IDs only through the issuer-service repository. A valid relying-party service therefore returned `referenced_service_not_found`.

This enables callers such as Wallet Certifier to pre-create one RP-owned depot per verification interaction and use that depot as the polling correlation key.

## Validation

- depot controller suite: 23/23 passing
- full Credentialing Hub suite: 466/466 passing
- ESLint on affected files
- `git diff --check`
