### PR TITLE
fix(deps): scope fast-uri override to runtime chain

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@fastify/swagger-ui>@fastify/static': 10.1.2
+  fast-json-stringify@7.0.1>fast-uri: 4.1.2
   mocha>serialize-javascript: 7.0.7
   auth0>uuid: 14.0.1
   eslint-plugin-better-mutation>lodash: 4.18.1
@@ -8352,8 +8353,8 @@ packages:
   fast-uri@3.1.4:
     resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -16518,7 +16519,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -16544,7 +16545,7 @@ snapshots:
 
   fast-uri@3.1.4: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fastest-levenshtein@1.0.16: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ linkWorkspacePackages: true
 overrides:
   # Temporary: remove once @fastify/swagger-ui supports patched @fastify/static 10.x.
   "@fastify/swagger-ui>@fastify/static": "10.1.2"
+  # Temporary: remove once fast-json-stringify no longer resolves vulnerable fast-uri 4.1.1.
+  "fast-json-stringify@7.0.1>fast-uri": "4.1.2"
   # Temporary: remove this override once the Hardhat dependency path no longer
   # resolves serialize-javascript 6.x (Dependabot alert #148 / GHSA-5c6j-r48x-rmvq).
   "mocha>serialize-javascript": "7.0.7"


### PR DESCRIPTION
## What changed

- Added a workspace-level pnpm override for `fast-json-stringify@7.0.1>fast-uri` so the vulnerable runtime chain resolves `fast-uri@4.1.2`.
- Regenerated `pnpm-lock.yaml` to capture the new resolution.

## Why

- This addresses the open high-severity Dependabot alert for `fast-uri` on the production Fastify path without forcing the unrelated dev-only `ajv` chain onto the same version.

## Validation

- `corepack pnpm@10.34.5 install --lockfile-only --no-frozen-lockfile`
