### PR TITLE
fix(credentialinghub): configure CAO for E2E

### DIFF
--- a/servers/credentialinghub/.localdev.env
+++ b/servers/credentialinghub/.localdev.env
@@ -8,6 +8,7 @@ MONGO_URI=mongodb://velocity-mongo:27017/credentialing_hub
 DEEP_LINK_PROTOCOL=velocity-network-devnet://
 KEY_ENCRYPTION_SECRET=1445253CA16FA4649F6D3C49E8D26
 OPERATOR_API_TOKEN=foo
+DEFAULT_CAO_DID=did:web:registrar-proxy:d:www.acmecorp-cih-e2e.com
 SECRET=secret
 LOG_SEVERITY=debug
 RPC_NODE_URL=http://blockchain:8545

--- a/servers/credentialinghub/e2e/org-registration-and-issuing.e2e.test.js
+++ b/servers/credentialinghub/e2e/org-registration-and-issuing.e2e.test.js
@@ -21,8 +21,7 @@ const http = require('node:http');
 const path = require('path');
 const { expect } = require('expect');
 const { MongoClient } = require('mongodb');
-const { nanoid, customAlphabet } = require('nanoid');
-const { lowercase } = require('nanoid-dictionary');
+const { nanoid } = require('nanoid');
 const { filter, first, find, map, omit } = require('lodash/fp');
 const {
   KeyPurposes,
@@ -92,6 +91,10 @@ dotenv.config({
 console.dir(e2eEnv);
 
 const OPERATOR_API_TOKEN = 'foo';
+const CAO_WEBSITE = 'https://www.acmecorp-cih-e2e.com';
+// The registrar derives this did:web from its configured host and the CAO
+// website hostname. Keep it aligned with DEFAULT_CAO_DID in .localdev.env.
+const DEFAULT_CAO_DID = 'did:web:registrar-proxy:d:www.acmecorp-cih-e2e.com';
 const EDUCATION_DEGREE_CREDENTIAL_TYPE = 'EducationDegreeGraduationV1.1';
 
 describe('org registration and issuing e2e', () => {
@@ -133,7 +136,7 @@ describe('org registration and issuing e2e', () => {
           logo: 'https://www.acmecorp.com/betamax-logo.png',
         },
       ],
-      website: `https://www.acmecorp-${customAlphabet(lowercase)()}.com`,
+      website: CAO_WEBSITE,
       registrationNumbers: [
         {
           authority: 'DunnAndBradstreet',
@@ -215,6 +218,7 @@ describe('org registration and issuing e2e', () => {
     // json response checks
     expect(createFullOrganizationResponse.id).toMatch(DID_FORMAT);
     const { id: did, ids, profile, keys } = createFullOrganizationResponse;
+    expect(did).toEqual(DEFAULT_CAO_DID);
     console.dir({ msg: 'Organization registered', did, keys });
 
     await wait(500);
@@ -293,7 +297,6 @@ describe('org registration and issuing e2e', () => {
     const createTenantPayload = {
       tenant: {
         did,
-        caoDid: did,
         name: createFullOrganizationResponse.profile.name,
         logo: createFullOrganizationResponse.profile.logo,
       },
@@ -321,7 +324,10 @@ describe('org registration and issuing e2e', () => {
     expect(createTenantResponse.status).toEqual(200);
     const createTenantJson = await createTenantResponse.json();
     expect(createTenantJson).toEqual({
-      tenant: expectedTenant(createTenantPayload.tenant, ids.ethereumAccount),
+      tenant: expectedTenant(
+        { ...createTenantPayload.tenant, caoDid: DEFAULT_CAO_DID },
+        ids.ethereumAccount,
+      ),
       keyMetadatas: expectedKeyMetadatas(createTenantPayload.keys),
       requestId: expect.any(String),
     });


### PR DESCRIPTION
## Summary

- configure `DEFAULT_CAO_DID` for the Credentialing Hub E2E stack
- use a stable CAO website whose registrar-generated `did:web` is known before CIH starts
- remove the now-rejected `caoDid` field from the tenant creation request
- assert that the registrar creates the same CAO DID used by the authenticated operator principal

## Root cause

After the CAO security provider changes, the built-in provider requires `DEFAULT_CAO_DID` during CIH startup and tenant creation derives `caoDid` from the authenticated operator principal. The E2E stack did not configure that value, while the test still supplied `caoDid` in the request. The CAO was also registered later in the test with a randomized website, so its `did:web` could not previously be known at server startup.

The registrar deterministically derives the test CAO as `did:web:registrar-proxy:d:www.acmecorp-cih-e2e.com`, allowing CIH and the registrar-created organization to use the same identity.

## Validation

- `pnpm exec eslint servers/credentialinghub/e2e/org-registration-and-issuing.e2e.test.js`
- `git diff --check`
- `IS_CI=true NODE_OPTIONS='--max_old_space_size=4096' NODE_TLS_REJECT_UNAUTHORIZED=0 pnpm exec nx run @verii/server-credentialing-hub:test:e2e`

The complete local E2E passed through CAO registration, tenant creation, credential issuance, presentation, and verification.