### PR TITLE
fix(credentialinghub): persist presentation exchange reference

### DIFF
--- a/servers/credentialinghub/src/entities/exchanges/orchestrators/post-presentation.js
+++ b/servers/credentialinghub/src/entities/exchanges/orchestrators/post-presentation.js
@@ -52,7 +52,7 @@ const postPresentation = async (
   validatePresentation(vp, exchange, context, vp.presentation_submission);
   const presentation = await repos.presentations.insert({
     depotId: exchange.depotId,
-    exchangeId,
+    exchangeId: exchange._id,
     format: PresentationFormat.JWT_VP,
     presentation: jwtPresentationSubmission,
   });

--- a/servers/credentialinghub/test/vn-api/vn-presentation-controller-post-presentation.test.js
+++ b/servers/credentialinghub/test/vn-api/vn-presentation-controller-post-presentation.test.js
@@ -502,12 +502,22 @@ describe('vn-api > presentations', () => {
             .collection('depots')
             .findOne({ _id: new ObjectId(depot._id) }),
         ).resolves.toEqual(expectedDbDepot(tenant, relyingPartyService, depot));
-        await expect(
-          mongoDb()
-            .collection('presentations')
-            .find({ depotId: new ObjectId(depot._id) })
-            .toArray(),
-        ).resolves.toEqual([expectedDbPresentation(tenant, exchange, jwtVp)]);
+        const [presentation] = await mongoDb()
+          .collection('presentations')
+          .find({ depotId: new ObjectId(depot._id) })
+          .toArray();
+        const operatorResponse = await fastify.injectJson({
+          method: 'GET',
+          url: `/operator/exchanges/get?tenantId=${tenant._id}&exchangeId=${exchange._id}`,
+        });
+
+        expect(operatorResponse.statusCode).toEqual(200);
+        expect(operatorResponse.json.exchange.presentationIds).toEqual([
+          presentation._id.toString(),
+        ]);
+        expect(presentation).toEqual(
+          expectedDbPresentation(tenant, exchange, jwtVp),
+        );
         await expect(
           mongoDb().collection('notification_events').countDocuments({}),
         ).resolves.toEqual(0);
@@ -1079,7 +1089,7 @@ const expectedDbPresentation = (tenant, exchange, jwtVp, overrides = {}) =>
   applyOverrides(
     {
       _id: expect.any(ObjectId),
-      exchangeId: exchange._id,
+      exchangeId: new ObjectId(exchange._id),
       depotId: new ObjectId(exchange.depotId),
       tenantId: new ObjectId(tenant._id),
       format: PresentationFormat.JWT_VP,

--- a/servers/credentialinghub/test/vn-api/vn-presentation-controller-post-presentation.test.js
+++ b/servers/credentialinghub/test/vn-api/vn-presentation-controller-post-presentation.test.js
@@ -502,10 +502,14 @@ describe('vn-api > presentations', () => {
             .collection('depots')
             .findOne({ _id: new ObjectId(depot._id) }),
         ).resolves.toEqual(expectedDbDepot(tenant, relyingPartyService, depot));
-        const [presentation] = await mongoDb()
+        const presentations = await mongoDb()
           .collection('presentations')
           .find({ depotId: new ObjectId(depot._id) })
           .toArray();
+        expect(presentations).toEqual([
+          expectedDbPresentation(tenant, exchange, jwtVp),
+        ]);
+        const [presentation] = presentations;
         const operatorResponse = await fastify.injectJson({
           method: 'GET',
           url: `/operator/exchanges/get?tenantId=${tenant._id}&exchangeId=${exchange._id}`,
@@ -515,9 +519,6 @@ describe('vn-api > presentations', () => {
         expect(operatorResponse.json.exchange.presentationIds).toEqual([
           presentation._id.toString(),
         ]);
-        expect(presentation).toEqual(
-          expectedDbPresentation(tenant, exchange, jwtVp),
-        );
         await expect(
           mongoDb().collection('notification_events').countDocuments({}),
         ).resolves.toEqual(0);


### PR DESCRIPTION
## Summary

- persist VN-API presentation `exchangeId` from the loaded exchange document as the canonical Mongo `ObjectId`
- add public endpoint integration coverage from VN presentation submission through operator exchange inspection
- preserve strict persistence cardinality coverage while asserting the returned `presentationIds`

## Root cause

The VN-API presentation handler persisted the raw `exchange_id` request string. Presentation lookup canonicalizes `exchangeId` to a Mongo `ObjectId`, so the saved presentation could be retrieved by depot but not by exchange. Operator exchange inspection therefore returned an empty `presentationIds` array, leaving downstream verification polling stuck.

## Impact

Successfully disclosed VN-API presentations are now discoverable through their exchange. No string/ObjectId fallback was added; new writes use the single canonical representation.

## Validation

- Credentialing Hub suite: 467/467 passing
- focused VN presentation integration test: passing
- affected-file ESLint with `--fix`: clean
- `git diff --check`: clean
- audited 13 comparable CIH ID writer/finder paths; no additional mismatches found