### PR TITLE
fix(release): respect selected release groups

### DIFF
--- a/.github/workflows/release-pr-validation.workflow.yml
+++ b/.github/workflows/release-pr-validation.workflow.yml
@@ -7,8 +7,10 @@ on:
       - '.github/releases/*.md'
       - 'package.json'
       - 'pnpm-lock.yaml'
+      - 'nx.json'
       - 'packages/*/package.json'
       - 'servers/*/package.json'
+      - 'tools/release/**'
       - 'tools/*/package.json'
 
 env:
@@ -31,6 +33,14 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Enable Corepack
         run: corepack enable
+      - name: Install dependencies
+        run: >-
+          corepack "$(node -p "require('./package.json').packageManager")"
+          install --frozen-lockfile
+      - name: Test release preparation
+        run: >-
+          corepack "$(node -p "require('./package.json').packageManager")"
+          run test:release
       - name: Fetch base branch
         run: git fetch origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
       - name: Validate release PR

--- a/nx.json
+++ b/nx.json
@@ -40,7 +40,7 @@
       "currentVersionResolver": "disk",
       "preserveLocalDependencyProtocols": true,
       "preserveMatchingDependencyRanges": false,
-      "updateDependents": "always"
+      "updateDependents": "auto"
     },
     "versionPlans": {
       "ignorePatternsForPlanCheck": [

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "cross-env NODE_ENV=test nx run-many --target=test --all",
     "test:affected": "cross-env NODE_ENV=test nx affected --target=test",
     "test:coverage-summary-local": "python3 -m unittest discover -s .github/scripts/tests -p 'test_coverage_summary.py' -v",
+    "test:release": "node --test tools/release/*.test.js",
     "release:prepare": "node tools/release/prepare-release.js",
     "release:validate-pr": "node tools/release/validate-release-pr.js",
     "depcheck": "knip --dependencies --workspace './contracts/*' --workspace './packages/*' --workspace './servers/*' --workspace './tools/*' --workspace './samples/*'",

--- a/tools/release/prepare-release.integration.test.js
+++ b/tools/release/prepare-release.integration.test.js
@@ -1,0 +1,109 @@
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { it } = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+const readJson = (root, relativePath) =>
+  JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8'));
+
+const copyTrackedWorkspace = (destination) => {
+  const result = spawnSync('git', ['ls-files', '-z'], {
+    cwd: repoRoot,
+    encoding: 'buffer',
+  });
+
+  assert.equal(result.status, 0, result.stderr.toString());
+
+  result.stdout
+    .toString()
+    .split('\0')
+    .filter(Boolean)
+    .forEach((relativePath) => {
+      const source = path.join(repoRoot, relativePath);
+      const target = path.join(destination, relativePath);
+
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.copyFileSync(source, target);
+    });
+
+  fs.symlinkSync(
+    path.join(repoRoot, 'node_modules'),
+    path.join(destination, 'node_modules'),
+    'dir',
+  );
+};
+
+it(
+  'prepares selected groups without versioning filtered-out dependents',
+  { timeout: 30000 },
+  () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'verii-release-prepare-'),
+    );
+
+    try {
+      copyTrackedWorkspace(fixtureRoot);
+
+      const result = spawnSync(
+        'node',
+        [
+          'tools/release/prepare-release.js',
+          '--groups',
+          'platform,credentialagent,credentialinghub',
+          '--bump',
+          'minor',
+          '--message',
+          'Test selected release groups',
+        ],
+        {
+          cwd: fixtureRoot,
+          encoding: 'utf8',
+        },
+      );
+
+      assert.equal(
+        result.status,
+        0,
+        `${result.stdout}\n${result.stderr}`.trim(),
+      );
+      assert.equal(
+        readJson(fixtureRoot, 'packages/auth/package.json').version,
+        '1.2.0',
+      );
+      assert.equal(
+        readJson(fixtureRoot, 'servers/credentialagent/package.json').version,
+        '1.28.0',
+      );
+      assert.equal(
+        readJson(fixtureRoot, 'servers/credentialinghub/package.json').version,
+        '2.1.0',
+      );
+      assert.equal(
+        readJson(fixtureRoot, 'packages/vnf-wallet-sdk-nodejs/package.json')
+          .version,
+        '2.10.0',
+      );
+      assert.deepEqual(readJson(fixtureRoot, '.github/release.json'), {
+        kind: 'verii-release',
+        bump: 'minor',
+        groups: {
+          platform: '1.2.0',
+          credentialagent: '1.28.0',
+          credentialinghub: '2.1.0',
+        },
+      });
+      assert.deepEqual(
+        fs
+          .readdirSync(path.join(fixtureRoot, '.nx/version-plans'))
+          .filter((file) => file.endsWith('.md')),
+        [],
+      );
+    } finally {
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  },
+);


### PR DESCRIPTION
Closed because the release scope now includes `sdk-nodejs`. The existing `updateDependents: "always"` policy correctly requires the SDK to be released when Platform advances, so this configuration change is no longer appropriate.

No changes from this PR were merged.