### PR TITLE
chore(release): prepare minor releases

### DIFF
--- a/.github/release.json
+++ b/.github/release.json
@@ -1,0 +1,10 @@
+{
+  "kind": "verii-release",
+  "bump": "minor",
+  "groups": {
+    "platform": "1.2.0",
+    "credentialagent": "1.28.0",
+    "credentialinghub": "2.1.0",
+    "sdk-nodejs": "2.11.0"
+  }
+}

--- a/.github/releases/credentialagent-v1.28.0.md
+++ b/.github/releases/credentialagent-v1.28.0.md
@@ -1,0 +1,17 @@
+## Changes
+
+### [#768](https://github.com/LFDT-Verii/core/pull/768) Use JWK blockchain private keys directly
+
+Credential Agent blockchain operations can pass private JWKs directly through the shared contract packages. The release also adopts ethers-backed account generation and removes the need for callers to maintain parallel JWK and hex representations.
+
+### [#764](https://github.com/LFDT-Verii/core/pull/764) Use native Node.js key conversion
+
+secp256k1 JWK and hex conversion now comes from `@verii/crypto` and native Node.js crypto APIs. Compatibility wrappers remain available through `@verii/jwt`.
+
+### [#550](https://github.com/LFDT-Verii/core/pull/550) Align Docker and E2E flows with pnpm
+
+Credential Agent and Mock Vendor container workflows now install and run with the repository's pnpm workspace and lockfile, keeping local Docker, E2E, and CI dependency resolution consistent.
+
+## Backward incompatibilities
+
+None.

