### PR TITLE
fix(ci): set CIH GHCR username

### DIFF
--- a/.github/workflows/node-ci-e2e-cih.workflow.yml
+++ b/.github/workflows/node-ci-e2e-cih.workflow.yml
@@ -73,10 +73,9 @@ jobs:
             exit 1
           fi
 
-          echo "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_READ_USER" --password-stdin
+          echo "$GHCR_READ_TOKEN" | docker login ghcr.io -u ops@velocitycareerlabs.com --password-stdin
         env:
           GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
-          GHCR_READ_USER: ops@velocitycareerlabs.com
 
       - name: Start Containers
         run: docker compose -f "$COMPOSE_FILE" up -d --build

--- a/.github/workflows/node-ci-e2e-cih.workflow.yml
+++ b/.github/workflows/node-ci-e2e-cih.workflow.yml
@@ -68,15 +68,15 @@ jobs:
 
       - name: Log in to GHCR
         run: |
-          if [ -z "$GHCR_READ_USER" ] || [ -z "$GHCR_READ_TOKEN" ]; then
-            echo "::error::GHCR_READ_USER and GHCR_READ_TOKEN secrets are required to pull the Fineract image"
+          if [ -z "$GHCR_READ_TOKEN" ]; then
+            echo "::error::GHCR_READ_TOKEN secret is required to pull the Fineract image"
             exit 1
           fi
 
           echo "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_READ_USER" --password-stdin
         env:
-          GHCR_READ_USER: ${{ secrets.GHCR_READ_USER }}
           GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
+          GHCR_READ_USER: ops@velocitycareerlabs.com
 
       - name: Start Containers
         run: docker compose -f "$COMPOSE_FILE" up -d --build


### PR DESCRIPTION
## Summary

- authenticate CIH E2E to GHCR as `ops@velocitycareerlabs.com`
- remove the `GHCR_READ_USER` variable and secret reference from all workflows
- keep `GHCR_READ_TOKEN` as the only required GHCR secret

## Why

The GHCR username is not sensitive. Keeping it in a variable or secret adds indirection, and storing it as a secret masks the account identity in Actions logs.

## Impact

The repository now has no `GHCR_READ_USER` workflow references. CIH E2E passes the ops account directly to `docker login`. A valid `GHCR_READ_TOKEN` for that account is still required; this PR does not rotate or replace the currently rejected token.

## Root cause

The workflow originally treated the username and token as one secret credential pair even though only the token requires secret storage.

## Validation

- `actionlint` across all workflows
- `git diff --check`
- repository-wide assertion that `.github/workflows` contains no `GHCR_READ_USER` references
- assertion that the CIH workflow authenticates as `ops@velocitycareerlabs.com`