--- a/.github/releases/credentialinghub-v2.1.0.md
+++ b/.github/releases/credentialinghub-v2.1.0.md
@@ -1,0 +1,39 @@
+## Changes
+
+### [#770](https://github.com/LFDT-Verii/core/pull/770) Revoke issued credentials
+
+Operators can revoke credentials through `POST /operator/credentials/revoke`. Credentialing Hub records the revocation, updates the on-chain registry, and notifies the wallet about revocation or replacement when exchange messaging settings are available.
+
+### [#775](https://github.com/LFDT-Verii/core/pull/775) Deliver signed notification webhooks
+
+Credential issuance and presentation flows can enqueue Mongo-backed webhook events for `presentation.received`, `credential.issued`, and `credential.rejected`. Delivery, retry, lease recovery, wildcard subscriptions, and HMAC signing are completed by [#814](https://github.com/LFDT-Verii/core/pull/814).
+
+### [#831](https://github.com/LFDT-Verii/core/pull/831) Inspect exchanges safely
+
+Authenticated operators can retrieve a tenant-scoped, sanitized exchange projection for status polling and downstream verification workflows. Persisted internal failures are mapped to safe public errors.
+
+### [#840](https://github.com/LFDT-Verii/core/pull/840) Publish API documentation by audience
+
+Swagger UI now separates Operator, OpenID4VC Wallet, and VN-API Wallet documents, with isolated schemas and security definitions for each audience. Existing Operator and OpenID4VC document URLs remain available, and VN-API documentation is exposed at `/documentation/vn-api.json`.
+
+### [#870](https://github.com/LFDT-Verii/core/pull/870) Support pluggable CAO operator authentication
+
+Deployments can inject a CAO security provider for Operator authentication, request-aware blockchain credentials, and Swagger metadata. Tenant operations are isolated by the authenticated principal's CAO through [#871](https://github.com/LFDT-Verii/core/pull/871), including resource concealment across CAO boundaries.
+
+### [#874](https://github.com/LFDT-Verii/core/pull/874) Create depots for relying-party services
+
+Operator depot creation now supports active relying-party services as well as issuer services, enabling presentation polling flows to use an RP-owned depot as their correlation key.
+
+### [#875](https://github.com/LFDT-Verii/core/pull/875) Link disclosed presentations to their exchange
+
+VN-API presentation submissions now persist the canonical exchange identifier, so operator exchange inspection returns the resulting presentation IDs instead of leaving downstream polling stuck.
+
+### [#878](https://github.com/LFDT-Verii/core/pull/878) Accept scalar W3C disclosure types
+
+Presentation verification responses now preserve and serialize both string and string-array `type` values for disclosed presentations and credentials. Credential issuance remains array-only.
+
+## Backward incompatibilities
+
+- The built-in Operator authentication provider now requires `DEFAULT_CAO_DID`.
+- Operator tenant creation derives `caoDid` from the authenticated principal and rejects caller-supplied `caoDid` values.
+- Custom `caoSecurityProvider` implementations must supply a non-empty string `caoDid` on the authenticated Operator principal; all Operator tenant access is scoped to that CAO.

--- a/.github/releases/credentialinghub-v2.1.0.md
+++ b/.github/releases/credentialinghub-v2.1.0.md
@@ -36,4 +36,3 @@ Presentation verification responses now preserve and serialize both string and s
 
 - The built-in Operator authentication provider now requires `DEFAULT_CAO_DID`.
 - Operator tenant creation derives `caoDid` from the authenticated principal and rejects caller-supplied `caoDid` values.
-- Custom `caoSecurityProvider` implementations must supply a non-empty string `caoDid` on the authenticated Operator principal; all Operator tenant access is scoped to that CAO.

--- a/.github/releases/platform-v1.2.0.md
+++ b/.github/releases/platform-v1.2.0.md
@@ -1,0 +1,47 @@
+## Changes
+
+### [#868](https://github.com/LFDT-Verii/core/pull/868) Resolve blockchain OAuth credentials per request
+
+Contract clients can now inject a request-aware VNF OAuth credential resolver while retaining the existing static configuration path. Token caching uses a stable, non-secret resolver key, enabling Credentialing Hub deployments to select CAO-specific blockchain credentials safely.
+
+### [#867](https://github.com/LFDT-Verii/core/pull/867) Delete superseded KMS keys and secrets
+
+`@verii/db-kms` now exposes `deleteKeyOrSecret(keyId)` for generated keys and imported secrets. Callers can clean up replaced or unattached credentials and distinguish an existing deletion from an already-absent key.
+
+### [#866](https://github.com/LFDT-Verii/core/pull/866) Protect sensitive authentication logs
+
+The shared server and logger packages can suppress request and response bodies on sensitive routes while preserving normal debug logging elsewhere. Credential, token, provisioning-code, and KMS identifiers remain redacted at every log level. Additional App Check and account-verification fields are redacted through [#872](https://github.com/LFDT-Verii/core/pull/872).
+
+### [#856](https://github.com/LFDT-Verii/core/pull/856) Search for services awaiting approval
+
+Registrar profile searches can opt into unapproved services with `include-unapproved-services`. Existing consumers retain activated-only results by default, and included services now report their approval state.
+
+### [#830](https://github.com/LFDT-Verii/core/pull/830) Recover interrupted organization registrations
+
+Operators can soft-delete partially created organizations that never reached service activation, allowing customers to register again. Organizations with activated services remain protected from deletion.
+
+### [#806](https://github.com/LFDT-Verii/core/pull/806) Add explicit HTTP error-response and timeout modes
+
+`@verii/http-client` can return 4xx and 5xx responses instead of throwing when configured with `responseErrorMode: 'return'`. Request timeouts now use Undici's native header and body phase timeouts.
+
+### [#768](https://github.com/LFDT-Verii/core/pull/768) Support JWK blockchain private keys
+
+Blockchain and contract packages now accept private JWKs as well as hex keys and provide ethers-backed account generation. The shared crypto package owns the secp256k1 JWK/hex conversion primitives introduced in [#764](https://github.com/LFDT-Verii/core/pull/764).
+
+### [#741](https://github.com/LFDT-Verii/core/pull/741) Keep Mongo repository state consistent across applications
+
+Mongo-backed platform packages now consume the application's Mongo and Spence repository instances as peers, preventing duplicate physical modules from splitting module-level connection and repository state.
+
+### [#840](https://github.com/LFDT-Verii/core/pull/840) Support audience-specific Swagger documents
+
+The shared server package can publish multiple named OpenAPI documents with isolated schemas and security definitions while preserving the existing single-document behavior. Packaged Velocity branding removes the need for external Swagger UI assets.
+
+### [#597](https://github.com/LFDT-Verii/core/pull/597) Stabilize Registrar organization and logout flows
+
+Organization creation is centralized across direct creation, invitations, and service onboarding. Token refresh after organization creation and the logout/auth-resolution fixes from [#575](https://github.com/LFDT-Verii/core/pull/575), [#598](https://github.com/LFDT-Verii/core/pull/598), and [#599](https://github.com/LFDT-Verii/core/pull/599) prevent stale sessions and incorrect redirects.
+
+## Backward incompatibilities
+
+- Mongo-backed package consumers must provide compatible `mongodb` and `@spencejs/spence-mongo-repos` peer dependencies.
+- The Registrar `resolve-kid` public-key response no longer supports PEM output. Its default format is now `hex`; supported formats are `hex`, `base58`, and `jwk`.
+- `@verii/http-client` `requestTimeout` now represents Undici header and body phase timeouts rather than a strict wall-clock request deadline.

--- a/.github/releases/sdk-nodejs-v2.11.0.md
+++ b/.github/releases/sdk-nodejs-v2.11.0.md
@@ -1,0 +1,13 @@
+## Changes
+
+### [#806](https://github.com/LFDT-Verii/core/pull/806) Adopt the Platform 1.2 HTTP client baseline
+
+The Node.js wallet SDK now publishes against `@verii/http-client` 1.2.0, including Undici-native header and body timeouts and an explicit error-response mode available to SDK network integrations.
+
+### [#768](https://github.com/LFDT-Verii/core/pull/768) Adopt the Platform 1.2 verification baseline
+
+The SDK now publishes against `@verii/vc-checks` 1.2.0, aligning wallet verification with the platform's JWK-capable key handling and updated shared verification dependencies.
+
+## Backward incompatibilities
+
+None.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/auth",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Authorization package",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/aws-clients/package.json
+++ b/packages/aws-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/aws-clients",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Set of aws functions and utils used by Verii projects",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/base-contract-io/package.json
+++ b/packages/base-contract-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/base-contract-io",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Package contains functions needed across all contract io packages",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/blockchain-functions/package.json
+++ b/packages/blockchain-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/blockchain-functions",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Blockchain related wrappers and helpers.",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/common-fetchers/package.json
+++ b/packages/common-fetchers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/common-fetchers",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Set of fetchers used by Velocity Network servers",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "src/index.js",

--- a/packages/common-functions/package.json
+++ b/packages/common-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/common-functions",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Set of functions and utils used by Verii projects",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/common-schemas/package.json
+++ b/packages/common-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/common-schemas",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Set of validation schemas",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/components-organizations-registrar/package.json
+++ b/packages/components-organizations-registrar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/components-organizations-registrar",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "type": "module",
   "license": "Apache-2.0",
   "repository": "https://github.com/LFDT-Verii/core",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/config",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Generic configuration file for Velocity Projects",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/contract-permissions/package.json
+++ b/packages/contract-permissions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/contract-permissions",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Package allows interacting with the permissions smart contracts, based on ethers.js",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/cose-key/package.json
+++ b/packages/cose-key/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/cose-key",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Set of cose key functions used in Verii projects",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/country-data/package.json
+++ b/packages/country-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/country-data",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Contains ISO 3166-1 and ISO 3166-2 data",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/crypto",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Set of crypto functions used in Verii projects",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/csv-parser/package.json
+++ b/packages/csv-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/csv-parser",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Csv parser package for velocitycore",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/db-kms/package.json
+++ b/packages/db-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/db-kms",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "KMS plugin that uses a db",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/did-doc/package.json
+++ b/packages/did-doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/did-doc",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Velocity DID documents library",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/did-web/package.json
+++ b/packages/did-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/did-web",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "did:web related functionality",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/endpoints-credential-types-registrar/package.json
+++ b/packages/endpoints-credential-types-registrar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/endpoints-credential-types-registrar",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Credential Types Registrar",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "src/index.js",

--- a/packages/endpoints-event-processing/package.json
+++ b/packages/endpoints-event-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/endpoints-event-processing",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Event processing",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "src/index.js",

--- a/packages/endpoints-organizations-registrar/package.json
+++ b/packages/endpoints-organizations-registrar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/endpoints-organizations-registrar",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Organization Registrar",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "src/index.js",

--- a/packages/error-aggregation/package.json
+++ b/packages/error-aggregation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/error-aggregation",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Aggregation of errors",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/fastify-plugins/package.json
+++ b/packages/fastify-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/fastify-plugins",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Plugin for handling errors",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/fineract-client/package.json
+++ b/packages/fineract-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/fineract-client",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Package containing the functions that interact with the fineract system",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/http-client",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "HTTP client for Verii network",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/image-processing/package.json
+++ b/packages/image-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/image-processing",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Set of image processing functions used in Verii projects",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/jwt",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Set of JWT related functions used in Verii projects",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/logger",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Logger for Verii network",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/math",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Velocity math package",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/metadata-registration/package.json
+++ b/packages/metadata-registration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/metadata-registration",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Package allows interacting with the smart contracts, based on ethers.js",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "./index.js",

--- a/packages/organizations-registry/package.json
+++ b/packages/organizations-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/organizations-registry",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Velocity DID documents library",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/rest-queries/package.json
+++ b/packages/rest-queries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/rest-queries",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Http REST Query language",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/sample-data/package.json
+++ b/packages/sample-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/sample-data",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Organizations, metadata and credentials that can be used for testing.",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/server-provider",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Server common package for Velocity Projects ",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/spencer-mongo-extensions/package.json
+++ b/packages/spencer-mongo-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/spencer-mongo-extensions",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Set of functions that extend spencer mongo functionality for use by Verii projects",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/test-regexes/package.json
+++ b/packages/test-regexes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/test-regexes",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Set of regexes for tests",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/tests-helpers/package.json
+++ b/packages/tests-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/tests-helpers",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Generic helpers for tests",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/validation",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Validation package for Velocity Projects, based on ajv and fastify validation",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/vc-checks/package.json
+++ b/packages/vc-checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/vc-checks",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Velocity Verifiable credentials checks functions",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/verii-issuing/package.json
+++ b/packages/verii-issuing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/verii-issuing",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Verii Issuing Package",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "src/index.js",

--- a/packages/verii-verification/package.json
+++ b/packages/verii-verification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/verii-verification",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Verii VC and VP Verification library ",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/packages/vnf-wallet-sdk-nodejs/package.json
+++ b/packages/vnf-wallet-sdk-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/vnf-nodejs-wallet-sdk",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "VNF Wallet SDK Nodejs",
   "repository": "https://github.com/LFDT-Verii/core",
   "author": "Andres Olave",

--- a/servers/credentialagent/package.json
+++ b/servers/credentialagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/server-credentialagent",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Credential Agent application",
   "main": "src/index.js",
   "repository": "https://github.com/LFDT-Verii/core",

--- a/servers/credentialinghub/package.json
+++ b/servers/credentialinghub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/server-credentialing-hub",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Credentialing Hub",
   "repository": "https://github.com/LFDT-Verii/core",
   "engines": {

--- a/servers/mockvendor/package.json
+++ b/servers/mockvendor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/server-mockvendor",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Mock Vendor backend",
   "repository": "https://github.com/LFDT-Verii/core",
   "engines": {

--- a/tools/agentdb-cli/package.json
+++ b/tools/agentdb-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/agentdb-cli",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A cli for working with agent database.",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "src/index.js",

--- a/tools/contracts-deployment/package.json
+++ b/tools/contracts-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/contracts-deployment",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A tool for deploying our contracts locally.",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/tools/data-loader/package.json
+++ b/tools/data-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/data-loader",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A tool for uploading data to the different target systems.",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "src/index.js",

--- a/tools/verifgen/package.json
+++ b/tools/verifgen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/verifgen",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A tool for creating verifiable credentials and verifiable presentations.",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "index.js",

--- a/tools/vnf-agent-cli/package.json
+++ b/tools/vnf-agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verii/vnf-agent-cli",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A CLI application for working with VNF Agents.",
   "repository": "https://github.com/LFDT-Verii/core",
   "main": "src/index.js",


### PR DESCRIPTION
## Release scope

- Platform `1.2.0`
- Credential Agent `1.28.0`
- Credentialing Hub `2.1.0`
- Node.js SDK `2.11.0`

## What changed

- advanced every selected fixed-version release group to its next minor version
- added `.github/release.json` for production promotion
- added product-facing release notes for all four group tags
- documented Platform Mongo/key/timeout compatibility changes and Credentialing Hub CAO identity requirements

The Node.js SDK is included because it depends on Platform packages and the repository's `updateDependents: always` policy releases that dependent with the Platform baseline.

## Validation

- `release:prepare` completed for all four groups
- all four release-note files passed `.github/scripts/validate-release-notes.sh`
- `corepack $(node -p "require('./package.json').packageManager") run release:validate-pr -- --base origin/main`
- `corepack $(node -p "require('./package.json').packageManager") install --frozen-lockfile`
- manifest diff audit confirmed package changes are version-only
- `git diff --check origin/main...HEAD`